### PR TITLE
EDGAR -> Use Cannelloni ports provided by CARL

### DIFF
--- a/.ci/docker/edgar/Dockerfile
+++ b/.ci/docker/edgar/Dockerfile
@@ -4,7 +4,9 @@ RUN apt update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install
 
 RUN mkdir /tmp/cannelloni
 WORKDIR /tmp/cannelloni
-RUN wget -c https://github.com/mguentner/cannelloni/archive/refs/tags/v1.1.0.tar.gz -O - | tar --strip-components=1 -xz
+RUN wget https://github.com/mguentner/cannelloni/archive/refs/tags/v1.1.0.tar.gz -O cannelloni-1.1.0.tar.gz 
+RUN echo "0dcb9277b21f916f5646574b9b2229d3b8e97d5e99b935a4d0b7509a5f0ccdcd cannelloni-1.1.0.tar.gz" | sha256sum --check --status
+RUN tar --strip-components=1 -xvf cannelloni-1.1.0.tar.gz 
 RUN cmake -DCMAKE_BUILD_TYPE=Release && make
 
 FROM ubuntu:22.04

--- a/opendut-carl/carl.toml
+++ b/opendut-carl/carl.toml
@@ -18,6 +18,7 @@ scopes = "openid,profile,email,roles,groups"
 
 [peer]
 disconnect.timeout.ms = 30000
+can.server_port_range_start = 10000
 
 [serve]
 ui.directory = "opendut-lea/"

--- a/opendut-carl/src/cluster/manager.rs
+++ b/opendut-carl/src/cluster/manager.rs
@@ -99,7 +99,8 @@ impl ClusterManager {
         }
 
         let port_start = self.options.can_server_port_range_start;
-        let port_end = self.options.can_server_port_range_start + u16::try_from(member_interface_mapping.len()).unwrap();
+        let port_end = self.options.can_server_port_range_start + u16::try_from(member_interface_mapping.len())
+            .map_err(|cause| DeployClusterError::Internal { cluster_id, cause: cause.to_string() })?;
         let can_server_ports = (port_start..port_end)
             .map(Port)
             .collect::<Vec<_>>();

--- a/opendut-carl/src/lib.rs
+++ b/opendut-carl/src/lib.rs
@@ -22,7 +22,7 @@ use opendut_util::{logging, project};
 use opendut_util::logging::LoggingConfig;
 use opendut_util::settings::LoadedConfig;
 
-use crate::cluster::manager::{ClusterManager, ClusterManagerRef};
+use crate::cluster::manager::{ClusterManager, ClusterManagerOptions, ClusterManagerRef};
 use crate::grpc::{ClusterManagerService, MetadataProviderService, PeerManagerService, PeerMessagingBrokerService};
 use crate::peer::broker::{PeerMessagingBroker, PeerMessagingBrokerOptions, PeerMessagingBrokerRef};
 use crate::resources::manager::{ResourcesManager, ResourcesManagerRef};
@@ -96,6 +96,7 @@ pub async fn create(settings: LoadedConfig) -> Result<()> { //TODO
         Arc::clone(&resources_manager),
         Arc::clone(&peer_messaging_broker),
         Clone::clone(&vpn),
+        ClusterManagerOptions::load(&settings.config)?,
     ));
 
     /// Isolation in function returning BoxFuture needed due to this: https://github.com/rust-lang/rust/issues/102211#issuecomment-1397600424

--- a/opendut-edgar/src/service/cluster_assignment.rs
+++ b/opendut-edgar/src/service/cluster_assignment.rs
@@ -1,7 +1,7 @@
 use std::net::{IpAddr, Ipv4Addr};
 use std::sync::Arc;
 
-use opendut_types::cluster::ClusterAssignment;
+use opendut_types::cluster::{ClusterAssignment, PeerClusterAssignment};
 use opendut_types::peer::PeerId;
 use opendut_types::util::net::NetworkInterfaceName;
 
