### PR TITLE
Feat/deploy toggle cluster 445 clean

### DIFF
--- a/opendut-lea/src/clusters/components/deploy_toggle.rs
+++ b/opendut-lea/src/clusters/components/deploy_toggle.rs
@@ -1,0 +1,122 @@
+use std::sync::Arc;
+
+use leptos::prelude::*;
+use tracing::{debug, error};
+use opendut_carl_api::carl::ClientError;
+use opendut_carl_api::carl::cluster::StoreClusterDeploymentError;
+use opendut_lea_components::tooltip::Tooltip;
+use opendut_lea_components::Toggle;
+use opendut_model::cluster::{ClusterDeployment, ClusterId};
+
+use crate::app::use_app_globals;
+use crate::clusters::IsDeployed;
+use crate::components::{Toast, use_toaster};
+
+#[component]
+pub fn DeployToggle<OnDeploymentChanged>(
+    #[prop(into)] cluster_id: Signal<ClusterId>,
+    #[prop(into)] is_deployed: Signal<IsDeployed>,
+    on_deployment_changed: OnDeploymentChanged,
+) -> impl IntoView
+where
+    OnDeploymentChanged: Fn() + Clone + Send + 'static,
+{
+    let globals = use_app_globals();
+    let toaster = use_toaster();
+
+    let on_deploy = {
+        let carl = globals.client.clone();
+        let toaster = Arc::clone(&toaster);
+        let on_deployment_changed = on_deployment_changed.clone();
+
+        move || {
+            let mut carl = carl.clone();
+            let toaster = Arc::clone(&toaster);
+            let cluster_id = cluster_id.get_untracked();
+            let on_deployment_changed = on_deployment_changed.clone();
+
+            leptos::task::spawn_local(async move {
+                match carl.cluster.store_cluster_deployment(ClusterDeployment { id: cluster_id }).await {
+                    Ok(cluster_id) => {
+                        debug!("Successfully stored cluster deployment: {}", cluster_id);
+                        toaster.toast(
+                            Toast::builder()
+                                .simple("Successfully stored cluster deployment!")
+                                .success()
+                        );
+                    }
+                    Err(cause) => {
+                        error!("Failed to store cluster deployment <{}>, due to error: {:?}", cluster_id, cause);
+                        match cause {
+                            ClientError::UsageError(StoreClusterDeploymentError::IllegalPeerState { invalid_peers, .. }) => {
+                                toaster.toast(
+                                    Toast::builder()
+                                        .simple(format!("Failed to store cluster deployment! Peers already in use: {}", invalid_peers.iter().map(|peer| peer.to_string()).collect::<Vec<_>>().join(", ")))
+                                        .error()
+                                );
+                            }
+                            _ => {
+                                toaster.toast(
+                                    Toast::builder()
+                                        .simple("Failed to store cluster deployment!")
+                                        .error()
+                                );
+                            }
+                        };
+                    }
+                }
+                on_deployment_changed();
+            })
+        }
+    };
+
+    let on_undeploy = {
+        let carl = globals.client.clone();
+        let toaster = Arc::clone(&toaster);
+        let on_deployment_changed = on_deployment_changed.clone();
+
+        move || {
+            let mut carl = carl.clone();
+            let toaster = Arc::clone(&toaster);
+            let cluster_id = cluster_id.get_untracked();
+            let on_deployment_changed = on_deployment_changed.clone();
+
+            leptos::task::spawn_local(async move {
+                match carl.cluster.delete_cluster_deployment(cluster_id).await {
+                    Ok(_) => {
+                        toaster.toast(Toast::builder()
+                            .simple("Successfully deleted cluster deployment!")
+                            .success()
+                        );
+                    }
+                    Err(_) => {
+                        toaster.toast(Toast::builder()
+                            .simple("Failed to delete cluster deployment!")
+                            .error()
+                        );
+                    }
+                }
+                on_deployment_changed();
+            })
+        }
+    };
+
+    let tooltip_text = Signal::derive(move || {
+        if is_deployed.get().0 {
+            "Deployment requested".to_string()
+        } else {
+            "Undeployed".to_string()
+        }
+    });
+
+    view! {
+        <Tooltip text=tooltip_text>
+            <Toggle
+                is_active=Signal::derive(move || is_deployed.get().0)
+                on_action=move || {
+                    if is_deployed.get().0 { on_undeploy() } else { on_deploy() }
+                }
+            />
+        </Tooltip>
+    }
+}

