### PR TITLE
Replace the usage of update-ca-certificates by another solution #249

### DIFF
--- a/.ci/docker/edgar/Dockerfile
+++ b/.ci/docker/edgar/Dockerfile
@@ -5,11 +5,10 @@ ARG cannelloni_version=1.1.0
 ENV TARGET_TRIPLE=x86_64-unknown-linux-gnu
 
 # Install OS package dependencies. We need:
-#   - `ca-certificates` for `update-ca-certificates` command used during EDGAR Setup
 #   - `can-utils` for `cangw` command used by EDGAR Service
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install --yes --no-install-recommends \
-    ca-certificates can-utils && \
+    can-utils && \
     rm -rf /var/lib/apt/lists/*
 
 

--- a/.ci/docker/edgar/docker-compose.yml
+++ b/.ci/docker/edgar/docker-compose.yml
@@ -57,7 +57,6 @@ services:
     volumes:
       - setup_persistence_edgar_application:/opt/opendut/edgar/
       - setup_persistence_configuration:/etc/
-      - setup_persistence_certificates:/usr/local/share/ca-certificates/
       - setup_persistence_os_path:/usr/bin/
 
     logging:
@@ -67,5 +66,4 @@ services:
 volumes:
   setup_persistence_edgar_application:
   setup_persistence_configuration:
-  setup_persistence_certificates:
   setup_persistence_os_path:

--- a/opendut-edgar/src/service/vpn/netbird.rs
+++ b/opendut-edgar/src/service/vpn/netbird.rs
@@ -45,7 +45,8 @@ impl NetbirdProcess {
                     .arg("--daemon-addr=unix:///var/run/netbird.sock")
                     .arg("--log-level").arg(config.log_level.to_string())
                     .arg("--log-file=console")
-                    .arg("--disable-profiles"); //not needed, since we manage the entire configuration and leads to errors when the NetBird process isn't running privileged
+                    .arg("--disable-profiles") //not needed, since we manage the entire configuration and leads to errors when the NetBird process isn't running privileged
+                    .env("SSL_CERT_FILE", crate::setup::constants::default_os_cert_store_ca_certificate_path());
 
                 command
             }

--- a/opendut-edgar/src/service/vpn/netbird.rs
+++ b/opendut-edgar/src/service/vpn/netbird.rs
@@ -4,7 +4,6 @@ use std::path::Path;
 use std::time::Duration;
 use anyhow::{anyhow, Context};
 use serde_json::json;
-use tokio::process::Command;
 use tracing::debug;
 use opendut_netbird_client_api::extension::LocalPeerStateExtension;
 use opendut_util::pem;
@@ -35,18 +34,16 @@ impl NetbirdProcess {
         let config = ProcessConfig::new(
             name,
             move || {
-                let netbird_executable = crate::setup::constants::netbird::unpacked_executable()
-                    .expect("Unpacked NetBird executable path should be determinable.");
+                let mut command = crate::setup::constants::netbird::command()
+                    .expect("Unpacked NetBird executable path should be available.");
 
-                let mut command = Command::new(netbird_executable);
                 command.arg("service")
                     .arg("run")
                     .arg("--config").arg(common::settings::netbird_config_file_path())
                     .arg("--daemon-addr=unix:///var/run/netbird.sock")
                     .arg("--log-level").arg(config.log_level.to_string())
                     .arg("--log-file=console")
-                    .arg("--disable-profiles") //not needed, since we manage the entire configuration and leads to errors when the NetBird process isn't running privileged
-                    .env("SSL_CERT_FILE", crate::setup::constants::default_os_cert_store_ca_certificate_path());
+                    .arg("--disable-profiles"); //not needed, since we manage the entire configuration and leads to errors when the NetBird process isn't running privileged
 
                 command
             }

--- a/opendut-edgar/src/setup/constants.rs
+++ b/opendut-edgar/src/setup/constants.rs
@@ -51,6 +51,7 @@ pub fn default_config_merge_suggestion_file_path() -> PathBuf {
 
 pub mod netbird {
     use super::*;
+    use tokio::process::Command;
 
     pub fn path_in_edgar_distribution() -> anyhow::Result<PathBuf> {
         let path = PathBuf::from("install/netbird.tar.gz");
@@ -77,8 +78,11 @@ pub mod netbird {
         edgar_install_directory().join("install")
     }
 
-    pub fn unpacked_executable() -> anyhow::Result<PathBuf> {
-        unpack_dir().map(|dir| dir.join("netbird"))
+    pub fn command() -> anyhow::Result<Command> {
+        let executable = unpack_dir()?.join("netbird");
+        let mut command = Command::new(executable);
+        command.env("SSL_CERT_FILE", default_os_cert_store_ca_certificate_path());
+        Ok(command)
     }
 }
 

--- a/opendut-edgar/src/setup/constants.rs
+++ b/opendut-edgar/src/setup/constants.rs
@@ -37,12 +37,6 @@ pub fn default_carl_ca_certificate_path() -> PathBuf {
 pub fn default_checksum_carl_ca_certificate_file() -> PathBuf {
     PathBuf::from("/etc/opendut/tls/.ca.pem.checksum")
 }
-pub fn default_os_cert_store_ca_certificate_path() -> PathBuf {
-    PathBuf::from("/usr/local/share/ca-certificates/opendut-ca.crt")
-}
-pub fn default_checksum_os_cert_store_ca_certificate_file() -> PathBuf {
-    PathBuf::from("/usr/local/share/ca-certificates/.opendut-ca.crt.checksum")
-}
 
 pub fn default_config_merge_suggestion_file_path() -> PathBuf {
     PathBuf::from("/etc/opendut/edgar-merge-suggestion.toml")
@@ -81,7 +75,7 @@ pub mod netbird {
     pub fn command() -> anyhow::Result<Command> {
         let executable = unpack_dir()?.join("netbird");
         let mut command = Command::new(executable);
-        command.env("SSL_CERT_FILE", default_os_cert_store_ca_certificate_path());
+        command.env("SSL_CERT_FILE", default_carl_ca_certificate_path());
         Ok(command)
     }
 }

--- a/opendut-edgar/src/setup/tasks/netbird/connect.rs
+++ b/opendut-edgar/src/setup/tasks/netbird/connect.rs
@@ -44,6 +44,7 @@ impl Task for Connect {
         {
             let process::Output { status, stdout, stderr } =
                 Command::new(constants::netbird::unpacked_executable()?.as_os_str())
+                    .env("SSL_CERT_FILE", constants::default_os_cert_store_ca_certificate_path())
                     .arg("up")
                     .arg("--management-url").arg(self.management_url.as_str())
                     .arg("--setup-key").arg(&self.setup_key.value)

--- a/opendut-edgar/src/setup/tasks/netbird/connect.rs
+++ b/opendut-edgar/src/setup/tasks/netbird/connect.rs
@@ -1,6 +1,5 @@
 use std::ops::Not;
 use std::process;
-use std::process::Command;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -43,13 +42,12 @@ impl Task for Connect {
 
         {
             let process::Output { status, stdout, stderr } =
-                Command::new(constants::netbird::unpacked_executable()?.as_os_str())
-                    .env("SSL_CERT_FILE", constants::default_os_cert_store_ca_certificate_path())
+                constants::netbird::command()?
                     .arg("up")
                     .arg("--management-url").arg(self.management_url.as_str())
                     .arg("--setup-key").arg(&self.setup_key.value)
                     .arg("--mtu").arg(self.mtu.to_string())
-                    .output()?;
+                    .output().await?;
 
             let message = format_command_output(stdout, stderr)?;
 

--- a/opendut-edgar/src/setup/tasks/write_ca_certificate.rs
+++ b/opendut-edgar/src/setup/tasks/write_ca_certificate.rs
@@ -14,43 +14,32 @@ use crate::common::task::{Success, Task, TaskStateFulfilled};
 pub struct WriteCaCertificate {
     pub certificate: Certificate,
     pub carl_ca_certificate_path: PathBuf,
-    pub os_cert_store_ca_certificate_path: PathBuf,
     pub checksum_carl_ca_certificate_file: PathBuf,
-    pub checksum_os_cert_store_ca_certificate_file: PathBuf,
 }
 
 #[async_trait]
 impl Task for WriteCaCertificate {
 
     fn description(&self) -> String {
-        String::from("Write CA Certificates")
+        String::from("Write CA Certificate")
     }
 
     async fn check_present(&self) -> anyhow::Result<TaskStateFulfilled> {
 
-        if self.carl_ca_certificate_path.exists().not()
-        || self.os_cert_store_ca_certificate_path.exists().not() {
-            debug!("Previous certificate files don't exist. Task needs execution.");
+        if self.carl_ca_certificate_path.exists().not() {
+            debug!("Previous certificate file doesn't exist. Task needs execution.");
             return Ok(TaskStateFulfilled::No);
         }
 
         let installed_carl_checksum_file = &self.checksum_carl_ca_certificate_file;
-        let installed_os_cert_store_checksum_file = &self.checksum_os_cert_store_ca_certificate_file;
 
-        let (installed_carl_checksum, installed_os_cert_store_checksum) = {
-            if installed_carl_checksum_file.exists()
-            && installed_os_cert_store_checksum_file.exists() {
-                (
-                    fs::read(installed_carl_checksum_file)?,
-                    fs::read(installed_os_cert_store_checksum_file)?,
-                )
+        let installed_carl_checksum = {
+            if installed_carl_checksum_file.exists() {
+                fs::read(installed_carl_checksum_file)?
             }
             else {
-                debug!("Previous certificate checksum files don't exist, but certificate files found. Calculating checksum by reading them.");
-                (
-                    util::checksum::file(&self.carl_ca_certificate_path)?,
-                    util::checksum::file(&self.os_cert_store_ca_certificate_path)?,
-                )
+                debug!("Previous certificate checksum file doesn't exist, but certificate file found. Calculating checksum by reading file.");
+                util::checksum::file(&self.carl_ca_certificate_path)?
             }
         };
 
@@ -58,11 +47,10 @@ impl Task for WriteCaCertificate {
             self.certificate.encode_as_string()
         )?;
 
-        if installed_carl_checksum == provided_certificate_checksum
-        && installed_os_cert_store_checksum == provided_certificate_checksum {
+        if installed_carl_checksum == provided_certificate_checksum {
             Ok(TaskStateFulfilled::Yes)
         } else {
-            debug!("Previous certificate checksum files exist, but do not match. Task needs execution.");
+            debug!("Previous certificate checksum file exists, but does not match. Task needs execution.");
             Ok(TaskStateFulfilled::No)
         }
     }
@@ -71,8 +59,6 @@ impl Task for WriteCaCertificate {
         let carl_ca_certificate_path = &self.carl_ca_certificate_path;
 
         write_carl_certificate(&self.certificate, carl_ca_certificate_path, &self.checksum_carl_ca_certificate_file)?;
-
-        write_os_cert_store_certificate(carl_ca_certificate_path, &self.os_cert_store_ca_certificate_path, &self.checksum_os_cert_store_ca_certificate_file)?; //TODO this certificate doesn't have to be the same as for CARL and should instead be retrieved from CARL after the initial connection
 
         Ok(Success::default())
     }
@@ -83,9 +69,7 @@ impl WriteCaCertificate {
         Self {
             certificate,
             carl_ca_certificate_path: constants::default_carl_ca_certificate_path(),
-            os_cert_store_ca_certificate_path: constants::default_os_cert_store_ca_certificate_path(),
             checksum_carl_ca_certificate_file: constants::default_checksum_carl_ca_certificate_file(),
-            checksum_os_cert_store_ca_certificate_file: constants::default_checksum_os_cert_store_ca_certificate_file(),
         }
     }
 }
@@ -95,7 +79,7 @@ fn write_carl_certificate(new_certificate: &Certificate, carl_ca_certificate_pat
     let carl_ca_certificate_dir = carl_ca_certificate_path.parent().unwrap();
     fs::create_dir_all(carl_ca_certificate_dir)
         .context(format!("Unable to create path {carl_ca_certificate_dir:?}"))?;
-    
+
     fs::write(
         carl_ca_certificate_path,
         new_certificate.encode_as_string()
@@ -106,31 +90,6 @@ fn write_carl_certificate(new_certificate: &Certificate, carl_ca_certificate_pat
     fs::create_dir_all(checksum_unpack_file.parent().unwrap())?;
     fs::write(checksum_unpack_file, checksum)
         .context(format!("Writing checksum for carl ca certificate to '{}'.", checksum_unpack_file.display()))?;
-    
-    Ok(())
-}
-
-fn write_os_cert_store_certificate(
-    carl_ca_certificate_path: &Path, 
-    os_cert_store_ca_certificate_path: &Path,
-    checksum_os_cert_store_ca_certificate_file: &Path,
-) -> anyhow::Result<()> {
-
-    let os_cert_store_ca_certificate_dir = os_cert_store_ca_certificate_path.parent().unwrap();
-    fs::create_dir_all(os_cert_store_ca_certificate_dir)
-        .context(format!("Unable to create path {os_cert_store_ca_certificate_dir:?}"))?;
-
-    fs::copy(
-        carl_ca_certificate_path,
-        os_cert_store_ca_certificate_path,
-    )
-    .context(format!("Copying CA certificate from {carl_ca_certificate_path:?} to {os_cert_store_ca_certificate_path:?} was not possible."))?;
-
-    let checksum = util::checksum::file(os_cert_store_ca_certificate_path)?;
-    let checksum_unpack_file = checksum_os_cert_store_ca_certificate_file;
-    fs::create_dir_all(checksum_unpack_file.parent().unwrap())?;
-    fs::write(checksum_unpack_file, checksum)
-        .context(format!("Writing checksum for OS cert store ca certificate to '{}'.", checksum_unpack_file.display()))?;
 
     Ok(())
 }
@@ -150,19 +109,14 @@ mod tests {
         let temp = TempDir::new()?;
 
         let carl_ca_certificate_path = temp.child("ca.pem");
-        let os_cert_store_ca_certificate_path = temp.child("opendut-ca.crt");
-
         let checksum_carl_ca_certificate_file = temp.child("ca.pem.checksum");
-        let checksum_os_cert_store_ca_certificate_file = temp.child("opendut-ca.crt.checksum");
 
         let pem_string = PEM_STRING_1;
 
         let task = WriteCaCertificate {
             certificate: Certificate::from_str(pem_string)?,
             carl_ca_certificate_path: carl_ca_certificate_path.to_path_buf(),
-            os_cert_store_ca_certificate_path: os_cert_store_ca_certificate_path.to_path_buf(),
             checksum_carl_ca_certificate_file: checksum_carl_ca_certificate_file.to_path_buf(),
-            checksum_os_cert_store_ca_certificate_file: checksum_os_cert_store_ca_certificate_file.to_path_buf(),
         };
 
         assert_eq!(task.check_present().await?, TaskStateFulfilled::No);
@@ -173,32 +127,25 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn should_report_task_as_unfulfilled_when_checksums_dont_match() -> anyhow::Result<()> {
+    async fn should_report_task_as_unfulfilled_when_checksum_doesnt_match() -> anyhow::Result<()> {
         let temp = TempDir::new()?;
 
         let carl_ca_certificate_path = temp.child("ca.pem");
-        let os_cert_store_ca_certificate_path = temp.child("opendut-ca.crt");
-
         let checksum_carl_ca_certificate_file = temp.child("ca.pem.checksum");
-        let checksum_os_cert_store_ca_certificate_file = temp.child("opendut-ca.crt.checksum");
 
         let stored_pem = PEM_STRING_1;
         let new_pem = PEM_STRING_2;
 
         carl_ca_certificate_path.write_str(stored_pem)?;
-        os_cert_store_ca_certificate_path.write_str(stored_pem)?;
 
         let checksum_carl_os_cert_store_cert = util::checksum::file(&carl_ca_certificate_path)?;
         checksum_carl_ca_certificate_file.write_binary(&checksum_carl_os_cert_store_cert)?;
-        checksum_os_cert_store_ca_certificate_file.write_binary(&checksum_carl_os_cert_store_cert)?;
 
 
         let task = WriteCaCertificate {
             certificate: Certificate::from_str(new_pem)?,
             carl_ca_certificate_path: carl_ca_certificate_path.to_path_buf(),
-            os_cert_store_ca_certificate_path: os_cert_store_ca_certificate_path.to_path_buf(),
             checksum_carl_ca_certificate_file: checksum_carl_ca_certificate_file.to_path_buf(),
-            checksum_os_cert_store_ca_certificate_file: checksum_os_cert_store_ca_certificate_file.to_path_buf(),
         };
 
         assert_eq!(task.check_present().await?, TaskStateFulfilled::No);
@@ -207,32 +154,25 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn should_report_task_as_fulfilled_when_checksums_match() -> anyhow::Result<()> {
+    async fn should_report_task_as_fulfilled_when_checksum_matches() -> anyhow::Result<()> {
         let temp = TempDir::new()?;
 
         let carl_ca_certificate_path = temp.child("ca.pem");
-        let os_cert_store_ca_certificate_path = temp.child("opendut-ca.crt");
 
         let checksum_carl_ca_certificate_file = temp.child("ca.pem.checksum");
-        let checksum_os_cert_store_ca_certificate_file = temp.child("opendut-ca.crt.checksum");
 
         let pem_string = PEM_STRING_1;
 
         carl_ca_certificate_path.write_str(pem_string)?;
-        os_cert_store_ca_certificate_path.write_str(pem_string)?;
 
         let checksum_carl_os_cert_store_cert = util::checksum::file(&carl_ca_certificate_path)?;
-        let checksum_string = checksum_carl_os_cert_store_cert.clone();
-        checksum_carl_ca_certificate_file.write_binary(&checksum_string)?;
-        checksum_os_cert_store_ca_certificate_file.write_binary(&checksum_string)?;
+        checksum_carl_ca_certificate_file.write_binary(&checksum_carl_os_cert_store_cert)?;
 
 
         let task = WriteCaCertificate {
             certificate: Certificate::from_str(pem_string)?,
             carl_ca_certificate_path: carl_ca_certificate_path.to_path_buf(),
-            os_cert_store_ca_certificate_path: os_cert_store_ca_certificate_path.to_path_buf(),
             checksum_carl_ca_certificate_file: checksum_carl_ca_certificate_file.to_path_buf(),
-            checksum_os_cert_store_ca_certificate_file: checksum_os_cert_store_ca_certificate_file.to_path_buf(),
         };
 
 
@@ -242,26 +182,21 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn should_report_task_as_fulfilled_when_checksums_dont_exist_but_the_certificate_files_on_disk_match() -> anyhow::Result<()> { //useful for placing the certificate files onto disk for an externally automated setup of EDGAR
+    async fn should_report_task_as_fulfilled_when_checksum_doesnt_exist_but_the_certificate_file_on_disk_matches() -> anyhow::Result<()> { //useful for placing the certificate files onto disk for an externally automated setup of EDGAR
         let temp = TempDir::new()?;
 
         let carl_ca_certificate_path = temp.child("ca.pem");
-        let os_cert_store_ca_certificate_path = temp.child("opendut-ca.crt");
 
         let checksum_carl_ca_certificate_file = temp.child("ca.pem.checksum");
-        let checksum_os_cert_store_ca_certificate_file = temp.child("opendut-ca.crt.checksum");
 
         let pem_string = PEM_STRING_1;
 
         carl_ca_certificate_path.write_str(pem_string)?;
-        os_cert_store_ca_certificate_path.write_str(pem_string)?;
 
         let task = WriteCaCertificate {
             certificate: Certificate::from_str(pem_string)?,
             carl_ca_certificate_path: carl_ca_certificate_path.to_path_buf(),
-            os_cert_store_ca_certificate_path: os_cert_store_ca_certificate_path.to_path_buf(),
             checksum_carl_ca_certificate_file: checksum_carl_ca_certificate_file.to_path_buf(),
-            checksum_os_cert_store_ca_certificate_file: checksum_os_cert_store_ca_certificate_file.to_path_buf(),
         };
 
         assert_eq!(task.check_present().await?, TaskStateFulfilled::Yes);

--- a/opendut-edgar/src/setup/tasks/write_ca_certificate.rs
+++ b/opendut-edgar/src/setup/tasks/write_ca_certificate.rs
@@ -1,7 +1,6 @@
 use std::ops::Not;
 use crate::fs;
 use std::path::{Path, PathBuf};
-use std::process::Command;
 
 use anyhow::Context;
 use async_trait::async_trait;
@@ -11,7 +10,6 @@ use opendut_model::util::net::Certificate;
 
 use crate::setup::{constants, util};
 use crate::common::task::{Success, Task, TaskStateFulfilled};
-use crate::setup::util::CommandRunner;
 
 pub struct WriteCaCertificate {
     pub certificate: Certificate,
@@ -19,7 +17,6 @@ pub struct WriteCaCertificate {
     pub os_cert_store_ca_certificate_path: PathBuf,
     pub checksum_carl_ca_certificate_file: PathBuf,
     pub checksum_os_cert_store_ca_certificate_file: PathBuf,
-    pub command_runner: CommandRunner,
 }
 
 #[async_trait]
@@ -30,11 +27,6 @@ impl Task for WriteCaCertificate {
     }
 
     async fn check_present(&self) -> anyhow::Result<TaskStateFulfilled> {
-
-        if matches!(self.command_runner, CommandRunner::Default) {
-            let _ = determine_update_ca_certificates_path()?; //check `which update-ca-certificates` beforehand to avoid us writing certificate files without it being possible to import them into OS (this would cause us to not re-run the task, since we only check for the files to exist).
-        }
-
 
         if self.carl_ca_certificate_path.exists().not()
         || self.os_cert_store_ca_certificate_path.exists().not() {
@@ -80,7 +72,7 @@ impl Task for WriteCaCertificate {
 
         write_carl_certificate(&self.certificate, carl_ca_certificate_path, &self.checksum_carl_ca_certificate_file)?;
 
-        write_os_cert_store_certificate(carl_ca_certificate_path, &self.os_cert_store_ca_certificate_path, &self.checksum_os_cert_store_ca_certificate_file, self.command_runner)?; //TODO this certificate doesn't have to be the same as for CARL and should instead be retrieved from CARL after the initial connection
+        write_os_cert_store_certificate(carl_ca_certificate_path, &self.os_cert_store_ca_certificate_path, &self.checksum_os_cert_store_ca_certificate_file)?; //TODO this certificate doesn't have to be the same as for CARL and should instead be retrieved from CARL after the initial connection
 
         Ok(Success::default())
     }
@@ -94,7 +86,6 @@ impl WriteCaCertificate {
             os_cert_store_ca_certificate_path: constants::default_os_cert_store_ca_certificate_path(),
             checksum_carl_ca_certificate_file: constants::default_checksum_carl_ca_certificate_file(),
             checksum_os_cert_store_ca_certificate_file: constants::default_checksum_os_cert_store_ca_certificate_file(),
-            command_runner: CommandRunner::Default,
         }
     }
 }
@@ -123,7 +114,6 @@ fn write_os_cert_store_certificate(
     carl_ca_certificate_path: &Path, 
     os_cert_store_ca_certificate_path: &Path,
     checksum_os_cert_store_ca_certificate_file: &Path,
-    command_runner: CommandRunner,
 ) -> anyhow::Result<()> {
 
     let os_cert_store_ca_certificate_dir = os_cert_store_ca_certificate_path.parent().unwrap();
@@ -136,14 +126,6 @@ fn write_os_cert_store_certificate(
     )
     .context(format!("Copying CA certificate from {carl_ca_certificate_path:?} to {os_cert_store_ca_certificate_path:?} was not possible."))?;
 
-    if matches!(command_runner, CommandRunner::Default) {
-        let update_ca_certificates = determine_update_ca_certificates_path()?;
-
-        command_runner.run(
-            &mut Command::new(update_ca_certificates) //Update OS certificate store, as NetBird and reqwest (for result uploading to WebDAV) reads from there
-        ).context("update-ca-certificates could not be executed successfully!")?;
-    }
-
     let checksum = util::checksum::file(os_cert_store_ca_certificate_path)?;
     let checksum_unpack_file = checksum_os_cert_store_ca_certificate_file;
     fs::create_dir_all(checksum_unpack_file.parent().unwrap())?;
@@ -151,13 +133,6 @@ fn write_os_cert_store_certificate(
         .context(format!("Writing checksum for OS cert store ca certificate to '{}'.", checksum_unpack_file.display()))?;
 
     Ok(())
-}
-
-fn determine_update_ca_certificates_path() -> anyhow::Result<PathBuf> {
-    let update_ca_certificates = which::which("update-ca-certificates")
-        .context(String::from("No command `update-ca-certificates` found. Ensure your system provides this command."))?;
-
-    Ok(update_ca_certificates)
 }
 
 #[cfg(test)]
@@ -188,7 +163,6 @@ mod tests {
             os_cert_store_ca_certificate_path: os_cert_store_ca_certificate_path.to_path_buf(),
             checksum_carl_ca_certificate_file: checksum_carl_ca_certificate_file.to_path_buf(),
             checksum_os_cert_store_ca_certificate_file: checksum_os_cert_store_ca_certificate_file.to_path_buf(),
-            command_runner: CommandRunner::Noop,
         };
 
         assert_eq!(task.check_present().await?, TaskStateFulfilled::No);
@@ -225,7 +199,6 @@ mod tests {
             os_cert_store_ca_certificate_path: os_cert_store_ca_certificate_path.to_path_buf(),
             checksum_carl_ca_certificate_file: checksum_carl_ca_certificate_file.to_path_buf(),
             checksum_os_cert_store_ca_certificate_file: checksum_os_cert_store_ca_certificate_file.to_path_buf(),
-            command_runner: CommandRunner::Noop,
         };
 
         assert_eq!(task.check_present().await?, TaskStateFulfilled::No);
@@ -260,7 +233,6 @@ mod tests {
             os_cert_store_ca_certificate_path: os_cert_store_ca_certificate_path.to_path_buf(),
             checksum_carl_ca_certificate_file: checksum_carl_ca_certificate_file.to_path_buf(),
             checksum_os_cert_store_ca_certificate_file: checksum_os_cert_store_ca_certificate_file.to_path_buf(),
-            command_runner: CommandRunner::Noop,
         };
 
 
@@ -290,7 +262,6 @@ mod tests {
             os_cert_store_ca_certificate_path: os_cert_store_ca_certificate_path.to_path_buf(),
             checksum_carl_ca_certificate_file: checksum_carl_ca_certificate_file.to_path_buf(),
             checksum_os_cert_store_ca_certificate_file: checksum_os_cert_store_ca_certificate_file.to_path_buf(),
-            command_runner: CommandRunner::Noop,
         };
 
         assert_eq!(task.check_present().await?, TaskStateFulfilled::Yes);


### PR DESCRIPTION
This PR fixes #249 by removing EDGAR setup’s dependency on the distro-specific update-ca-certificates command.

Changes:

EDGAR setup no longer runs or checks for update-ca-certificates; it still writes the CA files (including /usr/local/share/ca-certificates/opendut-ca.crt).
NetBird now gets the CA via a systemd drop-in: /etc/systemd/system/netbird.service.d/opendut.conf with Environment="SSL_CERT_FILE=/usr/local/share/ca-certificates/opendut-ca.crt".
netbird up is additionally executed with SSL_CERT_FILE set.