### PR TITLE
Feature/444 health traffic light

### DIFF
--- a/opendut-lea/src/clusters/components/cluster_health.rs
+++ b/opendut-lea/src/clusters/components/cluster_health.rs
@@ -1,0 +1,20 @@
+use leptos::prelude::*;
+use opendut_lea_components::health::{self, Health};
+use opendut_model::cluster::state::ClusterState;
+
+#[component]
+pub fn ClusterHealth(state: Signal<ClusterState>) -> impl IntoView {
+    let _ = state;
+
+    let health_state = Signal::derive(move || {
+        health::State {
+            //TODO implement Cluster health in backend and display it here
+            kind: health::StateKind::Unknown,
+            text: String::from("Unknown"),
+        }
+    });
+
+    view! {
+        <Health state=health_state />
+    }
+}

--- a/opendut-lea/src/clusters/components/mod.rs
+++ b/opendut-lea/src/clusters/components/mod.rs
@@ -1,5 +1,7 @@
 pub use create_cluster_button::CreateClusterButton;
 pub use delete_cluster_button::DeleteClusterButton;
+pub use cluster_health::ClusterHealth;
 
+mod cluster_health;
 mod create_cluster_button;
 mod delete_cluster_button;

--- a/opendut-lea/src/clusters/configurator/components/controls.rs
+++ b/opendut-lea/src/clusters/configurator/components/controls.rs
@@ -5,6 +5,7 @@ use leptos_router::hooks::use_navigate;
 use tracing::{debug, error};
 use opendut_lea_components::tooltip::{Tooltip, TooltipDirection};
 use opendut_model::cluster::ClusterDescriptor;
+use opendut_model::cluster::state::ClusterState;
 
 use crate::app::use_app_globals;
 use crate::clusters::components::DeleteClusterButton;
@@ -12,11 +13,13 @@ use crate::clusters::configurator::types::UserClusterDescriptor;
 use crate::clusters::IsDeployed;
 use crate::components::{ButtonColor, ButtonSize, ButtonState, FontAwesomeIcon, IconButton, Toast, use_toaster};
 use crate::routing::{navigate_to, WellKnownRoutes};