@@ -27,7 +27,7 @@ pub async fn network_interfaces_setup(
 
     let local_ip = local_peer_assignment.vpn_address;
 
-    let remote_ips = determine_remote_ips(&cluster_assignment, self_id, &local_ip)?;
+    let remote_ips = determine_remote_ips(&cluster_assignment, self_id)?;
 
     let local_ip = require_ipv4_for_gre(local_ip)?;
     let remote_ips = remote_ips.into_iter()
@@ -69,26 +69,26 @@ pub async fn setup_can(
         assignment.peer_id == self_id
     }).ok_or(Error::LocalPeerAssignmentNotFound { self_id })?;
 
-    let local_ip = local_peer_assignment.vpn_address;
-
     let is_leader = cluster_assignment.leader == self_id;
+
+    let server_port = local_peer_assignment.can_server_port;
 
     if is_leader {
 
-        let remote_ips = determine_remote_ips(cluster_assignment, self_id, &local_ip)?;
+        let remote_assignments = determine_remote_assignments(cluster_assignment, self_id)?;
         can_manager.setup_remote_routing_server(
             &can_bridge_name, 
-            &remote_ips
+            &remote_assignments
         ).await
         .map_err(Error::RemoteCanRoutingSetupFailed)?;
 
-    } else {
-        
-        let leader_ip = determine_leader_ip(cluster_assignment)?;
+    } else {        
+
+        let leader_assignment = determine_leader_assignment(cluster_assignment)?;
         can_manager.setup_remote_routing_client(
             &can_bridge_name, 
-            &local_ip, 
-            &leader_ip
+            &leader_assignment.vpn_address,
+            &server_port
         ).await
         .map_err(Error::RemoteCanRoutingSetupFailed)?;
     }
@@ -96,33 +96,37 @@ pub async fn setup_can(
     Ok(())
 }
 
