### PR TITLE
LEA: Extended the `Toggle` component

### DIFF
--- a/opendut-lea/assets/style/health-light.scss
+++ b/opendut-lea/assets/style/health-light.scss
@@ -4,7 +4,6 @@
 .health-light {
   width: 20px;
   height: 20px;
-  margin-right: 5px;
   background-color: #808080;
   box-shadow: inset #323232 0 -1px 9px;
   border-radius: 50%;

--- a/opendut-lea/assets/style/toggle.scss
+++ b/opendut-lea/assets/style/toggle.scss
@@ -9,21 +9,27 @@
   cursor: pointer;
 }
 
-.dut-toggle::before {
-  content: "";
+.dut-toggle .bubble {
   position: absolute;
-  width: 16px;
-  height: 16px;
-  background: white;
-  border-radius: 50%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
   top: 2px;
   left: 2px;
+  font-size: 16px;
+  color: white;
   transition: 0.3s;
 }
+
 .dut-toggle.active {
   background: $success;
 }
-.dut-toggle.active::before {
+
+.dut-toggle.active .bubble {
   left: 22px;
 }
 
+.dut-toggle.toggle-disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}

--- a/opendut-lea/opendut-lea-components/src/lib.rs
+++ b/opendut-lea/opendut-lea-components/src/lib.rs
@@ -32,7 +32,7 @@ pub use util::signal::{ButtonStateSignalProvider, ToggleSignal, Toggled};
 pub use util::table_row_selection::has_text_selection;
 pub use doorhanger::{Doorhanger, DoorhangerAlignment};
 pub use icon_text::IconText;
-pub use toggle::Toggle;
+pub use toggle::{Toggle, ToggleState};
 pub use tables::multiple_selection_table::{MultipleSelectionTable, MultipleSelectionTableRow, CollapsableInfo};
 pub use tables::selection_table::{SelectionTable, SelectionTableRow};
 pub use tables::overview_table::{TableHeading, OverviewTable, OverviewTableRow, OverviewTableCell};
@@ -64,8 +64,10 @@ pub enum FontAwesomeIcon {
     Check,
     ChevronDown,
     ChevronUp,
+    Circle,
     CircleExclamation,
     CircleNotch,
+    CircleFadeAnimation,
     Cluster,
     Code,
     Copy,
@@ -74,6 +76,7 @@ pub enum FontAwesomeIcon {
     EllipsisVertical,
     Email,
     Link,
+    Loading,
     OpenPage,
     Peers,
     Plus,
@@ -95,7 +98,9 @@ impl FontAwesomeIcon {
             FontAwesomeIcon::Check => "fa-solid fa-check",
             FontAwesomeIcon::ChevronDown => "fa-solid fa-chevron-down",
             FontAwesomeIcon::ChevronUp => "fa-solid fa-chevron-up",
+            FontAwesomeIcon::Circle => "fa-solid fa-circle",
             FontAwesomeIcon::CircleExclamation => "fa-solid fa-circle-exclamation",
+            FontAwesomeIcon::CircleFadeAnimation => "fa-solid fa-circle fa-fade",
             FontAwesomeIcon::CircleNotch => "fa-solid fa-circle-notch",
             FontAwesomeIcon::Cluster => "fa-solid fa-circle-nodes",
             FontAwesomeIcon::Code => "fa-solid fa-code",
@@ -105,6 +110,7 @@ impl FontAwesomeIcon {
             FontAwesomeIcon::EllipsisVertical => "fa-solid fa-ellipsis-vertical",
             FontAwesomeIcon::Email => "fa-regular fa-envelope",
             FontAwesomeIcon::Link => "fa-solid fa-link",
+            FontAwesomeIcon::Loading => "fa-solid fa-circle-notch fa-spin",
             FontAwesomeIcon::OpenPage => "fa-solid fa-arrow-up-right-from-square",
             FontAwesomeIcon::Peers => "fa-solid fa-microchip",
             FontAwesomeIcon::Plus => "fa-solid fa-plus",

--- a/opendut-lea/opendut-lea-components/src/toggle.rs
+++ b/opendut-lea/opendut-lea-components/src/toggle.rs
@@ -1,22 +1,55 @@
+use std::ops::Not;
 use leptos::prelude::*;
+use crate::FontAwesomeIcon;
+
+#[derive(Clone, Debug, Default)]
+pub enum ToggleState {
+    #[default] Enabled,
+    Disabled,
+    Loading,
+}
 
 #[component]
 pub fn Toggle<F>(
     #[prop(optional, into)] text: Option<Signal<String>>,
+    #[prop(optional, into)] state: Signal<ToggleState>,
     is_active: Signal<bool>,
     on_action: F,
 ) -> impl IntoView
 where F: Fn() + 'static {
+
+    let is_disabled = Signal::derive(move || matches!(state.get(), ToggleState::Enabled).not());
+    let is_loading = move || matches!(state.get(), ToggleState::Loading);
 
     view! {
         <div
             class="is-flex is-align-items-center is-justify-content-center"
             on:click=move |event| event.stop_propagation()
         >
-            <label class="dut-toggle"
+            <label
+                class="dut-toggle"
                 class=("active", move || is_active.get())
-                on:click=move |_| on_action()
-            />
+                class=("toggle-disabled", is_disabled)
+                on:click=move |_| {
+                    if !is_disabled.get() {
+                        on_action()
+                    }
+                }
+            >
+                <span class="bubble">
+                    { move ||
+                        if is_loading() {
+                            view! {
+                                <i class=FontAwesomeIcon::CircleFadeAnimation.as_class() />
+                            }
+                        } else {
+                            view! {
+                                <i class=FontAwesomeIcon::Circle.as_class() />
+                            }
+                        }
+                    }
+                </span>
+            </label>
             {
                 text.map(|text| {
                     view! {

--- a/opendut-lea/src/clusters/components/deploy_toggle.rs
+++ b/opendut-lea/src/clusters/components/deploy_toggle.rs
@@ -5,7 +5,7 @@ use tracing::{debug, error};
 use opendut_carl_api::carl::ClientError;
 use opendut_carl_api::carl::cluster::StoreClusterDeploymentError;
 use opendut_lea_components::tooltip::Tooltip;
-use opendut_lea_components::Toggle;
+use opendut_lea_components::{Toggle, ToggleState};
 use opendut_model::cluster::{ClusterDeployment, ClusterId};
 
 use crate::app::use_app_globals;
@@ -113,6 +113,7 @@ where
         <Tooltip text=tooltip_text>
             <Toggle
                 is_active=Signal::derive(move || is_deployed.get().0)
+                state=ToggleState::Enabled
                 on_action=move || {
                     if is_deployed.get().0 { on_undeploy() } else { on_deploy() }
                 }


### PR DESCRIPTION
## Changes
Extended the `Toggle` component by a `ToggleState` which includes following states:
  - enabled (default)  <img width="53" height="42" alt="image" src="https://github.com/user-attachments/assets/b964d9c5-fce8-46d5-bf9b-0ecce11e2558" /> 

  - disabled  <img width="53" height="41" alt="image" src="https://github.com/user-attachments/assets/912b0839-b0a0-463d-a1e7-66fb1eb5e296" /> 

  - loading
[Screencast from 05-04-2026 05:24:23 PM.webm](https://github.com/user-attachments/assets/a4caebce-3efe-46f5-9866-0d90dae59b60)

This extension is necessary for upcoming issues. 