--- a/opendut-lea/src/clusters/components/mod.rs
+++ b/opendut-lea/src/clusters/components/mod.rs
@@ -1,7 +1,9 @@
 pub use create_cluster_button::CreateClusterButton;
 pub use delete_cluster_button::DeleteClusterButton;
 pub use cluster_health::ClusterHealth;
+pub use deploy_toggle::DeployToggle;
 
 mod cluster_health;
 mod create_cluster_button;
 mod delete_cluster_button;
+mod deploy_toggle;

--- a/opendut-lea/src/clusters/configurator/components/controls.rs
+++ b/opendut-lea/src/clusters/configurator/components/controls.rs
@@ -8,19 +8,22 @@ use opendut_model::cluster::ClusterDescriptor;
 use opendut_model::cluster::state::ClusterState;
 
 use crate::app::use_app_globals;
-use crate::clusters::components::DeleteClusterButton;
+use crate::clusters::components::{ClusterHealth, DeleteClusterButton, DeployToggle};
 use crate::clusters::configurator::types::UserClusterDescriptor;
 use crate::clusters::IsDeployed;
 use crate::components::{ButtonColor, ButtonSize, ButtonState, FontAwesomeIcon, IconButton, Toast, use_toaster};
 use crate::routing::{navigate_to, WellKnownRoutes};
-use crate::clusters::components::ClusterHealth;
 
 #[component]
