### PR TITLE
Rotate Cannelloni server ports when redeploying

### DIFF
--- a/opendut-carl/carl.toml
+++ b/opendut-carl/carl.toml
@@ -29,6 +29,7 @@ scopes = "openid,profile,email"
 [peer]
 disconnect.timeout.ms = 30000
 can.server_port_range_start = 10000
+can.server_port_range_end = 20000
 ethernet.bridge.name.default = "br-opendut"
 
 [serve]

--- a/opendut-carl/src/cluster/manager.rs
+++ b/opendut-carl/src/cluster/manager.rs
@@ -119,8 +119,10 @@ impl ClusterManager {
                 and 'can_server_port_range_start' is very narrow for the configured number of peers ({}). This may cause errors on EDGAR.", 
                 self.options.can_server_port_range_start, self.options.can_server_port_range_end, n_peers);
         }
+
+        // Wrap-around the counter when we reached the end of the range of usable ports
         if self.can_server_port_counter + n_peers >= self.options.can_server_port_range_end {
-            self.can_server_port_counter = self.options.can_server_port_range_end;
+            self.can_server_port_counter = self.options.can_server_port_range_start;
         }
         
         let can_server_ports = (self.can_server_port_counter..self.can_server_port_counter + n_peers)

--- a/opendut-carl/src/grpc/cluster_manager.rs
+++ b/opendut-carl/src/grpc/cluster_manager.rs
@@ -107,7 +107,7 @@ impl ClusterManagerService for ClusterManagerFacade {
             Some(id) => {
                 let id = ClusterId::try_from(id)
                     .map_err(|_| Status::invalid_argument("Invalid ClusterId."))?;
-                let configuration = self.cluster_manager.find_configuration(id).await;
+                let configuration = self.cluster_manager.lock().await.find_configuration(id).await;
                 match configuration {
                     Some(configuration) => {
                         Ok(Response::new(GetClusterConfigurationResponse {
@@ -132,7 +132,7 @@ impl ClusterManagerService for ClusterManagerFacade {
     #[tracing::instrument(skip(self, request), level="trace")]
     async fn list_cluster_configurations(&self, request: Request<ListClusterConfigurationsRequest>) -> Result<Response<ListClusterConfigurationsResponse>, Status> {
         trace!("Received request: {}", request.debug_output());
-        let configurations = self.cluster_manager.list_configuration().await;
+        let configurations = self.cluster_manager.lock().await.list_configuration().await;
         Ok(Response::new(ListClusterConfigurationsResponse {
             result: Some(list_cluster_configurations_response::Result::Success(
                 ListClusterConfigurationsSuccess {
@@ -149,7 +149,7 @@ impl ClusterManagerService for ClusterManagerFacade {
         let request = request.into_inner();
         let cluster_deployment: ClusterDeployment = extract!(request.cluster_deployment)?;
 
-        let result = self.cluster_manager.store_cluster_deployment(cluster_deployment).await;
+        let result = self.cluster_manager.lock().await.store_cluster_deployment(cluster_deployment).await;
 
         match result {
             Err(error) => {
@@ -175,7 +175,7 @@ impl ClusterManagerService for ClusterManagerFacade {
         let request = request.into_inner();
         let cluster_id: ClusterId = extract!(request.cluster_id)?;
 
-        let result = self.cluster_manager.delete_cluster_deployment(cluster_id).await; // TODO: Replace with action
+        let result = self.cluster_manager.lock().await.delete_cluster_deployment(cluster_id).await; // TODO: Replace with action
 
         match result {
             Err(error) => {
@@ -198,7 +198,7 @@ impl ClusterManagerService for ClusterManagerFacade {
     #[tracing::instrument(skip(self, request), level="trace")]
     async fn list_cluster_deployments(&self, request: Request<ListClusterDeploymentsRequest>) -> Result<Response<ListClusterDeploymentsResponse>, Status> {
         trace!("Received request: {}", request.debug_output());
-        let deployments = self.cluster_manager.list_deployment().await;
+        let deployments = self.cluster_manager.lock().await.list_deployment().await;
         Ok(Response::new(ListClusterDeploymentsResponse {
             result: Some(list_cluster_deployments_response::Result::Success(
                 ListClusterDeploymentsSuccess {


### PR DESCRIPTION
This PR solves an issue with the assignment of cannelloni server ports to the EDGAR leader.

**Problem**
So far, the ports used by the cannelloni server are reused when redeploying the cluster. However, as the SCTP sockets are not immediately closed when the cannelloni instance is killed, starting the new cannelloni instance will fail for a few seconds after terminating the old one, as it cannot bind to the port. This causes the full cluster setup to take longer and pollutes the logs of the EDGAR leader with errors.

**Solution**
With this PR, the ports are rotated when redeploying the cluster, so that the new cannelloni instance can start immediately.