### PR TITLE
Add configuration to network interfaces

### DIFF
--- a/opendut-carl/src/actions/peers.rs
+++ b/opendut-carl/src/actions/peers.rs
@@ -287,10 +287,10 @@ mod test {
 
     use rstest::*;
 
-    use opendut_types::peer::{PeerLocation, PeerName, PeerNetworkConfiguration, PeerNetworkInterface};
+    use opendut_types::peer::{PeerLocation, PeerName, PeerNetworkConfiguration};
     use opendut_types::peer::executor::{ExecutorDescriptor, ExecutorDescriptors};
     use opendut_types::topology::{DeviceDescription, DeviceName, Topology};
-    use opendut_types::util::net::NetworkInterfaceName;
+    use opendut_types::util::net::{NetworkInterfaceConfiguration, NetworkInterfaceDescriptor, NetworkInterfaceName};
 
     use crate::resources::manager::ResourcesManager;
 
@@ -301,7 +301,7 @@ mod test {
         use rstest::*;
 
         use opendut_types::topology::{DeviceDescription, DeviceName};
-        use opendut_types::util::net::NetworkInterfaceName;
+        use opendut_types::util::net::{NetworkInterfaceConfiguration, NetworkInterfaceDescriptor, NetworkInterfaceName};
 
         use super::*;
 
@@ -326,7 +326,10 @@ mod test {
                 id: additional_device_id,
                 name: DeviceName::try_from("PeerA_Device_42").unwrap(),
                 description: DeviceDescription::try_from("Additional device for peerA").ok(),
-                interface: NetworkInterfaceName::try_from("eth1").unwrap(),
+                interface: NetworkInterfaceDescriptor {
+                    name: NetworkInterfaceName::try_from("eth1").unwrap(),
+                    configuration: NetworkInterfaceConfiguration::Ethernet,
+                },
                 tags: vec![],
             };
 
@@ -375,9 +378,10 @@ mod test {
             location: PeerLocation::try_from("Ulm").ok(),
             network_configuration: PeerNetworkConfiguration {
                 interfaces: vec![
-                    PeerNetworkInterface {
+                    NetworkInterfaceDescriptor {
                         name: NetworkInterfaceName::try_from("eth0").unwrap(),
-                    }
+                        configuration: NetworkInterfaceConfiguration::Ethernet,
+                    },
                 ]
             },
             topology: Topology {
@@ -386,14 +390,20 @@ mod test {
                         id: peer_a_device_1,
                         name: DeviceName::try_from("PeerA_Device_1").unwrap(),
                         description: DeviceDescription::try_from("Huii").ok(),
-                        interface: NetworkInterfaceName::try_from("eth0").unwrap(),
+                        interface: NetworkInterfaceDescriptor {
+                            name: NetworkInterfaceName::try_from("eth0").unwrap(),
+                            configuration: NetworkInterfaceConfiguration::Ethernet,
+                        },
                         tags: vec![],
                     },
                     DeviceDescriptor {
                         id: peer_a_device_2,
                         name: DeviceName::try_from("PeerA_Device_2").unwrap(),
                         description: DeviceDescription::try_from("Huii").ok(),
-                        interface: NetworkInterfaceName::try_from("eth1").unwrap(),
+                        interface: NetworkInterfaceDescriptor {
+                            name: NetworkInterfaceName::try_from("eth1").unwrap(),
+                            configuration: NetworkInterfaceConfiguration::Ethernet,
+                        },
                         tags: vec![],
                     }
                 ]

--- a/opendut-carl/src/grpc/peer_manager.rs
+++ b/opendut-carl/src/grpc/peer_manager.rs
@@ -230,11 +230,11 @@ mod tests {
     use googletest::prelude::*;
     use url::Url;
 
-    use opendut_types::peer::{PeerLocation, PeerName, PeerNetworkConfiguration, PeerNetworkInterface};
+    use opendut_types::peer::{PeerLocation, PeerName, PeerNetworkConfiguration};
     use opendut_types::peer::executor::{ContainerCommand, ContainerImage, ContainerName, Engine, ExecutorDescriptor, ExecutorDescriptors};
     use opendut_types::proto;
     use opendut_types::topology::Topology;
-    use opendut_types::util::net::NetworkInterfaceName;
+    use opendut_types::util::net::{NetworkInterfaceConfiguration, NetworkInterfaceDescriptor, NetworkInterfaceName};
 
     use crate::resources::manager::ResourcesManager;
     use crate::vpn::Vpn;
@@ -270,9 +270,10 @@ mod tests {
             location: PeerLocation::try_from("SiFi").ok(),
             network_configuration: PeerNetworkConfiguration {
                 interfaces: vec![
-                    PeerNetworkInterface {
+                    NetworkInterfaceDescriptor {
                         name: NetworkInterfaceName::try_from("eth0").unwrap(),
-                    }
+                        configuration: NetworkInterfaceConfiguration::Ethernet,
+                    },
                 ],
             },
             topology: Topology::default(),

--- a/opendut-carl/src/resources/manager.rs
+++ b/opendut-carl/src/resources/manager.rs
@@ -86,10 +86,10 @@ mod test {
     use googletest::prelude::*;
 
     use opendut_types::cluster::{ClusterConfiguration, ClusterId, ClusterName};
-    use opendut_types::peer::{PeerDescriptor, PeerId, PeerLocation, PeerName, PeerNetworkConfiguration, PeerNetworkInterface};
+    use opendut_types::peer::{PeerDescriptor, PeerId, PeerLocation, PeerName, PeerNetworkConfiguration};
     use opendut_types::peer::executor::{ContainerCommand, ContainerImage, ContainerName, Engine, ExecutorDescriptor, ExecutorDescriptors};
     use opendut_types::topology::Topology;
-    use opendut_types::util::net::NetworkInterfaceName;
+    use opendut_types::util::net::{NetworkInterfaceConfiguration, NetworkInterfaceDescriptor, NetworkInterfaceName};
 
     use super::*;
 
@@ -105,9 +105,10 @@ mod test {
             location: PeerLocation::try_from("Ulm").ok(),
             network_configuration: PeerNetworkConfiguration {
                 interfaces: vec![
-                    PeerNetworkInterface {
+                    NetworkInterfaceDescriptor {
                         name: NetworkInterfaceName::try_from("eth0").unwrap(),
-                    }
+                        configuration: NetworkInterfaceConfiguration::Ethernet,
+                    },
                 ]
             },
             topology: Topology::default(),

--- a/opendut-cleo/src/commands/cluster_configuration.rs
+++ b/opendut-cleo/src/commands/cluster_configuration.rs
@@ -119,7 +119,7 @@ pub mod create {
         use googletest::prelude::*;
         use rstest::{fixture, rstest};
         use opendut_types::topology::{DeviceDescription, DeviceId, DeviceName};
-        use opendut_types::util::net::NetworkInterfaceName;
+        use opendut_types::util::net::{NetworkInterfaceConfiguration, NetworkInterfaceDescriptor, NetworkInterfaceName};
 
         #[fixture]
         fn all_devices() -> Vec<DeviceDescriptor> {
@@ -128,21 +128,30 @@ pub mod create {
                     id: DeviceId::random(),
                     name: DeviceName::try_from("MyDevice").unwrap(),
                     description: DeviceDescription::try_from("").ok(),
-                    interface: NetworkInterfaceName::try_from("eth0").unwrap(),
+                    interface: NetworkInterfaceDescriptor {
+                        name: NetworkInterfaceName::try_from("eth0").unwrap(),
+                        configuration: NetworkInterfaceConfiguration::Ethernet,
+                    },
                     tags: vec![],
                 },
                 DeviceDescriptor {
                     id: DeviceId::random(),
                     name: DeviceName::try_from("YourDevice").unwrap(),
                     description: DeviceDescription::try_from("").ok(),
-                    interface: NetworkInterfaceName::try_from("eth0").unwrap(),
+                    interface: NetworkInterfaceDescriptor {
+                        name: NetworkInterfaceName::try_from("eth0").unwrap(),
+                        configuration: NetworkInterfaceConfiguration::Ethernet,
+                    },
                     tags: vec![],
                 },
                 DeviceDescriptor {
                     id: DeviceId::random(),
                     name: DeviceName::try_from("HisDevice").unwrap(),
                     description: DeviceDescription::try_from("").ok(),
-                    interface: NetworkInterfaceName::try_from("eth0").unwrap(),
+                    interface: NetworkInterfaceDescriptor {
+                        name: NetworkInterfaceName::try_from("eth0").unwrap(),
+                        configuration: NetworkInterfaceConfiguration::Ethernet,
+                    },
                     tags: vec![],
                 }
             ]

--- a/opendut-cleo/src/commands/peer.rs
+++ b/opendut-cleo/src/commands/peer.rs
@@ -97,9 +97,9 @@ pub mod list {
     mod test {
         use googletest::prelude::*;
 
-        use opendut_types::peer::{PeerDescriptor, PeerId, PeerLocation, PeerName, PeerNetworkConfiguration, PeerNetworkInterface};
+        use opendut_types::peer::{PeerDescriptor, PeerId, PeerLocation, PeerName, PeerNetworkConfiguration};
         use opendut_types::peer::executor::ExecutorDescriptors;
-        use opendut_types::util::net::NetworkInterfaceName;
+        use opendut_types::util::net::{NetworkInterfaceConfiguration, NetworkInterfaceDescriptor, NetworkInterfaceName};
 
         use super::*;
 
@@ -110,8 +110,9 @@ pub mod list {
                 name: PeerName::try_from("MyPeer").unwrap(),
                 location: Some(PeerLocation::try_from("SiFi").unwrap()),
                 network_configuration: PeerNetworkConfiguration {
-                    interfaces: vec!(PeerNetworkInterface {
+                    interfaces: vec!(NetworkInterfaceDescriptor {
                         name: NetworkInterfaceName::try_from("eth0").unwrap(),
+                        configuration: NetworkInterfaceConfiguration::Ethernet,
                     })
                 },
                 topology: Default::default(),

--- a/opendut-edgar/src/service/can_manager.rs
+++ b/opendut-edgar/src/service/can_manager.rs
@@ -8,7 +8,7 @@ use regex::Regex;
 
 use tokio::process::Command;
 
-use opendut_types::util::net::NetworkInterfaceName;
+use opendut_types::util::net::{NetworkInterfaceDescriptor, NetworkInterfaceName};
 
 use crate::service::cannelloni_manager::CannelloniManager;
 use crate::service::network_interface::manager::NetworkInterfaceManagerRef;
@@ -107,7 +107,7 @@ impl CanManager {
     pub async fn setup_local_routing(
         &self,
         bridge_name: &NetworkInterfaceName,
-        local_can_interfaces: Vec<NetworkInterfaceName>,
+        local_can_interfaces: Vec<NetworkInterfaceDescriptor>,
     ) -> Result<(), Error> {
     
     
@@ -117,10 +117,10 @@ impl CanManager {
         self.remove_all_can_routes().await?;
     
         for interface in local_can_interfaces {
-            self.create_can_route(bridge_name, &interface, true, 2).await?;
-            self.create_can_route(bridge_name, &interface, false, 2).await?;
-            self.create_can_route(&interface, bridge_name, true, 2).await?;
-            self.create_can_route(&interface, bridge_name, false, 2).await?;
+            self.create_can_route(bridge_name, &interface.name, true, 2).await?;
+            self.create_can_route(bridge_name, &interface.name, false, 2).await?;
+            self.create_can_route(&interface.name, bridge_name, true, 2).await?;
+            self.create_can_route(&interface.name, bridge_name, false, 2).await?;
         }
     
         Ok(())

--- a/opendut-lea/src/clusters/configurator/components/device_selector.rs
+++ b/opendut-lea/src/clusters/configurator/components/device_selector.rs
@@ -143,7 +143,7 @@ pub fn DeviceInfo(device: DeviceDescriptor, peer_id: PeerId) -> impl IntoView {
             <div class="field">
                 <label class="label">Interface</label>
                 <div class="control">
-                    <p>{device.interface.name()}</p>
+                    <p>{device.interface.name.name()}</p>
                 </div>
             </div>
             <div class="field">

--- a/opendut-lea/src/peers/configurator/mod.rs
+++ b/opendut-lea/src/peers/configurator/mod.rs
@@ -68,7 +68,7 @@ pub fn PeerConfigurator() -> impl IntoView {
                                 create_rw_signal(UserDeviceConfiguration {
                                     id: device.id,
                                     name: UserInputValue::Right(device.name.to_string()),
-                                    interface: UserInputValue::Right(device.interface.name()),
+                                    interface: UserInputValue::Right(device.interface.name.name()),
                                     description: UserInputValue::Right(device.description.unwrap_or_default().to_string()),
                                     is_collapsed: true
                                 })

--- a/opendut-lea/src/peers/configurator/types.rs
+++ b/opendut-lea/src/peers/configurator/types.rs
@@ -1,9 +1,9 @@
 use leptos::{RwSignal, SignalGetUntracked};
 
-use opendut_types::peer::{PeerDescriptor, PeerId, PeerLocation, PeerName, PeerNetworkConfiguration, PeerNetworkInterface};
+use opendut_types::peer::{PeerDescriptor, PeerId, PeerLocation, PeerName, PeerNetworkConfiguration};
 use opendut_types::peer::executor::{ContainerCommand, ContainerCommandArgument, ContainerDevice, ContainerEnvironmentVariable, ContainerImage, ContainerName, ContainerPortSpec, ContainerVolume, Engine, ExecutorDescriptor, ExecutorDescriptors};
 use opendut_types::topology::{DeviceDescription, DeviceDescriptor, DeviceId, DeviceName, Topology};
-use opendut_types::util::net::NetworkInterfaceName;
+use opendut_types::util::net::{NetworkInterfaceConfiguration, NetworkInterfaceDescriptor, NetworkInterfaceName};
 
 use crate::components::UserInputValue;
 
@@ -108,7 +108,7 @@ impl TryFrom<UserPeerConfiguration> for PeerDescriptor {
             .into_iter()
             .map(|signal| signal.get_untracked())
             .map(|interface| {
-                PeerNetworkInterface::try_from(interface)
+                NetworkInterfaceDescriptor::try_from(interface)
                     .map_err(|_|  PeerMisconfigurationError::InvalidPeerNetworkConfiguration)
             })
             .collect::<Result<Vec<_>, _>>()?;
@@ -172,18 +172,22 @@ impl TryFrom<UserDeviceConfiguration> for DeviceDescriptor {
             id: configuration.id,
             name,
             description: Some(description),
-            interface,
+            interface: NetworkInterfaceDescriptor {
+                name: interface,
+                configuration: NetworkInterfaceConfiguration::Ethernet, // TODO: Do not assume Ethernet here
+            },
             tags: vec![],
         })
     }
 }
 
-impl TryFrom<UserPeerNetworkInterface> for PeerNetworkInterface {
+impl TryFrom<UserPeerNetworkInterface> for NetworkInterfaceDescriptor {
     type Error = PeerMisconfigurationError;
 
     fn try_from(configuration: UserPeerNetworkInterface) -> Result<Self, Self::Error> {
-        Ok(PeerNetworkInterface {
+        Ok(Self {
             name: configuration.name,
+            configuration: NetworkInterfaceConfiguration::Ethernet, // TODO: Do not assume Ethernet here
         })
     }
 }

--- a/opendut-types/proto/opendut/types/cluster/cluster.proto
+++ b/opendut-types/proto/opendut/types/cluster/cluster.proto
@@ -41,7 +41,7 @@ message PeerClusterAssignment {
   opendut.types.peer.PeerId peer_id = 1;
   opendut.types.util.IpAddress vpn_address = 2;
   opendut.types.util.Port can_server_port = 3;
-  repeated opendut.types.util.NetworkInterfaceName device_interfaces = 4;
+  repeated opendut.types.util.NetworkInterfaceDescriptor device_interfaces = 4;
 }
 // ANCHOR_END: PeerClusterAssignment
 

--- a/opendut-types/proto/opendut/types/peer/peer.proto
+++ b/opendut-types/proto/opendut/types/peer/peer.proto
@@ -21,12 +21,8 @@ message PeerLocation {
   string value = 1;
 }
 
-message PeerNetworkInterface {
-  opendut.types.util.NetworkInterfaceName name = 1;
-}
-
 message PeerNetworkConfiguration {
-  repeated PeerNetworkInterface interfaces = 1;
+  repeated opendut.types.util.NetworkInterfaceDescriptor interfaces = 1;
 }
 
 message PeerDescriptor {

--- a/opendut-types/proto/opendut/types/topology/device.proto
+++ b/opendut-types/proto/opendut/types/topology/device.proto
@@ -13,7 +13,7 @@ message DeviceDescriptor {
   opendut.types.topology.DeviceId id = 1;
   opendut.types.topology.DeviceName name = 2;
   opendut.types.topology.DeviceDescription description = 3;
-  opendut.types.util.NetworkInterfaceName interface = 4;
+  opendut.types.util.NetworkInterfaceDescriptor interface = 4;
   repeated opendut.types.topology.DeviceTag tags = 5;
 }
 

--- a/opendut-types/proto/opendut/types/util/net.proto
+++ b/opendut-types/proto/opendut/types/util/net.proto
@@ -37,3 +37,21 @@ message IpV6Address {
 message NetworkInterfaceName {
   string name = 1;
 }
+
+message EthernetInterfaceConfiguration {}
+
+message CanInterfaceConfiguration {
+  int32 bitrate = 1;
+  int32 sample_point = 2;
+  bool flexible_data_rate = 3;
+  int32 data_bitrate = 4;
+  int32 data_sample_point = 5;
+}
+
+message NetworkInterfaceDescriptor {
+  NetworkInterfaceName name = 1;
+  oneof configuration {
+    EthernetInterfaceConfiguration ethernet = 2;
+    CanInterfaceConfiguration can = 3;
+  }
+}

--- a/opendut-types/src/cluster/assignment.rs
+++ b/opendut-types/src/cluster/assignment.rs
@@ -1,7 +1,7 @@
 use std::net::IpAddr;
 use crate::cluster::ClusterId;
 use crate::peer::PeerId;
-use crate::util::net::NetworkInterfaceName;
+use crate::util::net::NetworkInterfaceDescriptor;
 use crate::util::Port;
 
 
@@ -17,5 +17,5 @@ pub struct PeerClusterAssignment {
     pub peer_id: PeerId,
     pub vpn_address: IpAddr,
     pub can_server_port: Port,
-    pub device_interfaces: Vec<NetworkInterfaceName>,
+    pub device_interfaces: Vec<NetworkInterfaceDescriptor>,
 }

--- a/opendut-types/src/peer/mod.rs
+++ b/opendut-types/src/peer/mod.rs
@@ -9,8 +9,8 @@ use url::Url;
 use uuid::Uuid;
 use crate::peer::executor::{ExecutorDescriptors};
 
-use crate::topology::{Topology};
-use crate::util::net::{Certificate, NetworkInterfaceName};
+use crate::topology::Topology;
+use crate::util::net::{Certificate, NetworkInterfaceDescriptor};
 use crate::vpn::VpnPeerConfiguration;
 
 pub mod state;
@@ -219,23 +219,12 @@ impl fmt::Display for PeerLocation {
 
 #[derive(Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
 pub struct PeerNetworkConfiguration {
-    pub interfaces: Vec<PeerNetworkInterface>,
+    pub interfaces: Vec<NetworkInterfaceDescriptor>,
 }
 
 impl PeerNetworkConfiguration {
-    pub fn new(interfaces: Vec<PeerNetworkInterface>) -> Self {
+    pub fn new(interfaces: Vec<NetworkInterfaceDescriptor>) -> Self {
         Self { interfaces }
-    }
-}
-
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
-pub struct PeerNetworkInterface {
-    pub name: NetworkInterfaceName,
-}
-
-impl PeerNetworkInterface {
-    pub fn new(name: NetworkInterfaceName) -> Self {
-        Self { name }
     }
 }
 

--- a/opendut-types/src/proto/cluster.rs
+++ b/opendut-types/src/proto/cluster.rs
@@ -248,7 +248,7 @@ impl TryFrom<PeerClusterAssignment> for crate::cluster::PeerClusterAssignment {
             .ok_or(ErrorBuilder::new("field 'can_server_port' not set"))?
             .try_into()?;
 
-        let device_interfaces: Vec<crate::util::net::NetworkInterfaceName> = value.device_interfaces
+        let device_interfaces: Vec<crate::util::net::NetworkInterfaceDescriptor> = value.device_interfaces
             .into_iter()
             .map(TryInto::try_into)
             .collect::<Result<_, _>>()?;

--- a/opendut-types/src/proto/peer.rs
+++ b/opendut-types/src/proto/peer.rs
@@ -3,6 +3,8 @@ use crate::proto::{ConversionError, ConversionErrorBuilder};
 use crate::proto::vpn::VpnPeerConfig;
 use crate::proto::executor;
 
+use super::util::NetworkInterfaceDescriptor;
+
 include!(concat!(env!("OUT_DIR"), "/opendut.types.peer.rs"));
 
 impl From<crate::peer::PeerId> for PeerId {
@@ -86,7 +88,7 @@ impl From<crate::peer::PeerNetworkConfiguration> for PeerNetworkConfiguration {
             interfaces: value
                 .interfaces
                 .into_iter()
-                .map(PeerNetworkInterface::from)
+                .map(NetworkInterfaceDescriptor::from)
                 .collect(),
         }
     }
@@ -99,33 +101,9 @@ impl TryFrom<PeerNetworkConfiguration> for crate::peer::PeerNetworkConfiguration
         value
             .interfaces
             .into_iter()
-            .map(PeerNetworkInterface::try_into)
+            .map(NetworkInterfaceDescriptor::try_into)
             .collect::<Result<_, _>>()
             .map(|interfaces| Self { interfaces })
-    }
-}
-
-impl From<crate::peer::PeerNetworkInterface> for PeerNetworkInterface {
-    fn from(value: crate::peer::PeerNetworkInterface) -> Self {
-        Self {
-            name: Some(value.name.into())
-        }
-    }
-}
-
-impl TryFrom<PeerNetworkInterface> for crate::peer::PeerNetworkInterface {
-    type Error = ConversionError;
-
-    fn try_from(value: PeerNetworkInterface) -> Result<Self, Self::Error> {
-        type ErrorBuilder = ConversionErrorBuilder<PeerNetworkInterface, crate::peer::PeerNetworkInterface>;
-
-        let name = value.name
-            .ok_or(ErrorBuilder::new("Interface not set"))?
-            .try_into()?;
-
-        Ok(crate::peer::PeerNetworkInterface {
-            name
-        })
     }
 }
 

--- a/opendut-types/src/proto/topology.rs
+++ b/opendut-types/src/proto/topology.rs
@@ -143,7 +143,7 @@ impl TryFrom<DeviceDescriptor> for crate::topology::DeviceDescriptor {
             .try_into()?;
         let device_description: Option<crate::topology::DeviceDescription> =
             value.description.map(TryFrom::try_from).transpose()?;
-        let interface: crate::util::net::NetworkInterfaceName = value
+        let interface: crate::util::net::NetworkInterfaceDescriptor = value
             .interface
             .ok_or(ErrorBuilder::new("Interface not set"))?
             .try_into()?;
@@ -166,8 +166,9 @@ impl TryFrom<DeviceDescriptor> for crate::topology::DeviceDescriptor {
 #[cfg(test)]
 #[allow(non_snake_case)]
 mod tests {
-    use crate::proto::util::NetworkInterfaceName;
+    use crate::proto::util::{network_interface_descriptor, EthernetInterfaceConfiguration, NetworkInterfaceDescriptor, NetworkInterfaceName};
     use crate::topology::{DeviceDescription, DeviceName, DeviceTag};
+    use crate::util::net::NetworkInterfaceConfiguration;
     use googletest::prelude::*;
     use uuid::Uuid;
 
@@ -184,14 +185,20 @@ mod tests {
                     id: Clone::clone(&device_id_1).into(),
                     name: DeviceName::try_from("device-1")?,
                     description: DeviceDescription::try_from("Some device").ok(),
-                    interface: crate::util::net::NetworkInterfaceName::try_from("tap0")?,
+                    interface: crate::util::net::NetworkInterfaceDescriptor { 
+                        name: crate::util::net::NetworkInterfaceName::try_from("tap0")?,
+                        configuration: NetworkInterfaceConfiguration::Ethernet,
+                    },
                     tags: vec![DeviceTag::try_from("tag-1")?, DeviceTag::try_from("tag-2")?],
                 },
                 crate::topology::DeviceDescriptor {
                     id: Clone::clone(&device_id_2).into(),
                     name: DeviceName::try_from("device-2")?,
                     description: DeviceDescription::try_from("Some other device").ok(),
-                    interface: crate::util::net::NetworkInterfaceName::try_from("tap1")?,
+                    interface: crate::util::net::NetworkInterfaceDescriptor { 
+                        name: crate::util::net::NetworkInterfaceName::try_from("tap1")?,
+                        configuration: NetworkInterfaceConfiguration::Ethernet,
+                    },
                     tags: vec![DeviceTag::try_from("tag-2")?],
                 },
             ],
@@ -207,8 +214,13 @@ mod tests {
                     description: Some(crate::proto::topology::DeviceDescription {
                         value: String::from("Some device"),
                     }),
-                    interface: Some(NetworkInterfaceName {
-                        name: String::from("tap0"),
+                    interface: Some(NetworkInterfaceDescriptor{
+                        name: Some(NetworkInterfaceName {
+                            name: String::from("tap0"),
+                        }),
+                        configuration: Some(network_interface_descriptor::Configuration::Ethernet(
+                            EthernetInterfaceConfiguration{},
+                        )),
                     }),
                     tags: vec![
                         Some(crate::proto::topology::DeviceTag {
@@ -229,8 +241,13 @@ mod tests {
                     description: Some(crate::proto::topology::DeviceDescription {
                         value: String::from("Some other device"),
                     }),
-                    interface: Some(NetworkInterfaceName {
-                        name: String::from("tap1"),
+                    interface: Some(NetworkInterfaceDescriptor{
+                        name: Some(NetworkInterfaceName {
+                            name: String::from("tap1"),
+                        }),
+                        configuration: Some(network_interface_descriptor::Configuration::Ethernet(
+                            EthernetInterfaceConfiguration{},
+                        )),
                     }),
                     tags: vec![Some(crate::proto::topology::DeviceTag {
                         value: String::from("tag-2"),
@@ -262,8 +279,13 @@ mod tests {
                 description: Some(crate::proto::topology::DeviceDescription {
                     value: String::from("Some device"),
                 }),
-                interface: Some(NetworkInterfaceName {
-                    name: String::from("tap0"),
+                interface: Some(NetworkInterfaceDescriptor{
+                    name: Some(NetworkInterfaceName {
+                        name: String::from("tap0"),
+                    }),
+                    configuration: Some(network_interface_descriptor::Configuration::Ethernet(
+                        EthernetInterfaceConfiguration{},
+                    )),
                 }),
                 tags: vec![
                     Some(crate::proto::topology::DeviceTag {

--- a/opendut-types/src/topology/mod.rs
+++ b/opendut-types/src/topology/mod.rs
@@ -2,7 +2,7 @@ use std::fmt;
 use std::ops::Not;
 use std::str::FromStr;
 
-use crate::util::net::NetworkInterfaceName;
+use crate::util::net::NetworkInterfaceDescriptor;
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
@@ -263,6 +263,6 @@ pub struct DeviceDescriptor {
     pub id: DeviceId,
     pub name: DeviceName,
     pub description: Option<DeviceDescription>,
-    pub interface: NetworkInterfaceName,
+    pub interface: NetworkInterfaceDescriptor,
     pub tags: Vec<DeviceTag>,
 }


### PR DESCRIPTION
This PR sets the stage for #128 by introducing a new struct for representing network interfaces that allows for specifying the interface type (Ethernet, CAN) and additional configuration options for CAN.
This PR only modifies the internal representation of network interfaces and does not functionally change anything. However, as code throughout the entire codebase had to be modified, I'd like to get it merged as soon as possible to keep the merge conflicts to a minimum.