### PR TITLE
Rename Netbird CA logic

### DIFF
--- a/opendut-edgar/src/setup/constants.rs
+++ b/opendut-edgar/src/setup/constants.rs
@@ -26,10 +26,10 @@ pub fn default_carl_ca_certificate_path() -> PathBuf {
 pub fn default_checksum_carl_ca_certificate_file() -> PathBuf {
     PathBuf::from("/etc/opendut/tls/.ca.pem.checksum")
 }
-pub fn default_netbird_ca_certificate_path() -> PathBuf {
+pub fn default_os_cert_store_ca_certificate_path() -> PathBuf {
     PathBuf::from("/usr/local/share/ca-certificates/opendut-ca.crt")
 }
-pub fn default_checksum_netbird_ca_certificate_file() -> PathBuf {
+pub fn default_checksum_os_cert_store_ca_certificate_file() -> PathBuf {
     PathBuf::from("/usr/local/share/ca-certificates/.opendut-ca.crt.checksum")
 }
 

--- a/opendut-edgar/src/setup/tasks/write_ca_certificate.rs
+++ b/opendut-edgar/src/setup/tasks/write_ca_certificate.rs
@@ -16,9 +16,9 @@ use crate::setup::util::{CommandRunner, DefaultCommandRunner};
 pub struct WriteCaCertificate {
     pub certificate: Certificate,
     pub carl_ca_certificate_path: PathBuf,
-    pub netbird_ca_certificate_path: PathBuf,
+    pub os_cert_store_ca_certificate_path: PathBuf,
     pub checksum_carl_ca_certificate_file: PathBuf,
-    pub checksum_netbird_ca_certificate_file: PathBuf,
+    pub checksum_os_cert_store_ca_certificate_file: PathBuf,
     pub command_runner: Box<dyn CommandRunner>,
 }
 
@@ -30,9 +30,9 @@ impl Task for WriteCaCertificate {
 
     fn check_fulfilled(&self) -> anyhow::Result<TaskFulfilled> {
         let unpacked_carl_checksum_file = &self.checksum_carl_ca_certificate_file;
-        let unpacked_netbird_checksum_file = &self.checksum_netbird_ca_certificate_file;
+        let unpacked_os_cert_store_checksum_file = &self.checksum_os_cert_store_ca_certificate_file;
 
-        if unpacked_carl_checksum_file.exists() && unpacked_netbird_checksum_file.exists() {
+        if unpacked_carl_checksum_file.exists() && unpacked_os_cert_store_checksum_file.exists() {
 
             let mut hasher = Sha256::new();
             let pem_string: String = encode(&self.certificate.0);
@@ -40,10 +40,10 @@ impl Task for WriteCaCertificate {
             let provided_certificate_checksum = hasher.finalize().to_vec();
 
             let carl_installed_digest = fs::read(unpacked_carl_checksum_file)?;
-            let netbird_installed_digest = fs::read(unpacked_netbird_checksum_file)?;
+            let os_cert_store_installed_digest = fs::read(unpacked_os_cert_store_checksum_file)?;
 
             if carl_installed_digest == provided_certificate_checksum
-                && netbird_installed_digest == provided_certificate_checksum {
+                && os_cert_store_installed_digest == provided_certificate_checksum {
                 return Ok(TaskFulfilled::Yes);
             }
         }
@@ -57,7 +57,7 @@ impl Task for WriteCaCertificate {
 
         write_carl_certificate(new_certificate, carl_ca_certificate_path, &self.checksum_carl_ca_certificate_file)?;
 
-        write_netbird_certificate(carl_ca_certificate_path, &self.netbird_ca_certificate_path, &self.checksum_netbird_ca_certificate_file, self.command_runner.as_ref())?; //TODO this certificate doesn't have to be the same as for CARL and should instead be retrieved from CARL after the initial connection
+        write_os_cert_store_certificate(carl_ca_certificate_path, &self.os_cert_store_ca_certificate_path, &self.checksum_os_cert_store_ca_certificate_file, self.command_runner.as_ref())?; //TODO this certificate doesn't have to be the same as for CARL and should instead be retrieved from CARL after the initial connection
 
         Ok(Success::default())
     }
@@ -68,9 +68,9 @@ impl WriteCaCertificate {
         Self {
             certificate,
             carl_ca_certificate_path: constants::default_carl_ca_certificate_path(),
-            netbird_ca_certificate_path: constants::default_netbird_ca_certificate_path(),
+            os_cert_store_ca_certificate_path: constants::default_os_cert_store_ca_certificate_path(),
             checksum_carl_ca_certificate_file: constants::default_checksum_carl_ca_certificate_file(),
-            checksum_netbird_ca_certificate_file: constants::default_checksum_netbird_ca_certificate_file(),
+            checksum_os_cert_store_ca_certificate_file: constants::default_checksum_os_cert_store_ca_certificate_file(),
             command_runner: Box::new(DefaultCommandRunner),
         }
     }
@@ -98,36 +98,36 @@ fn write_carl_certificate(new_certificate: Pem, carl_ca_certificate_path: &Path,
     Ok(())
 }
 
-fn write_netbird_certificate(
+fn write_os_cert_store_certificate(
     carl_ca_certificate_path: &Path, 
-    netbird_ca_certificate_path: &Path,
-    checksum_netbird_ca_certificate_file: &Path,
+    os_cert_store_ca_certificate_path: &Path,
+    checksum_os_cert_store_ca_certificate_file: &Path,
     command_runner: &dyn CommandRunner
 ) -> anyhow::Result<()> {
 
-    let netbird_ca_certificate_dir = netbird_ca_certificate_path.parent().unwrap();
-    fs::create_dir_all(netbird_ca_certificate_dir)
-        .context(format!("Unable to create path {:?}", netbird_ca_certificate_dir))?;
+    let os_cert_store_ca_certificate_dir = os_cert_store_ca_certificate_path.parent().unwrap();
+    fs::create_dir_all(os_cert_store_ca_certificate_dir)
+        .context(format!("Unable to create path {:?}", os_cert_store_ca_certificate_dir))?;
 
     fs::copy(
         carl_ca_certificate_path,
-        netbird_ca_certificate_path,
+        os_cert_store_ca_certificate_path,
     ).context(format!(
-        "Copying CA certificate from {:?} to {:?} was not possible.", carl_ca_certificate_path, netbird_ca_certificate_path
+        "Copying CA certificate from {:?} to {:?} was not possible.", carl_ca_certificate_path, os_cert_store_ca_certificate_path
     ))?;
 
     let update_ca_certificates = which::which("update-ca-certificates")
         .context(String::from("No command `update-ca-certificates` found. Ensure your system provides this command."))?;
 
     command_runner.run(
-        &mut Command::new(update_ca_certificates) //Update OS certificate store, as NetBird reads from there
+        &mut Command::new(update_ca_certificates) //Update OS certificate store, as NetBird and reqwest (for result uploading to WebDAV) reads from there
     ).context("update-ca-certificates could not be executed successfully!")?;
 
-    let checksum = util::file_checksum(netbird_ca_certificate_path)?;
-    let checksum_unpack_file = checksum_netbird_ca_certificate_file;
+    let checksum = util::file_checksum(os_cert_store_ca_certificate_path)?;
+    let checksum_unpack_file = checksum_os_cert_store_ca_certificate_file;
     fs::create_dir_all(checksum_unpack_file.parent().unwrap())?;
     fs::write(checksum_unpack_file, checksum)
-        .context(format!("Writing checksum for netbird ca certificate to '{}'.", checksum_unpack_file.display()))?;
+        .context(format!("Writing checksum for OS cert store ca certificate to '{}'.", checksum_unpack_file.display()))?;
 
     Ok(())
 }
@@ -137,7 +137,7 @@ mod tests {
     use std::str::FromStr;
     use assert_fs::prelude::*;
     use assert_fs::TempDir;
-    use pem::{Pem};
+    use pem::Pem;
 
     use opendut_types::util::net::Certificate;
 
@@ -152,18 +152,18 @@ mod tests {
 
         let carl_ca_certificate_path = temp.child("ca.pem");
 
-        let netbird_ca_certificate_path = temp.child("opendut-ca.crt");
+        let os_cert_store_ca_certificate_path = temp.child("opendut-ca.crt");
 
         let checksum_carl_ca_certificate_file = temp.child("ca.pem.checksum");
 
-        let checksum_netbird_ca_certificate_file = temp.child("opendut-ca.crt.checksum");
+        let checksum_os_cert_store_ca_certificate_file = temp.child("opendut-ca.crt.checksum");
 
         let task = WriteCaCertificate {
             certificate: Certificate(Pem::new("Test Tag".to_string(), vec![])),
             carl_ca_certificate_path: carl_ca_certificate_path.to_path_buf(),
-            netbird_ca_certificate_path: netbird_ca_certificate_path.to_path_buf(),
+            os_cert_store_ca_certificate_path: os_cert_store_ca_certificate_path.to_path_buf(),
             checksum_carl_ca_certificate_file: checksum_carl_ca_certificate_file.to_path_buf(),
-            checksum_netbird_ca_certificate_file: checksum_netbird_ca_certificate_file.to_path_buf(),
+            checksum_os_cert_store_ca_certificate_file: checksum_os_cert_store_ca_certificate_file.to_path_buf(),
             command_runner: Box::new(NoopCommandRunner),
         };
 
@@ -180,11 +180,11 @@ mod tests {
 
         let carl_ca_certificate_path = temp.child("ca.pem");
 
-        let netbird_ca_certificate_path = temp.child("opendut-ca.crt");
+        let os_cert_store_ca_certificate_path = temp.child("opendut-ca.crt");
 
         let checksum_carl_ca_certificate_file = temp.child("ca.pem.checksum");
 
-        let checksum_netbird_ca_certificate_file = temp.child("opendut-ca.crt.checksum");
+        let checksum_os_cert_store_ca_certificate_file = temp.child("opendut-ca.crt.checksum");
 
         const PEM_STORED: &'static str = "-----BEGIN RSA PUBLIC KEY-----
 MIIBPQIBAAJBAOsfi5AGYhdRs/x6q5H7kScxA0Kzzqe6WI6gf6+tc6IvKQJo5rQc
@@ -209,20 +209,20 @@ ANJGc7AFk4fyFD/OezhwGHbWmo/S+bfeAiIh2Ss2FxKJ
 ";
 
         carl_ca_certificate_path.write_str(PEM_STORED).unwrap();
-        netbird_ca_certificate_path.write_str(PEM_STORED).unwrap();
-        let checksum_carl_netbird_cert = util::file_checksum(&carl_ca_certificate_path).unwrap();
+        os_cert_store_ca_certificate_path.write_str(PEM_STORED).unwrap();
+        let checksum_carl_os_cert_store_cert = util::file_checksum(&carl_ca_certificate_path).unwrap();
 
-        let checksum_string = checksum_carl_netbird_cert.clone();
+        let checksum_string = checksum_carl_os_cert_store_cert.clone();
         checksum_carl_ca_certificate_file.write_binary(&checksum_string).unwrap();
-        checksum_netbird_ca_certificate_file.write_binary(&checksum_string).unwrap();
+        checksum_os_cert_store_ca_certificate_file.write_binary(&checksum_string).unwrap();
 
 
         let task = WriteCaCertificate {
             certificate: Certificate(Pem::from_str(NEW_PEM)?),
             carl_ca_certificate_path: carl_ca_certificate_path.to_path_buf(),
-            netbird_ca_certificate_path: netbird_ca_certificate_path.to_path_buf(),
+            os_cert_store_ca_certificate_path: os_cert_store_ca_certificate_path.to_path_buf(),
             checksum_carl_ca_certificate_file: checksum_carl_ca_certificate_file.to_path_buf(),
-            checksum_netbird_ca_certificate_file: checksum_netbird_ca_certificate_file.to_path_buf(),
+            checksum_os_cert_store_ca_certificate_file: checksum_os_cert_store_ca_certificate_file.to_path_buf(),
             command_runner: Box::new(NoopCommandRunner),
         };
 
@@ -239,11 +239,11 @@ ANJGc7AFk4fyFD/OezhwGHbWmo/S+bfeAiIh2Ss2FxKJ
 
         let carl_ca_certificate_path = temp.child("ca.pem");
 
-        let netbird_ca_certificate_path = temp.child("opendut-ca.crt");
+        let os_cert_store_ca_certificate_path = temp.child("opendut-ca.crt");
 
         let checksum_carl_ca_certificate_file = temp.child("ca.pem.checksum");
 
-        let checksum_netbird_ca_certificate_file = temp.child("opendut-ca.crt.checksum");
+        let checksum_os_cert_store_ca_certificate_file = temp.child("opendut-ca.crt.checksum");
 
         const PEM: &'static str = "-----BEGIN RSA PUBLIC KEY-----
 MIIBPQIBAAJBAOsfi5AGYhdRs/x6q5H7kScxA0Kzzqe6WI6gf6+tc6IvKQJo5rQc
@@ -258,20 +258,20 @@ ANJGc7AFk4fyFD/OezhwGHbWmo/S+bfeAiIh2Ss2FxKJ
         let pem = Pem::from_str(PEM)?.to_string();
 
         carl_ca_certificate_path.write_str(pem.as_str()).unwrap();
-        netbird_ca_certificate_path.write_str(pem.as_str()).unwrap();
-        let checksum_carl_netbird_cert = util::file_checksum(&carl_ca_certificate_path).unwrap();
+        os_cert_store_ca_certificate_path.write_str(pem.as_str()).unwrap();
+        let checksum_carl_os_cert_store_cert = util::file_checksum(&carl_ca_certificate_path).unwrap();
 
-        let checksum_string = checksum_carl_netbird_cert.clone();
+        let checksum_string = checksum_carl_os_cert_store_cert.clone();
         checksum_carl_ca_certificate_file.write_binary(&checksum_string).unwrap();
-        checksum_netbird_ca_certificate_file.write_binary(&checksum_string).unwrap();
+        checksum_os_cert_store_ca_certificate_file.write_binary(&checksum_string).unwrap();
 
 
         let task = WriteCaCertificate {
             certificate: Certificate(Pem::from_str(PEM)?),
             carl_ca_certificate_path: carl_ca_certificate_path.to_path_buf(),
-            netbird_ca_certificate_path: netbird_ca_certificate_path.to_path_buf(),
+            os_cert_store_ca_certificate_path: os_cert_store_ca_certificate_path.to_path_buf(),
             checksum_carl_ca_certificate_file: checksum_carl_ca_certificate_file.to_path_buf(),
-            checksum_netbird_ca_certificate_file: checksum_netbird_ca_certificate_file.to_path_buf(),
+            checksum_os_cert_store_ca_certificate_file: checksum_os_cert_store_ca_certificate_file.to_path_buf(),
             command_runner: Box::new(NoopCommandRunner),
         };
 


### PR DESCRIPTION
Minor cosmetic change that renames the logic in which the openDuT CA is written to the OS certificate store on a peer to account for the fact that the certificate from the OS store is not only used by Netbird, but also by `reqwest` when uploading results to the WebDAV server.