-pub fn Controls(
+pub fn Controls<OnDeploymentChanged>(
     cluster_descriptor: ReadSignal<UserClusterDescriptor>,
     deployed_signal: Signal<IsDeployed>,
     cluster_state: Signal<ClusterState>,
-) -> impl IntoView {
+    on_deployment_changed: OnDeploymentChanged,
+) -> impl IntoView
+where
+    OnDeploymentChanged: Fn() + Clone + Send + 'static,
+{
 
     let cluster_id = Signal::derive(move || {
         cluster_descriptor.get().id
@@ -34,6 +37,12 @@ pub fn Controls(
 
     view! {
         <div class="is-flex is-align-items-center">
+            <DeployToggle
+                cluster_id
+                is_deployed=deployed_signal
+                on_deployment_changed
+            />
+            <div class="px-2" />
             <ClusterHealth state=cluster_state />
             <div class="px-2" />
             <SaveClusterButton

--- a/opendut-lea/src/clusters/configurator/components/controls.rs
+++ b/opendut-lea/src/clusters/configurator/components/controls.rs
@@ -16,7 +16,7 @@ use crate::routing::{navigate_to, WellKnownRoutes};
 
 #[component]
 pub fn Controls<OnDeploymentChanged>(
-    cluster_descriptor: ReadSignal<UserClusterDescriptor>,
+    cluster_descriptor: RwSignal<UserClusterDescriptor>,
     deployed_signal: Signal<IsDeployed>,
     cluster_state: Signal<ClusterState>,
     on_deployment_changed: OnDeploymentChanged,
@@ -28,6 +28,9 @@ where
     let cluster_id = Signal::derive(move || {
         cluster_descriptor.get().id
     });
+    let is_new_cluster = Signal::derive(move || {
+        cluster_descriptor.get().is_new
+    });
 
     let use_navigate = use_navigate();
     let on_delete = { move || {
@@ -37,12 +40,16 @@ where
 
     view! {
         <div class="is-flex is-align-items-center">
-            <DeployToggle
-                cluster_id
-                is_deployed=deployed_signal
-                on_deployment_changed
-            />
-            <div class="px-2" />
+            <div class=("is-hidden", move || is_new_cluster.get())>
+                <DeployToggle
+                    cluster_id
+                    is_deployed=deployed_signal
+                    on_deployment_changed
+                />
+            </div>
+            <div class=("is-hidden", move || is_new_cluster.get())>
+                <div class="px-2" />
+            </div>
             <ClusterHealth state=cluster_state />
             <div class="px-2" />
             <SaveClusterButton
@@ -62,12 +69,19 @@ where
 
 #[component]
 fn SaveClusterButton(
-    cluster_descriptor: ReadSignal<UserClusterDescriptor>,
+    cluster_descriptor: RwSignal<UserClusterDescriptor>,
     deployed_signal: Signal<IsDeployed>
 ) -> impl IntoView {
 
     let globals = use_app_globals();
     let toaster = use_toaster();
+
+    let set_is_new = create_write_slice(
+        cluster_descriptor,
+        |config, is_new| {
+            config.is_new = is_new;
+        },
+    );
 
     let pending = RwSignal::new(false);
 
@@ -107,6 +121,7 @@ fn SaveClusterButton(
                                 .simple("Successfully stored cluster descriptor.")
                                 .success()
                             );
+                            set_is_new.set(false);
                         }
                         Err(cause) => {
                             error!("Failed to store cluster <{}>, due to error: {:?}", "id", cause);

--- a/opendut-lea/src/clusters/configurator/mod.rs
+++ b/opendut-lea/src/clusters/configurator/mod.rs
@@ -97,9 +97,12 @@ fn LoadedClusterConfigurator(
         ]
     });
 
+    let refetch_cluster_deployments = RwSignal::new(());
+
     let cluster_deployments = {
         let carl = globals.client.clone();
         LocalResource::new(move || {
+            refetch_cluster_deployments.track();
             let mut carl = carl.clone();
             async move {
                 carl.cluster.list_cluster_deployments().await
@@ -161,6 +164,7 @@ fn LoadedClusterConfigurator(
                         cluster_descriptor=cluster_descriptor.read_only()
                         deployed_signal
                         cluster_state=cluster_state.into()
+                        on_deployment_changed=move || refetch_cluster_deployments.notify()
                     />
                 }
             }

--- a/opendut-lea/src/clusters/configurator/mod.rs
+++ b/opendut-lea/src/clusters/configurator/mod.rs
@@ -34,6 +34,7 @@ pub fn ClusterConfigurator() -> impl IntoView {
             name: UserInputValue::Left(String::from("Enter a valid cluster name.")),
             devices: DeviceSelection::Left(String::from("Select at least two devices.")),
             leader: LeaderSelection::Left(String::from("Select a leader.")),
+            is_new: true,
         }
     );
 
@@ -52,6 +53,7 @@ pub fn ClusterConfigurator() -> impl IntoView {
                             name: UserInputValue::Right(configuration.name.value().to_owned()),
                             devices: DeviceSelection::Right(configuration.devices),
                             leader: LeaderSelection::Right(configuration.leader),
+                            is_new: false,
                         }
                     )
                 } else {
@@ -161,7 +163,7 @@ fn LoadedClusterConfigurator(
             controls=move || {
                 view! {
                     <Controls
-                        cluster_descriptor=cluster_descriptor.read_only()
+                        cluster_descriptor
                         deployed_signal
                         cluster_state=cluster_state.into()
                         on_deployment_changed=move || refetch_cluster_deployments.notify()

--- a/opendut-lea/src/clusters/configurator/types/mod.rs
+++ b/opendut-lea/src/clusters/configurator/types/mod.rs
@@ -24,6 +24,7 @@ pub struct UserClusterDescriptor {
     pub name: UserInputValue,
     pub devices: DeviceSelection,
     pub leader: LeaderSelection,
+    pub is_new: bool,
 }
 
 impl TryFrom<UserClusterDescriptor> for ClusterDescriptor {

--- a/opendut-lea/src/clusters/overview/mod.rs
+++ b/opendut-lea/src/clusters/overview/mod.rs
@@ -1,17 +1,14 @@
 mod row;
 
 use leptos::prelude::*;
-use tracing::{debug, error};
-use opendut_carl_api::carl::ClientError;
-use opendut_carl_api::carl::cluster::StoreClusterDeploymentError;
 use opendut_lea_components::{ButtonColor, ButtonSize, ButtonState, FontAwesomeIcon, IconButton, OverviewTable, TableHeading};
-use opendut_model::cluster::{ClusterDeployment, ClusterDescriptor, ClusterId};
+use opendut_model::cluster::ClusterDescriptor;
 
 use crate::app::use_app_globals;
 use crate::clusters::components::CreateClusterButton;
 use crate::clusters::IsDeployed;
 use crate::clusters::overview::row::Row;
-use crate::components::{use_toaster, BasePageContainer, Breadcrumb, Toast};
+use crate::components::{BasePageContainer, Breadcrumb};
 
 #[component]
 pub fn ClustersOverview() -> impl IntoView {
@@ -54,87 +51,6 @@ pub fn ClustersOverview() -> impl IntoView {
         })
     };
 
-    let on_deploy = {
-        let carl = carl.clone();
-        let toaster = use_toaster();
-
-        move |cluster_id: ClusterId| {
-            let carl = carl.clone();
-            let toaster = toaster.clone();
-
-            move || {
-                let mut carl = carl.clone();
-                let toaster = toaster.clone();
-
-                leptos::task::spawn_local(async move {
-                    match carl.cluster.store_cluster_deployment(ClusterDeployment { id: cluster_id }).await {
-                        Ok(cluster_id) => {
-                            debug!("Successfully stored cluster deployment: {}", cluster_id);
-                            toaster.toast(
-                                Toast::builder()
-                                    .simple("Successfully stored cluster deployment!")
-                                    .success()
-                            );
-                        }
-                        Err(cause) => {
-                            error!("Failed to store cluster deployment <{}>, due to error: {:?}", cluster_id, cause);
-                            match cause {
-                                ClientError::UsageError(StoreClusterDeploymentError::IllegalPeerState { invalid_peers, .. }) => {
-                                    toaster.toast(
-                                        Toast::builder()
-                                            .simple(format!("Failed to store cluster deployment! Peers already in use: {}", invalid_peers.iter().map(|peer| peer.to_string()).collect::<Vec<_>>().join(", ")))
-                                            .error()
-                                    );
-                                }
-                                _ => {
-                                    toaster.toast(
-                                        Toast::builder()
-                                            .simple("Failed to store cluster deployment!")
-                                            .error()
-                                    );
-                                }
-                            };
-                        }
-                    }
-                    refetch_cluster_deployments.notify();
-                })
-            }
-        }
-    };
-
-    let on_undeploy = {
-        let carl = carl.clone();
-        let toaster = use_toaster();
-
-        move |id: ClusterId| {
-            let carl = carl.clone();
-            let toaster = toaster.clone();
-
-            move || {
-                let mut carl = carl.clone();
-                let toaster = toaster.clone();
-
-                leptos::task::spawn_local(async move {
-                    match carl.cluster.delete_cluster_deployment(id).await {
-                        Ok(_) => {
-                            toaster.toast(Toast::builder()
-                                .simple("Successfully deleted cluster deployment!")
-                                .success()
-                            );
-                        }
-                        Err(_) => {
-                            toaster.toast(Toast::builder()
-                                .simple("Failed to delete cluster deployment!")
-                                .error()
-                            );
-                        }
-                    }
-                    refetch_cluster_deployments.notify();
-                })
-            }
-        }
-    };
-
     let on_delete = move || {
         refetch_cluster_descriptors.notify();
     };
@@ -173,9 +89,6 @@ pub fn ClustersOverview() -> impl IntoView {
         >
             <OverviewTable headings=table_headings>
                 { move || {
-                        let on_deploy = on_deploy.clone();
-                        let on_undeploy = on_undeploy.clone();
-
                         Suspend::new(async move {
                             let clusters = clusters.await;
                             let deployed_clusters = cluster_deployments.await
@@ -192,9 +105,8 @@ pub fn ClustersOverview() -> impl IntoView {
                                         view! {
                                             <Row
                                                 cluster_descriptor=RwSignal::new(cluster_descriptor)
-                                                on_deploy=on_deploy(cluster_id)
-                                                on_undeploy=on_undeploy(cluster_id)
                                                 is_deployed = RwSignal::new(IsDeployed(deployed_clusters.contains(&cluster_id)))
+                                                on_deployment_changed=move || refetch_cluster_deployments.notify()
                                                 on_delete
                                             />
                                         }

--- a/opendut-lea/src/clusters/overview/row.rs
+++ b/opendut-lea/src/clusters/overview/row.rs
@@ -1,24 +1,20 @@
 use crate::clusters::IsDeployed;
-use crate::clusters::components::DeleteClusterButton;
+use crate::clusters::components::{ClusterHealth, DeleteClusterButton, DeployToggle};
 use leptos::prelude::*;
-use opendut_lea_components::tooltip::Tooltip;
-use opendut_lea_components::{ButtonColor, OverviewTableCell, Toggle};
+use opendut_lea_components::{ButtonColor, OverviewTableCell};
 use opendut_model::cluster::ClusterDescriptor;
-use crate::clusters::components::ClusterHealth;
 use opendut_model::cluster::state::ClusterState;
 use crate::components::ClickableOverviewTableRow;
 
 #[component]
-pub fn Row<OnDeployFn, OnUndeployFn, OnDeleteFn>(
+pub fn Row<OnDeploymentChanged, OnDeleteFn>(
     cluster_descriptor: RwSignal<ClusterDescriptor>,
-    on_deploy: OnDeployFn,
-    on_undeploy: OnUndeployFn,
     is_deployed: RwSignal<IsDeployed>,
+    on_deployment_changed: OnDeploymentChanged,
     on_delete: OnDeleteFn,
 ) -> impl IntoView
 where
-    OnDeployFn: Fn() + Send + 'static,
-    OnUndeployFn: Fn() + Send + 'static,
+    OnDeploymentChanged: Fn() + Clone + Send + 'static,
     OnDeleteFn: Fn() + Copy + Send + 'static,
 {
     let cluster_id = create_read_slice(cluster_descriptor, |cluster_descriptor| {
@@ -31,33 +27,18 @@ where
 
     let configurator_href = Signal::derive(move || format!("/clusters/{}/configure/general", cluster_id.get()));
 
-    let tooltip_text = Signal::derive(move || {
-        if is_deployed.get().0 {
-            "Deployment requested".to_string()
-        } else {
-            "Undeployed".to_string()
-        }
-    });
-
     let cluster_state = RwSignal::new(ClusterState::default());
 
     view! {
         <ClickableOverviewTableRow configurator_href>
             <OverviewTableCell>
-                <Tooltip
-                    text=tooltip_text
-                >
-                    <div>
-                        <Toggle
-                            is_active = Signal::derive(move || {
-                                is_deployed.get().0
-                            })
-                            on_action = move || {
-                                if is_deployed.get().0 { on_undeploy() } else { on_deploy() }
-                            }
-                        />
-                    </div>
-                </Tooltip>
+                <div on:click=|event| event.stop_propagation()>
+                    <DeployToggle
+                        cluster_id
+                        is_deployed
+                        on_deployment_changed
+                    />
+                </div>
             </OverviewTableCell>
 
             <OverviewTableCell>


### PR DESCRIPTION
fixes https://github.com/eclipse-opendut/opendut/issues/445

Summary

- Adds a deploy/undeploy toggle to the ClusterConfigurator controls bar
- Placed to the left of the health traffic light, matching the ClusterOverview layout
- Reuses the existing Toggle component and follows the same deploy/undeploy pattern
- UI change


<img width="1421" height="424" alt="image" src="https://github.com/user-attachments/assets/04bdf200-446d-4c03-bf2a-48290ae8e9ef" />
