### PR TITLE
Allow Interface type configuration via CLEO

### DIFF
--- a/.ci/docker/edgar/scripts/managed.sh
+++ b/.ci/docker/edgar/scripts/managed.sh
@@ -82,9 +82,9 @@ opendut-cleo create peer --name "$NAME" --id "$PEER_ID" --location "$NAME"
 DEVICE_INTERFACE="dut0"
 ip link add $DEVICE_INTERFACE type dummy
 ip link set dev $DEVICE_INTERFACE up
-opendut-cleo create network-configuration --peer-id "$PEER_ID" --interface "$DEVICE_INTERFACE"
-opendut-cleo create network-configuration --peer-id "$PEER_ID" --interface vcan0
-opendut-cleo create network-configuration --peer-id "$PEER_ID" --interface vcan1
+opendut-cleo create network-configuration --peer-id "$PEER_ID" --type ethernet --interface-name "$DEVICE_INTERFACE"
+opendut-cleo create network-configuration --peer-id "$PEER_ID" --type can --interface-name vcan0
+opendut-cleo create network-configuration --peer-id "$PEER_ID" --type can --interface-name vcan1
 opendut-cleo create device --peer-id "$PEER_ID" --name device-"$NAME" --interface "$DEVICE_INTERFACE" --tag "$OPENDUT_EDGAR_CLUSTER_NAME"
 opendut-cleo create device --peer-id "$PEER_ID" --name device-"$NAME"-vcan0 --interface vcan0 --tag "$OPENDUT_EDGAR_CLUSTER_NAME"
 opendut-cleo create device --peer-id "$PEER_ID" --name device-"$NAME"-vcan1 --interface vcan1 --tag "$OPENDUT_EDGAR_CLUSTER_NAME"

--- a/.ci/docker/edgar/scripts/managed.sh
+++ b/.ci/docker/edgar/scripts/managed.sh
@@ -82,9 +82,9 @@ opendut-cleo create peer --name "$NAME" --id "$PEER_ID" --location "$NAME"
 DEVICE_INTERFACE="dut0"
 ip link add $DEVICE_INTERFACE type dummy
 ip link set dev $DEVICE_INTERFACE up
-opendut-cleo create network-configuration --peer-id "$PEER_ID" --type ethernet --interface-name "$DEVICE_INTERFACE"
-opendut-cleo create network-configuration --peer-id "$PEER_ID" --type can --interface-name vcan0
-opendut-cleo create network-configuration --peer-id "$PEER_ID" --type can --interface-name vcan1
+opendut-cleo create network-interface --peer-id "$PEER_ID" --type ethernet --name "$DEVICE_INTERFACE"
+opendut-cleo create network-interface --peer-id "$PEER_ID" --type can --name vcan0
+opendut-cleo create network-interface --peer-id "$PEER_ID" --type can --name vcan1
 opendut-cleo create device --peer-id "$PEER_ID" --name device-"$NAME" --interface "$DEVICE_INTERFACE" --tag "$OPENDUT_EDGAR_CLUSTER_NAME"
 opendut-cleo create device --peer-id "$PEER_ID" --name device-"$NAME"-vcan0 --interface vcan0 --tag "$OPENDUT_EDGAR_CLUSTER_NAME"
 opendut-cleo create device --peer-id "$PEER_ID" --name device-"$NAME"-vcan1 --interface vcan1 --tag "$OPENDUT_EDGAR_CLUSTER_NAME"

--- a/opendut-cleo/src/commands/mod.rs
+++ b/opendut-cleo/src/commands/mod.rs
@@ -2,5 +2,5 @@ pub mod cluster_configuration;
 pub mod cluster_deployment;
 pub mod device;
 pub mod peer;
-pub mod network_configuration;
+pub mod network_interface;
 pub mod executor;