-fn determine_remote_ips(cluster_assignment: &ClusterAssignment, self_id: PeerId, local_ip: &IpAddr) -> Result<Vec<IpAddr>, Error> {
-    let is_leader = cluster_assignment.leader == self_id;
-
-    let remote_ips = if is_leader {
-        cluster_assignment.assignments.iter()
-            .map(|assignment| assignment.vpn_address)
-            .filter(|address| address != local_ip)
-            .collect()
-    }
-    else {
-        let leader_ip = determine_leader_ip(cluster_assignment)?;
-
-        vec![leader_ip]
-    };
+fn determine_remote_ips(cluster_assignment: &ClusterAssignment, self_id: PeerId) -> Result<Vec<IpAddr>, Error> {
+    let remote_assignments = determine_remote_assignments(cluster_assignment, self_id);
+    let remote_ips = remote_assignments?.iter().map(|remote_assignment| remote_assignment.vpn_address).collect();
 
     Ok(remote_ips)
 }
 
-fn determine_leader_ip(cluster_assignment: &ClusterAssignment) -> Result<IpAddr, Error>{
-    let leader_ip = cluster_assignment.assignments.iter().find_map(|peer_assignment| {
-        let is_leader = peer_assignment.peer_id == cluster_assignment.leader;
+fn determine_remote_assignments(cluster_assignment: &ClusterAssignment, self_id: PeerId) -> Result<Vec<PeerClusterAssignment>, Error> {
+    let is_leader = cluster_assignment.leader == self_id;
 
-        is_leader
-            .then_some(peer_assignment.vpn_address)
-    }).ok_or(Error::LeaderIpAddressNotDeterminable)?;
+    let remote_peer_cluster_assignments = if is_leader {
+        cluster_assignment.assignments.iter()
+            .filter(|assignment| assignment.peer_id != self_id).cloned()
+            .collect::<Vec<PeerClusterAssignment>>()
+    }
+    else {
+        let leader_ip = determine_leader_assignment(cluster_assignment)?;
 
-    Ok(leader_ip)
+        vec![leader_ip.clone()]
+    };
+
+    Ok(remote_peer_cluster_assignments)
+}
+
+fn determine_leader_assignment(cluster_assignment: &ClusterAssignment) -> Result<&PeerClusterAssignment, Error>{
+    let leader_assignment = cluster_assignment.assignments
+        .iter().find(|peer_assignment| 
+            peer_assignment.peer_id == cluster_assignment.leader
+            ).ok_or(Error::LeaderNotDeterminable)?;
+
+    Ok(leader_assignment)
 }
 
 fn require_ipv4_for_gre(ip_address: IpAddr) -> Result<Ipv4Addr, Error> {
@@ -181,8 +185,8 @@ pub enum Error {
     BridgeRecreationFailed(network_interface::manager::Error),
     #[error("Could not find PeerAssignment for this peer (<{self_id}>) in the ClusterAssignment.")]
     LocalPeerAssignmentNotFound { self_id: PeerId },
-    #[error("Could not determine leader IP address from ClusterAssignment.")]
-    LeaderIpAddressNotDeterminable,
+    #[error("Could not determine leader from ClusterAssignment.")]
+    LeaderNotDeterminable,
     #[error("IPv6 isn't yet supported for GRE interfaces.")]
     Ipv6NotSupported,
     #[error("GRE interface setup failed: {0}")]

--- a/opendut-types/proto/opendut/types/cluster/cluster.proto
+++ b/opendut-types/proto/opendut/types/cluster/cluster.proto
@@ -40,7 +40,8 @@ message ClusterAssignment {
 message PeerClusterAssignment {
   opendut.types.peer.PeerId peer_id = 1;
   opendut.types.util.IpAddress vpn_address = 2;
-  repeated opendut.types.util.NetworkInterfaceName device_interfaces = 3;
+  opendut.types.util.Port can_server_port = 3;
+  repeated opendut.types.util.NetworkInterfaceName device_interfaces = 4;
 }
 // ANCHOR_END: PeerClusterAssignment
 

--- a/opendut-types/src/cluster/assignment.rs
+++ b/opendut-types/src/cluster/assignment.rs
@@ -2,6 +2,7 @@ use std::net::IpAddr;
 use crate::cluster::ClusterId;
 use crate::peer::PeerId;
 use crate::util::net::NetworkInterfaceName;
+use crate::util::Port;
 
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -15,5 +16,6 @@ pub struct ClusterAssignment {
 pub struct PeerClusterAssignment {
     pub peer_id: PeerId,
     pub vpn_address: IpAddr,
+    pub can_server_port: Port,
     pub device_interfaces: Vec<NetworkInterfaceName>,
 }

--- a/opendut-types/src/proto/cluster.rs
+++ b/opendut-types/src/proto/cluster.rs
@@ -225,6 +225,7 @@ impl From<crate::cluster::PeerClusterAssignment> for PeerClusterAssignment {
         Self {
             peer_id: Some(value.peer_id.into()),
             vpn_address: Some(value.vpn_address.into()),
+            can_server_port: Some(value.can_server_port.into()),
             device_interfaces: value.device_interfaces.into_iter().map(Into::into).collect(),
         }
     }
@@ -243,6 +244,10 @@ impl TryFrom<PeerClusterAssignment> for crate::cluster::PeerClusterAssignment {
             .ok_or(ErrorBuilder::new("field 'vpn_address' not set"))?
             .try_into()?;
 
+        let can_server_port: crate::util::Port = value.can_server_port
+            .ok_or(ErrorBuilder::new("field 'can_server_port' not set"))?
+            .try_into()?;
+
         let device_interfaces: Vec<crate::util::net::NetworkInterfaceName> = value.device_interfaces
             .into_iter()
             .map(TryInto::try_into)
@@ -251,6 +256,7 @@ impl TryFrom<PeerClusterAssignment> for crate::cluster::PeerClusterAssignment {
         Ok(Self {
             peer_id,
             vpn_address,
+            can_server_port,
             device_interfaces,
         })
     }

--- a/opendut-types/src/util/mod.rs
+++ b/opendut-types/src/util/mod.rs
@@ -19,7 +19,7 @@ impl From<&str> for Hostname {
     }
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Port(pub u16);
 
 impl From<u16> for Port {


### PR DESCRIPTION
This PR enables EDGARs to obtain the SCTP ports on which the Cannelloni instances on the EDGAR leader are listening from CARL instead of deriving them from the IP address. Addresses one of the TODOs from #105.