### PR TITLE
EDGAR Setup WriteCaCertificate -> Calculate checksum from certificates on disk, when no checksum files exist.

### DIFF
--- a/.ci/docker/edgar/docker-compose.yml
+++ b/.ci/docker/edgar/docker-compose.yml
@@ -11,7 +11,8 @@ services:
     #command: sleep infinity
     volumes:
       - ../../../target/ci/distribution/x86_64-unknown-linux-gnu/:/opt/artifacts
-      - "../../../resources/development/tls/insecure-development-ca.pem:/etc/opendut/tls/ca.pem"
+      - "../../../resources/development/tls/insecure-development-ca.pem:/etc/opendut/tls/ca.pem:ro"
+      - "../../../resources/development/tls/insecure-development-ca.pem:/usr/local/share/ca-certificates/opendut-ca.crt:ro"
       - "../../../target/debug/:/usr/local/opendut/bin/debug/"
     cap_add:
       - NET_ADMIN
@@ -64,7 +65,8 @@ services:
     #command: sleep infinity
     volumes:
       - ../../../target/ci/distribution/x86_64-unknown-linux-gnu/:/opt/artifacts:ro
-      - "../../../resources/development/tls/insecure-development-ca.pem:/etc/opendut/tls/ca.pem"
+      - "../../../resources/development/tls/insecure-development-ca.pem:/etc/opendut/tls/ca.pem:ro"
+      - "../../../resources/development/tls/insecure-development-ca.pem:/usr/local/share/ca-certificates/opendut-ca.crt:ro"
       - "../../../target/debug/:/usr/local/opendut/bin/debug/:ro"
     cap_add:
       - NET_ADMIN

--- a/opendut-edgar/src/setup/tasks/copy_executable.rs
+++ b/opendut-edgar/src/setup/tasks/copy_executable.rs
@@ -16,9 +16,9 @@ impl Task for CopyExecutable {
     fn check_fulfilled(&self) -> Result<TaskFulfilled> {
         let installed_path = executable_install_path()?;
         if installed_path.exists() {
-            let installed_digest = util::file_checksum(installed_path)?;
+            let installed_digest = util::checksum::file(installed_path)?;
             let unpacked_path = std::env::current_exe()?;
-            let unpacked_digest = util::file_checksum(unpacked_path)?;
+            let unpacked_digest = util::checksum::file(unpacked_path)?;
 
             if installed_digest == unpacked_digest {
                 return Ok(TaskFulfilled::Yes);

--- a/opendut-edgar/src/setup/tasks/create_service.rs
+++ b/opendut-edgar/src/setup/tasks/create_service.rs
@@ -63,7 +63,7 @@ impl Task for CreateServiceFile {
         let unpacked_systemd_checksum_file = &self.checksum_systemd_file;
         if unpacked_systemd_checksum_file.exists() {
             let systemd_installed_digest = fs::read(unpacked_systemd_checksum_file)?;
-            let systemd_distribution_digest = util::sha256_digest(systemd_file_content(&self.service_user).as_bytes())?;
+            let systemd_distribution_digest = util::checksum::string(systemd_file_content(&self.service_user))?;
 
             if systemd_installed_digest == systemd_distribution_digest {
                 return Ok(TaskFulfilled::Yes);
@@ -84,7 +84,7 @@ impl Task for CreateServiceFile {
             Command::new("systemctl").arg("daemon-reload")
         ).context("systemctl daemon-reload could not be executed successfully!")?;
 
-        let checksum_systemd_file = util::sha256_digest(systemd_file_content.as_bytes())?;
+        let checksum_systemd_file = util::checksum::string(systemd_file_content)?;
         let checksum_systemd_file_unpack_file = &self.checksum_systemd_file;
         fs::create_dir_all(checksum_systemd_file_unpack_file.parent().unwrap())?;
         fs::write(checksum_systemd_file_unpack_file, checksum_systemd_file)

--- a/opendut-edgar/src/setup/tasks/netbird/unpack.rs
+++ b/opendut-edgar/src/setup/tasks/netbird/unpack.rs
@@ -22,7 +22,7 @@ impl Task for Unpack {
         let unpacked_checksum_file = &self.checksum_unpack_file;
         if unpacked_checksum_file.exists() {
             let installed_digest = fs::read(unpacked_checksum_file)?;
-            let distribution_digest = util::file_checksum(&self.from)?;
+            let distribution_digest = util::checksum::file(&self.from)?;
 
             if installed_digest == distribution_digest {
                 return Ok(TaskFulfilled::Yes);
@@ -40,7 +40,7 @@ impl Task for Unpack {
         fs::create_dir_all(&self.to_dir)?;
         archive.unpack(&self.to_dir)?;
 
-        let checksum = util::file_checksum(&self.from)?;
+        let checksum = util::checksum::file(&self.from)?;
         let checksum_unpack_file = &self.checksum_unpack_file;
         fs::create_dir_all(checksum_unpack_file.parent().unwrap())?;
         fs::write(checksum_unpack_file, checksum)
@@ -87,7 +87,7 @@ mod tests {
 
         assert_eq!(task.check_fulfilled()?, TaskFulfilled::No);
         
-        checksum_file_path.write_binary(&util::file_checksum(from.path())?)?;
+        checksum_file_path.write_binary(&util::checksum::file(from.path())?)?;
 
         let task = Unpack {
             from: from.to_path_buf(),


### PR DESCRIPTION
This is useful for scripting EDGAR's setup via an external tool, as happens in the Testenv.

Additionally, the mount of the certificate into the Testenv was made read-only, so that superfluous write attempts break the build, which happen when the task check doesn't work correctly.