--- a/opendut-cleo/src/commands/network_interface.rs
+++ b/opendut-cleo/src/commands/network_interface.rs
@@ -11,7 +11,7 @@ pub mod create {
         carl: &mut CarlClient,
         peer_id: Uuid,
         interface_type: NetworkInterfaceType,
-        interface_name: Option<String>,
+        interface_name: String,
         output: CreateOutputFormat,
     ) -> crate::Result<()> {
         let peer_id = PeerId::from(peer_id);
@@ -22,7 +22,7 @@ pub mod create {
         let peer_interface_names = peer_descriptor.network_configuration.interfaces
             .iter().map(|interface| interface.name.clone()).collect::<Vec<_>>();
 
-        let interface_name = NetworkInterfaceName::try_from(interface_name.unwrap_or_default()).map_err(|error| error.to_string())?;
+        let interface_name = NetworkInterfaceName::try_from(interface_name).map_err(|error| error.to_string())?;
 
         // TODO: Properly implement CAN parameter configuration
         let interface_configuration = match interface_type {

--- a/opendut-cleo/src/main.rs
+++ b/opendut-cleo/src/main.rs
@@ -186,7 +186,7 @@ enum CreateResource {
         #[arg(short, long, num_args = 1..)]
         args: Option<Vec<ContainerCommandArgument>>,
     },
-    NetworkConfiguration {
+    NetworkInterface {
         ///ID of the peer to add the network interface to
         #[arg(long)]
         peer_id: Uuid,
@@ -194,8 +194,8 @@ enum CreateResource {
         #[arg(long("type"))]
         interface_type: NetworkInterfaceType,
         ///Name of the network interface
-        #[arg(long("interface-name"))]
-        interface_name: Option<String>,
+        #[arg(long("name"))]
+        interface_name: String,
     },
     Device {
         ///ID of the peer to add the device to
@@ -272,7 +272,7 @@ enum DeleteResource {
         #[arg(short, long)]
         images: Vec<ContainerImage>,
     },
-    NetworkConfiguration {
+    NetworkInterface {
         ///ID of the peer to delete the network configuration from
         #[arg(long)]
         peer_id: Uuid,
@@ -404,8 +404,8 @@ async fn execute() -> Result<()> {
                 CreateResource::ContainerExecutor { peer_id, engine, name, image, volumes, devices, envs, ports, command, args} => {
                     commands::executor::create::execute(&mut carl, peer_id, engine, name, image, volumes, devices, envs, ports, command, args, output).await?;
                 }
-                CreateResource::NetworkConfiguration { peer_id, interface_type, interface_name} => {
-                    commands::network_configuration::create::execute(&mut carl, peer_id, interface_type, interface_name, output).await?;
+                CreateResource::NetworkInterface { peer_id, interface_type, interface_name} => {
+                    commands::network_interface::create::execute(&mut carl, peer_id, interface_type, interface_name, output).await?;
                 }
                 CreateResource::Device { peer_id, device_id, name, description, interface, tags } => {
                     commands::device::create::execute(&mut carl, peer_id, device_id, name, description, interface, tags, output).await?;
@@ -445,8 +445,8 @@ async fn execute() -> Result<()> {
                 DeleteResource::ContainerExecutor { peer_id, images} => {
                     commands::executor::delete::execute(&mut carl, peer_id, images).await?;
                 }
-                DeleteResource::NetworkConfiguration { peer_id,  interfaces} => {
-                    commands::network_configuration::delete::execute(&mut carl, peer_id, interfaces).await?;
+                DeleteResource::NetworkInterface { peer_id,  interfaces} => {
+                    commands::network_interface::delete::execute(&mut carl, peer_id, interfaces).await?;
                 }
                 DeleteResource::Device { id } => {
                     commands::device::delete::execute(&mut carl, id).await?;

--- a/opendut-cleo/src/main.rs
+++ b/opendut-cleo/src/main.rs
@@ -7,7 +7,7 @@ use console::Style;
 use uuid::Uuid;
 
 use opendut_carl_api::carl::CarlClient;
-use opendut_types::peer::{PeerSetup};
+use opendut_types::peer::PeerSetup;
 use opendut_types::peer::executor::{ContainerCommand, ContainerCommandArgument, ContainerDevice, ContainerImage, ContainerName, ContainerPortSpec, ContainerVolume};
 use opendut_types::topology::DeviceName;
 use opendut_types::util::net::NetworkInterfaceName;
@@ -116,6 +116,12 @@ pub enum EngineVariants {
     Podman,
 }
 
+#[derive(Clone, Debug, ValueEnum)]
+pub enum NetworkInterfaceType {
+    Ethernet,
+    Can,
+}
+
 #[derive(Subcommand, Clone, Debug)]
 enum CreateResource {
     ClusterConfiguration {
@@ -184,9 +190,12 @@ enum CreateResource {
         ///ID of the peer to add the network interface to
         #[arg(long)]
         peer_id: Uuid,
-        ///Device interfaces per peer
-        #[arg(long("interface"))]
-        interfaces: Option<Vec<String>>,
+        ///Type of the network interface
+        #[arg(long("type"))]
+        interface_type: NetworkInterfaceType,
+        ///Name of the network interface
+        #[arg(long("interface-name"))]
+        interface_name: Option<String>,
     },
     Device {
         ///ID of the peer to add the device to
@@ -395,8 +404,8 @@ async fn execute() -> Result<()> {
                 CreateResource::ContainerExecutor { peer_id, engine, name, image, volumes, devices, envs, ports, command, args} => {
                     commands::executor::create::execute(&mut carl, peer_id, engine, name, image, volumes, devices, envs, ports, command, args, output).await?;
                 }
-                CreateResource::NetworkConfiguration { peer_id, interfaces} => {
-                    commands::network_configuration::create::execute(&mut carl, peer_id, interfaces, output).await?;
+                CreateResource::NetworkConfiguration { peer_id, interface_type, interface_name} => {
+                    commands::network_configuration::create::execute(&mut carl, peer_id, interface_type, interface_name, output).await?;
                 }
                 CreateResource::Device { peer_id, device_id, name, description, interface, tags } => {
                     commands::device::create::execute(&mut carl, peer_id, device_id, name, description, interface, tags, output).await?;

--- a/opendut-edgar/src/service/cluster_assignment.rs
+++ b/opendut-edgar/src/service/cluster_assignment.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 
 use opendut_types::cluster::{ClusterAssignment, PeerClusterAssignment};
 use opendut_types::peer::PeerId;
-use opendut_types::util::net::{NetworkInterfaceDescriptor, NetworkInterfaceName};
+use opendut_types::util::net::{NetworkInterfaceConfiguration, NetworkInterfaceDescriptor, NetworkInterfaceName};
 
 use crate::service::network_interface;
 use crate::service::network_interface::{bridge, gre};
@@ -137,14 +137,13 @@ fn require_ipv4_for_gre(ip_address: IpAddr) -> Result<Ipv4Addr, Error> {
     }
 }
 
-// TODO: Use some proper way to determine whether an interface is an Ethernet or a CAN one
 fn get_own_ethernet_interfaces(cluster_assignment: &ClusterAssignment,
     self_id: PeerId) -> Result<Vec<NetworkInterfaceDescriptor>, Error> {
 
     let own_cluster_assignment = cluster_assignment.assignments.iter().find(|assignment| assignment.peer_id == self_id).unwrap();
 
     let own_ethernet_interfaces: Vec<NetworkInterfaceDescriptor> = own_cluster_assignment.device_interfaces.iter()
-        .filter(|interface| !interface.name.name().contains("can"))
+        .filter(|interface| interface.configuration == NetworkInterfaceConfiguration::Ethernet)
         .cloned()
         .collect();
 
@@ -158,7 +157,7 @@ fn get_own_can_interfaces(
     let own_cluster_assignment = cluster_assignment.assignments.iter().find(|assignment| assignment.peer_id == self_id).unwrap();
 
     let own_can_interfaces: Vec<NetworkInterfaceDescriptor> = own_cluster_assignment.device_interfaces.iter()
-        .filter(|interface| interface.name.name().contains("can"))
+        .filter(|interface| matches!(interface.configuration, NetworkInterfaceConfiguration::Can{ .. }))
         .cloned()
         .collect();
 


### PR DESCRIPTION
This PR facilitates the selection of the interface type (Ethernet, CAN) via CLEO and makes EDGAR treat the interface according to its configured type.