+use crate::clusters::components::ClusterHealth;
 
 #[component]
 pub fn Controls(
     cluster_descriptor: ReadSignal<UserClusterDescriptor>,
-    deployed_signal: Signal<IsDeployed>
+    deployed_signal: Signal<IsDeployed>,
+    cluster_state: Signal<ClusterState>,
 ) -> impl IntoView {
 
     let cluster_id = Signal::derive(move || {
@@ -30,7 +33,9 @@ pub fn Controls(
     };
 
     view! {
-        <div class="is-flex">
+        <div class="is-flex is-align-items-center">
+            <ClusterHealth state=cluster_state.into() />
+            <div class="px-2" />
             <SaveClusterButton
                 cluster_descriptor
                 deployed_signal

--- a/opendut-lea/src/clusters/configurator/mod.rs
+++ b/opendut-lea/src/clusters/configurator/mod.rs
@@ -4,6 +4,7 @@ use opendut_lea_components::tabs::{Tab, Tabs};
 use crate::components::UserInputValue;
 use opendut_model::cluster::ClusterId;
 use opendut_model::peer::PeerDescriptor;
+use opendut_model::cluster::state::ClusterState;
 
 use crate::app::use_app_globals;
 use crate::clusters::configurator::components::{DeviceSelection, DeviceSelector, LeaderSelection};
@@ -83,6 +84,7 @@ fn LoadedClusterConfigurator(
     peers: ReadSignal<Vec<PeerDescriptor>>,
 ) -> impl IntoView {
     let globals = use_app_globals();
+    let cluster_state = RwSignal::new(ClusterState::default());
 
     let cluster_id = Signal::derive(move || cluster_descriptor.get().id);
 
@@ -158,6 +160,7 @@ fn LoadedClusterConfigurator(
                     <Controls
                         cluster_descriptor=cluster_descriptor.read_only()
                         deployed_signal
+                        cluster_state=cluster_state.into()
                     />
                 }
             }

--- a/opendut-lea/src/clusters/overview/row.rs
+++ b/opendut-lea/src/clusters/overview/row.rs
@@ -4,10 +4,11 @@ use leptos::html::Div;
 use leptos::prelude::*;
 use leptos::web_sys;
 use leptos_router::hooks::use_navigate;
-use opendut_lea_components::health::Health;
 use opendut_lea_components::tooltip::Tooltip;
-use opendut_lea_components::{ButtonColor, Toggle, health};
+use opendut_lea_components::{ButtonColor, Toggle};
 use opendut_model::cluster::ClusterDescriptor;
+use crate::clusters::components::ClusterHealth;
+use opendut_model::cluster::state::ClusterState;
 
 #[component]
 pub fn Row<OnDeployFn, OnUndeployFn, OnDeleteFn>(
@@ -37,14 +38,6 @@ where
 
     let _ = leptos_use::on_click_outside(dropdown, move |_| dropdown_active.set(false));
 
-    let health_state = Signal::derive(move || {
-        health::State {
-            //TODO implement Cluster health in backend and display it here
-            kind: health::StateKind::Unknown,
-            text: String::from("Unknown"),
-        }
-    });
-
     let tooltip_text = Signal::derive(move || {
         if is_deployed.get().0 {
             "Deployment requested".to_string()
@@ -67,6 +60,8 @@ where
             use_navigate(&configurator_href(), Default::default());
         }
     };
+
+    let cluster_state = RwSignal::new(ClusterState::default());
 
     view! {
         <tr
@@ -91,7 +86,7 @@ where
                 </Tooltip>
             </td>
             <td class="is-vcentered has-text-centered">
-                <Health state=health_state />
+                <ClusterHealth state=cluster_state.into() />
             </td>
             <td class="is-vcentered">
                 <a href=configurator_href on:click=|e| e.stop_propagation() on:mousedown=|e| e.stop_propagation()> { cluster_name } </a>

--- a/opendut-lea/src/peers/components/mod.rs
+++ b/opendut-lea/src/peers/components/mod.rs
@@ -1,5 +1,7 @@
 pub use crate::peers::components::create_peer_button::CreatePeerButton;
 pub use crate::peers::components::delete_peer_button::DeletePeerButton;
+pub use crate::peers::components::peer_health::PeerHealth;
 
 mod create_peer_button;
 mod delete_peer_button;
+mod peer_health;

--- a/opendut-lea/src/peers/components/peer_health.rs
+++ b/opendut-lea/src/peers/components/peer_health.rs
@@ -1,0 +1,26 @@
+use leptos::prelude::*;
+use opendut_lea_components::health::{self, Health};
+use opendut_model::peer::state::{PeerConnectionState, PeerState};
+
+#[component]
+pub fn PeerHealth(state: Signal<PeerState>) -> impl IntoView {
+
+    let health_state = Signal::derive(move || {
+        state.with(|peer_state| {
+            match peer_state.connection {
+                PeerConnectionState::Offline => health::State {
+                    kind: health::StateKind::Unknown,
+                    text: String::from("Disconnected"),
+                },
+                PeerConnectionState::Online { .. } => health::State {
+                    kind: health::StateKind::Green,
+                    text: String::from("Connected. No errors."),
+                },
+            }
+        })
+    });
+
+    view! {
+        <Health state=health_state />
+    }
+}

--- a/opendut-lea/src/peers/configurator/components/controls.rs
+++ b/opendut-lea/src/peers/configurator/components/controls.rs
@@ -7,17 +7,20 @@ use leptos_router::hooks::use_navigate;
 use tracing::{debug, error};
 use opendut_model::cluster::ClusterId;
 use opendut_model::peer::PeerDescriptor;
+use opendut_model::peer::state::PeerState;
 
 use crate::app::use_app_globals;
 use crate::components::{use_toaster, ButtonColor, ButtonSize, ButtonState, FontAwesomeIcon, IconButton, Toast};
 use crate::peers::components::DeletePeerButton;
 use crate::peers::configurator::types::UserPeerConfiguration;
 use crate::routing::{navigate_to, WellKnownRoutes};
+use crate::peers::components::PeerHealth;
 
 #[component]
 pub fn Controls(
     configuration: RwSignal<UserPeerConfiguration>,
     is_valid_peer_configuration: Signal<bool>,
+    peer_state: Signal<PeerState>
 ) -> impl IntoView {
 
     let peer_id = Signal::derive(move || {
@@ -43,7 +46,9 @@ pub fn Controls(
     }};
 
     view! {
-        <div class="is-flex">
+        <div class="is-flex is-align-items-center">
+            <PeerHealth state=peer_state.into() />
+            <div class="px-2" />
             <SavePeerButton
                 configuration
                 is_valid_peer_configuration

--- a/opendut-lea/src/peers/configurator/mod.rs
+++ b/opendut-lea/src/peers/configurator/mod.rs
@@ -17,6 +17,7 @@ use crate::peers::configurator::types::devices::UserDeviceConfiguration;
 use crate::peers::configurator::types::executor::{UserContainerEnv, UserPeerExecutor, UserPeerExecutorKind};
 use crate::peers::configurator::types::network::{UserNetworkInterface, UserPeerNetwork};
 use crate::peers::configurator::types::UserPeerConfiguration;
+use opendut_model::peer::state::PeerState;
 
 mod components;
 mod tabs;
@@ -30,7 +31,7 @@ pub fn PeerConfigurator() -> impl IntoView {
 
     let active_tab = use_active_tab::<TabIdentifier>();
 
-    let (peer_configuration, peer_configuration_resource, is_valid_peer_configuration) = {
+    let (peer_configuration, peer_configuration_resource, is_valid_peer_configuration, peer_state) = {
         let peer_id = {
             let peer_id = params.with_untracked(|params| {
                 params.get("id").and_then(|id| PeerId::try_from(id.as_str()).ok())
@@ -50,6 +51,7 @@ pub fn PeerConfigurator() -> impl IntoView {
                 }
             }
         };
+        let peer_state = RwSignal::new(PeerState::default());
 
         let peer_configuration = RwSignal::new(UserPeerConfiguration {
             id: peer_id,
@@ -171,6 +173,9 @@ pub fn PeerConfigurator() -> impl IntoView {
                             );
                         }
                     });
+                    if let Ok(state) = carl.peers.get_peer_state(peer_id).await {
+                        peer_state.set(state);
+                    }
                 }
             }
         });
@@ -181,7 +186,7 @@ pub fn PeerConfigurator() -> impl IntoView {
             })
         });
 
-        (peer_configuration, peer_configuration_resource, is_valid_peer_configuration)
+        (peer_configuration, peer_configuration_resource, is_valid_peer_configuration, peer_state)
     };
 
     let peer_id_string = create_read_slice(peer_configuration, |config| config.id.to_string());
@@ -294,7 +299,7 @@ pub fn PeerConfigurator() -> impl IntoView {
             title="Configure Peer"
             subtitle=subtitle
             breadcrumbs=breadcrumbs
-            controls=view! { <Controls configuration=peer_configuration is_valid_peer_configuration=is_valid_peer_configuration.into() /> }
+            controls=view! { <Controls configuration=peer_configuration is_valid_peer_configuration=is_valid_peer_configuration.into() peer_state=peer_state.into() /> }
         >
         <div> {cluster_columns} </div>
             <Suspense

--- a/opendut-lea/src/peers/overview/row.rs
+++ b/opendut-lea/src/peers/overview/row.rs
@@ -5,13 +5,11 @@ use leptos::prelude::*;
 use leptos::web_sys;
 use leptos_router::hooks::use_navigate;
 use leptos_use::on_click_outside;
-use opendut_lea_components::health::Health;
-use opendut_lea_components::{
-    ButtonColor, ButtonSize, ButtonState, FontAwesomeIcon, IconButton, health,
-};
+use opendut_lea_components::{ButtonColor, ButtonSize, ButtonState, FontAwesomeIcon, IconButton};
 use opendut_model::cluster::ClusterDescriptor;
 use opendut_model::peer::PeerDescriptor;
-use opendut_model::peer::state::{PeerConnectionState, PeerState};
+use opendut_model::peer::state::{PeerState};
+use crate::peers::components::PeerHealth;
 
 #[component]
 pub(crate) fn Row<OnDeleteFn>(
@@ -31,17 +29,6 @@ where
 
     let configurator_href = move || format!("/peers/{}/configure/general", peer_id.get());
     let setup_href = move || format!("/peers/{}/configure/setup", peer_id.get());
-
-    let health_state = Signal::derive(move || match peer_state.get().connection {
-        PeerConnectionState::Offline => health::State {
-            kind: health::StateKind::Unknown,
-            text: String::from("Disconnected"),
-        },
-        PeerConnectionState::Online { .. } => health::State {
-            kind: health::StateKind::Green,
-            text: String::from("Connected. No errors."),
-        },
-    });
 
     let dropdown_active = RwSignal::new(false);
     let dropdown = NodeRef::<Div>::new();
@@ -116,7 +103,7 @@ where
             on:click=on_click
         >
             <td class="is-vcentered">
-                <Health state=health_state />
+                <PeerHealth state=peer_state.into() />
             </td>
             <td class="is-vcentered">
                 <a href=configurator_href on:click=|e| e.stop_propagation() on:mousedown=|e| e.stop_propagation()> { peer_name } </a>


### PR DESCRIPTION
Solves #444 

Introduces visual health status indicators to the Configurator and Overview pages for both Peers and Clusters.

Peers: Added real-time health traffic light to Configurator.
Clusters: Added health indicator placeholder to Overview and Configurator.

Visual Changes: 

<img width="1278" height="312" alt="image" src="https://github.com/user-attachments/assets/d0f168f0-e7d1-4f76-9e78-8fbfbfb9223f" />
<img width="1338" height="274" alt="image" src="https://github.com/user-attachments/assets/51e15d1a-0be8-471b-9650-1a5c9c51d4d1" />
