### PR TITLE
Fix 477: Reduce LEA WASM binary size and enable HTTP compression

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -255,6 +255,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-compression"
+version = "0.4.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0f9ee0f6e02ffd7ad5816e9464499fba7b3effd01123b515c41d1697c43dad1"
+dependencies = [
+ "compression-codecs",
+ "compression-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "async-lock"
 version = "3.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1108,6 +1120,26 @@ dependencies = [
  "bytes",
  "memchr",
 ]
+
+[[package]]
+name = "compression-codecs"
+version = "0.4.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb7b51a7d9c967fc26773061ba86150f19c50c0d65c887cb1fbe295fd16619b7"
+dependencies = [
+ "brotli",
+ "compression-core",
+ "flate2",
+ "memchr",
+ "zstd",
+ "zstd-safe",
+]
+
+[[package]]
+name = "compression-core"
+version = "0.4.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75984efb6ed102a0d42db99afb6c1948f0380d1d91808d5529916e6c08b49d8d"
 
 [[package]]
 name = "concurrent-queue"
@@ -2027,7 +2059,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5737,7 +5769,7 @@ dependencies = [
  "once_cell",
  "socket2 0.6.3",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6363,7 +6395,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6441,7 +6473,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7631,7 +7663,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8185,6 +8217,7 @@ version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
+ "async-compression",
  "bitflags",
  "bytes",
  "futures-core",
@@ -9364,7 +9397,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -173,7 +173,7 @@ tonic-web = "0.14"
 tonic-web-wasm-client = "0.9"
 tonic-async-interceptor = "0.14"
 tower = "0.5"
-tower-http = { version = "0.6", features = ["cors", "fs"] }
+tower-http = { version = "0.6", features = ["cors", "fs", "compression-full"] }
 tracing = "0.1"
 tracing-opentelemetry = "0.32.0"
 tracing-subscriber = { version = "0.3", default-features = false }
@@ -220,3 +220,9 @@ trunk = "0.21.14"
 
 [workspace.lints.clippy]
 unnecessary_lazy_evaluations = "allow"
+
+[profile.wasm-release]
+inherits = "release"
+opt-level = "z"
+lto = true
+codegen-units = 1

--- a/opendut-carl/src/startup/http.rs
+++ b/opendut-carl/src/startup/http.rs
@@ -2,6 +2,7 @@ use std::path::PathBuf;
 use anyhow::Context;
 use axum::routing::get;
 use config::Config;
+use tower_http::compression::CompressionLayer;
 use tower_http::services::{ServeDir, ServeFile};
 use tracing::info;
 use opendut_auth::registration::resources::ResourceHomeUrl;
@@ -50,7 +51,8 @@ pub fn create_http_service(settings: &Config) -> anyhow::Result<axum::Router<Htt
         .fallback_service(
             ServeDir::new(&lea_dir)
                 .fallback(ServeFile::new(lea_index_html))
-        );
+        )
+        .layer(CompressionLayer::new());
 
     Ok(router)
 }

--- a/opendut-lea/Trunk.toml
+++ b/opendut-lea/Trunk.toml
@@ -1,5 +1,6 @@
 [build]
 target = "index.html"
+cargo_profile = "wasm-release"
 
 [watch]
 watch = [


### PR DESCRIPTION
Reduce LEA WASM binary size and enable HTTP compression

- Add [profile.wasm-release] with opt-level z, LTO, codegen-units 1
- Configure Trunk to use wasm-release profile
- Add CompressionLayer to CARL HTTP server (tower-http compression-full)

WASM binary: 37MB -> 6.1MB (83% reduction)
Transfer size: 37MB -> 1.7MB (95% reduction)

Resolves: #477