### PR TITLE
issue 431 fix

### DIFF
--- a/opendut-lea/src/peers/configurator/tabs/setup/mod.rs
+++ b/opendut-lea/src/peers/configurator/tabs/setup/mod.rs
@@ -1,3 +1,4 @@
+use leptos::either::Either;
 use leptos::prelude::*;
 
 use crate::components::WarningMessage;
@@ -7,14 +8,27 @@ use crate::peers::configurator::types::UserPeerConfiguration;
 #[component]
 pub fn SetupTab(peer_configuration: ReadSignal<UserPeerConfiguration>) -> impl IntoView {
 
+    let is_new = Signal::derive(move || peer_configuration.get().is_new);
     let kind = Signal::derive(move || GenerateSetupStringKind::Edgar(peer_configuration.get().id));
 
     view! {
         <div class="field">
-            <GenerateSetupStringForm kind />
-            <WarningMessage>
-                Setup-Strings may only be used to set up one host. For setting up multiple hosts, you should create a peer for each host.
-            </WarningMessage>
+            {move || {
+                if is_new.get() {
+                    Either::Left(view! {
+                        <WarningMessage>
+                            "The peer configuration must be saved before a Setup-String can be generated. Please complete the configuration and save the peer first."
+                        </WarningMessage>
+                    })
+                } else {
+                    Either::Right(view! {
+                        <GenerateSetupStringForm kind />
+                        <WarningMessage>
+                            "Setup-Strings may only be used to set up one host. For setting up multiple hosts, you should create a peer for each host."
+                        </WarningMessage>
+                    })
+                }
+            }}
         </div>
     }
 }


### PR DESCRIPTION
## Problem

When creating a new Peer in LEA, the Setup tab is hidden until the configuration is saved. However, users can access it by manually changing the URL to end with `/setup`. Clicking the "Generate" button in this state crashes the web UI because the peer doesn't exist on the server yet.

## implementation

Modified `opendut-lea/src/peers/configurator/tabs/setup/mod.rs` to check the `is_new` signal (the same signal that controls Setup tab visibility in the tab bar). When `is_new` is `true`, the Setup tab now renders a warning message, "The peer configuration must be saved before a Setup-String can be generated. Please complete the configuration and save the peer first."

Once the peer is saved and `is_new` becomes `false`, the normal Generate form is displayed as before.

## Testing

- Created a new peer without saving
- Manually navigated to the Setup tab via URL
- Confirmed the warning message is displayed instead of the Generate button
- Confirmed no crash occurs
- Confirmed that saved peers still show the Generate button and setup string generation works normally

