### PR TITLE
Feature/414 clickable table rows

### DIFF
--- a/opendut-lea/src/clusters/overview/row.rs
+++ b/opendut-lea/src/clusters/overview/row.rs
@@ -1,11 +1,13 @@
+use crate::clusters::IsDeployed;
+use crate::clusters::components::DeleteClusterButton;
 use leptos::html::Div;
 use leptos::prelude::*;
-use opendut_lea_components::{health, ButtonColor, Toggle};
+use leptos::web_sys;
+use leptos_router::hooks::use_navigate;
 use opendut_lea_components::health::Health;
-use opendut_lea_components::tooltip::{Tooltip};
+use opendut_lea_components::tooltip::Tooltip;
+use opendut_lea_components::{ButtonColor, Toggle, health};
 use opendut_model::cluster::ClusterDescriptor;
-use crate::clusters::components::DeleteClusterButton;
-use crate::clusters::IsDeployed;
 
 #[component]
 pub fn Row<OnDeployFn, OnUndeployFn, OnDeleteFn>(
@@ -20,18 +22,13 @@ where
     OnUndeployFn: Fn() + Send + 'static,
     OnDeleteFn: Fn() + Copy + Send + 'static,
 {
+    let cluster_id = create_read_slice(cluster_descriptor, |cluster_descriptor| {
+        cluster_descriptor.id
+    });
 
-    let cluster_id = create_read_slice(cluster_descriptor,
-        |cluster_descriptor| {
-            cluster_descriptor.id
-        }
-    );
-
-    let cluster_name = create_read_slice(cluster_descriptor,
-        |cluster_descriptor| {
-            Clone::clone(&cluster_descriptor.name).to_string()
-        }
-    );
+    let cluster_name = create_read_slice(cluster_descriptor, |cluster_descriptor| {
+        Clone::clone(&cluster_descriptor.name).to_string()
+    });
 
     let configurator_href = move || format!("/clusters/{}/configure/general", cluster_id.get());
 
@@ -41,7 +38,8 @@ where
     let _ = leptos_use::on_click_outside(dropdown, move |_| dropdown_active.set(false));
 
     let health_state = Signal::derive(move || {
-        health::State { //TODO implement Cluster health in backend and display it here
+        health::State {
+            //TODO implement Cluster health in backend and display it here
             kind: health::StateKind::Unknown,
             text: String::from("Unknown"),
         }
@@ -55,30 +53,55 @@ where
         }
     });
 
+    let mousedown_pos = RwSignal::new((0, 0));
+    let use_navigate = use_navigate();
+
+    let on_mousedown = move |e: web_sys::MouseEvent| {
+        mousedown_pos.set((e.client_x(), e.client_y()));
+    };
+
+    let on_click = move |e: web_sys::MouseEvent| {
+        let (start_x, start_y) = mousedown_pos.get();
+        let (end_x, end_y) = (e.client_x(), e.client_y());
+        let diff_x = (end_x - start_x) as f64;
+        let diff_y = (end_y - start_y) as f64;
+        // euclidean distance formula -> distance = sqrt(diff_x² + diff_y²)
+        let distance = (diff_x * diff_x + diff_y * diff_y).sqrt();
+        if distance < 5.0 {
+            use_navigate(&configurator_href(), Default::default());
+        }
+    };
+
     view! {
-        <tr>
+        <tr
+            class="is-clickable"
+            on:mousedown=on_mousedown
+            on:click=on_click
+        >
             <td class="is-vcentered has-text-centered">
                 <Tooltip
                     text=tooltip_text
                 >
-                    <Toggle
-                        is_active = Signal::derive(move || {
-                            is_deployed.get().0
-                        })
-                        on_action = move || {
-                            if is_deployed.get().0 { on_undeploy() } else { on_deploy() }
-                        }
-                    />
+                    <div on:click=|e| e.stop_propagation() on:mousedown=|e| e.stop_propagation()>
+                        <Toggle
+                            is_active = Signal::derive(move || {
+                                is_deployed.get().0
+                            })
+                            on_action = move || {
+                                if is_deployed.get().0 { on_undeploy() } else { on_deploy() }
+                            }
+                        />
+                    </div>
                 </Tooltip>
             </td>
             <td class="is-vcentered has-text-centered">
                 <Health state=health_state />
             </td>
             <td class="is-vcentered">
-                <a href=configurator_href> { cluster_name } </a>
+                <a href=configurator_href on:click=|e| e.stop_propagation() on:mousedown=|e| e.stop_propagation()> { cluster_name } </a>
             </td>
             <td class="is-vcentered is-flex is-justify-content-center">
-                <div class="is-pulled-right">
+                <div class="is-pulled-right" on:click=|e| e.stop_propagation() on:mousedown=|e| e.stop_propagation()>
                     <DeleteClusterButton
                         cluster_id
                         deployed_signal=is_deployed

--- a/opendut-lea/src/clusters/overview/row.rs
+++ b/opendut-lea/src/clusters/overview/row.rs
@@ -61,13 +61,9 @@ where
     };
 
     let on_click = move |e: web_sys::MouseEvent| {
-        let (start_x, start_y) = mousedown_pos.get();
-        let (end_x, end_y) = (e.client_x(), e.client_y());
-        let diff_x = (end_x - start_x) as f64;
-        let diff_y = (end_y - start_y) as f64;
-        // euclidean distance formula -> distance = sqrt(diff_x² + diff_y²)
-        let distance = (diff_x * diff_x + diff_y * diff_y).sqrt();
-        if distance < 5.0 {
+        let distance = crate::util::calculate_distance(mousedown_pos.get(), (e.client_x(), e.client_y()));
+        // fixes text selection issue: mouse moved < threshold -> click, else it's a drag.
+        if distance < crate::util::MOUSE_DRAG_PIXEL_THRESHOLD {
             use_navigate(&configurator_href(), Default::default());
         }
     };

--- a/opendut-lea/src/peers/overview/mod.rs
+++ b/opendut-lea/src/peers/overview/mod.rs
@@ -33,6 +33,7 @@ pub fn PeersOverview() -> impl IntoView {
                 peers.sort_by(|peer_a, peer_b| {
                     peer_a.name.value().to_lowercase()
                         .cmp(&peer_b.name.value().to_lowercase())
+                        .then(peer_a.id.to_string().cmp(&peer_b.id.to_string()))
                 });
 
                 let mut peer_states = carl.peers.list_peer_states().await

--- a/opendut-lea/src/peers/overview/row.rs
+++ b/opendut-lea/src/peers/overview/row.rs
@@ -84,7 +84,7 @@ where
                 let cluster_name = move || cluster_name.to_string();
                 let configurator_href = move || format!("/clusters/{cluster_id}/configure/general");
                 view! {
-                    <a href={ configurator_href }>{ cluster_name }</a>
+                    <a href=configurator_href on:click=|e| e.stop_propagation() on:mousedown=|e| e.stop_propagation()> { cluster_name } </a>
                 }
             })
             .collect();
@@ -102,13 +102,9 @@ where
     };
 
     let on_click = move |e: web_sys::MouseEvent| {
-        let (start_x, start_y) = mousedown_pos.get();
-        let (end_x, end_y) = (e.client_x(), e.client_y());
-        let diff_x = (end_x - start_x) as f64;
-        let diff_y = (end_y - start_y) as f64;
-        // euclidean distance formula -> distance = sqrt(diff_x² + diff_y²)
-        let distance = (diff_x * diff_x + diff_y * diff_y).sqrt();
-        if distance < 5.0 {
+        let distance = util::calculate_distance(mousedown_pos.get(), (e.client_x(), e.client_y()));
+        // fixes text selection issue: mouse moved < threshold -> click, else it's a drag.
+        if distance < util::MOUSE_DRAG_PIXEL_THRESHOLD {
             use_navigate(&configurator_href(), Default::default());
         }
     };
@@ -125,12 +121,13 @@ where
             <td class="is-vcentered">
                 <a href=configurator_href on:click=|e| e.stop_propagation() on:mousedown=|e| e.stop_propagation()> { peer_name } </a>
             </td>
-            <td class="is-vcentered" on:click=|e| e.stop_propagation() on:mousedown=|e| e.stop_propagation()>
+            <td class="is-vcentered">
                 { cluster_columns }
             </td>
             <td class="is-vcentered">
-                <div class="is-flex" on:click=|e| e.stop_propagation() on:mousedown=|e| e.stop_propagation()>
+                <div class="is-flex">
                     <DeletePeerButton
+                        on:click=|e| e.stop_propagation() on:mousedown=|e| e.stop_propagation()
                         peer_id used_clusters_length
                         button_color=ButtonColor::TextDanger
                         on_delete

--- a/opendut-lea/src/peers/overview/row.rs
+++ b/opendut-lea/src/peers/overview/row.rs
@@ -1,13 +1,17 @@
+use crate::peers::components::DeletePeerButton;
+use crate::util;
 use leptos::html::Div;
 use leptos::prelude::*;
+use leptos::web_sys;
+use leptos_router::hooks::use_navigate;
 use leptos_use::on_click_outside;
-use opendut_lea_components::{health, ButtonColor, ButtonSize, ButtonState, FontAwesomeIcon, IconButton};
 use opendut_lea_components::health::Health;
+use opendut_lea_components::{
+    ButtonColor, ButtonSize, ButtonState, FontAwesomeIcon, IconButton, health,
+};
 use opendut_model::cluster::ClusterDescriptor;
 use opendut_model::peer::PeerDescriptor;
 use opendut_model::peer::state::{PeerConnectionState, PeerState};
-use crate::peers::components::DeletePeerButton;
-use crate::util;
 
 #[component]
 pub(crate) fn Row<OnDeleteFn>(
@@ -16,93 +20,120 @@ pub(crate) fn Row<OnDeleteFn>(
     cluster_descriptor: RwSignal<Vec<ClusterDescriptor>>,
     on_delete: OnDeleteFn,
 ) -> impl IntoView
-where OnDeleteFn: Fn() + Copy + Send + 'static, {
+where
+    OnDeleteFn: Fn() + Copy + Send + 'static,
+{
+    let peer_id = create_read_slice(peer_descriptor, |peer_descriptor| peer_descriptor.id);
 
-    let peer_id = create_read_slice(peer_descriptor,
-        |peer_descriptor| {
-            peer_descriptor.id
-        }
-    );
+    let peer_name = create_read_slice(peer_descriptor, |peer_descriptor| {
+        Clone::clone(&peer_descriptor.name).to_string()
+    });
 
-    let peer_name = create_read_slice(peer_descriptor,
-        |peer_descriptor| {
-            Clone::clone(&peer_descriptor.name).to_string()
-        }
-    );
+    let configurator_href = move || format!("/peers/{}/configure/general", peer_id.get());
+    let setup_href = move || format!("/peers/{}/configure/setup", peer_id.get());
 
-    let configurator_href = move || { format!("/peers/{}/configure/general", peer_id.get()) };
-    let setup_href = move || { format!("/peers/{}/configure/setup", peer_id.get()) };
-
-    let health_state = Signal::derive(move || {
-        match peer_state.get().connection {
-            PeerConnectionState::Offline => {
-                health::State {
-                    kind: health::StateKind::Unknown,
-                    text: String::from("Disconnected"),
-                }
-            }
-            PeerConnectionState::Online { .. } => {
-                health::State {
-                    kind: health::StateKind::Green,
-                    text: String::from("Connected. No errors."),
-                }
-            }
-        }
+    let health_state = Signal::derive(move || match peer_state.get().connection {
+        PeerConnectionState::Offline => health::State {
+            kind: health::StateKind::Unknown,
+            text: String::from("Disconnected"),
+        },
+        PeerConnectionState::Online { .. } => health::State {
+            kind: health::StateKind::Green,
+            text: String::from("Connected. No errors."),
+        },
     });
 
     let dropdown_active = RwSignal::new(false);
     let dropdown = NodeRef::<Div>::new();
 
-    let _ = on_click_outside(dropdown, move |_| dropdown_active.set(false) );
+    let _ = on_click_outside(dropdown, move |_| dropdown_active.set(false));
     let used_clusters_length = RwSignal::new(0);
 
     let cluster_columns = move || {
-        let devices_in_peer = peer_descriptor.get().topology.devices.into_iter().map(|device| device.id).collect::<Vec<_>>();
+        let devices_in_peer = peer_descriptor
+            .get()
+            .topology
+            .devices
+            .into_iter()
+            .map(|device| device.id)
+            .collect::<Vec<_>>();
 
         let devices_in_cluster = {
-            let mut devices_in_cluster = cluster_descriptor.get().into_iter()
+            let mut devices_in_cluster = cluster_descriptor
+                .get()
+                .into_iter()
                 .map(|cluster| (cluster.id, cluster.name, cluster.devices))
-                .collect::<Vec<(_,_,_)>>();
+                .collect::<Vec<(_, _, _)>>();
 
-            devices_in_cluster.sort_by(|(_, name_a, _), (_, name_b, _)|
+            devices_in_cluster.sort_by(|(_, name_a, _), (_, name_b, _)| {
                 name_a.to_string().cmp(&name_b.to_string())
-            );
+            });
 
             devices_in_cluster
         };
 
-        let cluster_view_list: Vec<View<_>> = devices_in_cluster.into_iter()
-            .filter(|(_, _, devices)| devices_in_peer.clone().into_iter().any(|device| devices.contains(&device)))
+        let cluster_view_list: Vec<View<_>> = devices_in_cluster
+            .into_iter()
+            .filter(|(_, _, devices)| {
+                devices_in_peer
+                    .clone()
+                    .into_iter()
+                    .any(|device| devices.contains(&device))
+            })
             .map(|(cluster_id, cluster_name, _)| {
-                let cluster_name = move || { cluster_name.to_string() };
-                let configurator_href = move || { format!("/clusters/{cluster_id}/configure/general") };
+                let cluster_name = move || cluster_name.to_string();
+                let configurator_href = move || format!("/clusters/{cluster_id}/configure/general");
                 view! {
                     <a href={ configurator_href }>{ cluster_name }</a>
                 }
-            }).collect();
+            })
+            .collect();
 
         used_clusters_length.set(cluster_view_list.len());
 
         util::view::join_with_comma_spans(cluster_view_list)
     };
 
+    let mousedown_pos = RwSignal::new((0, 0));
+    let use_navigate = use_navigate();
+
+    let on_mousedown = move |e: web_sys::MouseEvent| {
+        mousedown_pos.set((e.client_x(), e.client_y()));
+    };
+
+    let on_click = move |e: web_sys::MouseEvent| {
+        let (start_x, start_y) = mousedown_pos.get();
+        let (end_x, end_y) = (e.client_x(), e.client_y());
+        let diff_x = (end_x - start_x) as f64;
+        let diff_y = (end_y - start_y) as f64;
+        // euclidean distance formula -> distance = sqrt(diff_x² + diff_y²)
+        let distance = (diff_x * diff_x + diff_y * diff_y).sqrt();
+        if distance < 5.0 {
+            use_navigate(&configurator_href(), Default::default());
+        }
+    };
+
     view! {
-        <tr>
+        <tr
+            class="is-clickable"
+            on:mousedown=on_mousedown
+            on:click=on_click
+        >
             <td class="is-vcentered">
                 <Health state=health_state />
             </td>
             <td class="is-vcentered">
-                <a href=configurator_href> { peer_name } </a>
+                <a href=configurator_href on:click=|e| e.stop_propagation() on:mousedown=|e| e.stop_propagation()> { peer_name } </a>
             </td>
-            <td class="is-vcentered">
+            <td class="is-vcentered" on:click=|e| e.stop_propagation() on:mousedown=|e| e.stop_propagation()>
                 { cluster_columns }
             </td>
             <td class="is-vcentered">
-                <div class="is-flex">
-                    <DeletePeerButton 
-                        peer_id used_clusters_length 
-                        button_color=ButtonColor::TextDanger 
-                        on_delete 
+                <div class="is-flex" on:click=|e| e.stop_propagation() on:mousedown=|e| e.stop_propagation()>
+                    <DeletePeerButton
+                        peer_id used_clusters_length
+                        button_color=ButtonColor::TextDanger
+                        on_delete
                     />
                     <div class="dropdown is-right pl-2" class=("is-active", move || dropdown_active.get())>
                         <div class="dropdown-trigger">

--- a/opendut-lea/src/util.rs
+++ b/opendut-lea/src/util.rs
@@ -1,3 +1,5 @@
+pub const MOUSE_DRAG_PIXEL_THRESHOLD: f64 = 5.0;
+
 pub mod view {
     use leptos::prelude::*;
 
@@ -17,4 +19,13 @@ pub mod view {
         }
         elements_with_separator
     }
+}
+
+pub fn calculate_distance(start: (i32, i32), end: (i32, i32)) -> f64 {
+    let (start_x, start_y) = start;
+    let (end_x, end_y) = end;
+    let diff_x = (end_x - start_x) as f64;
+    let diff_y = (end_y - start_y) as f64;
+    // euclidean distance formula -> distance = sqrt(diff_x² + diff_y²)
+    (diff_x * diff_x + diff_y * diff_y).sqrt()
 }


### PR DESCRIPTION
Fixes #414 

Clicking on a row in Cluster/Peer Overview now navigates to the respective configurator while taking into account of user selecting texts.

- Uses mouse distance to solve text selection case (< 5px = click, ≥ 5px = drag)
- No new dependencies added