### PR TITLE
Fix: #360 UI to configure Git Source

### DIFF
--- a/opendut-carl/src/manager/mod.rs
+++ b/opendut-carl/src/manager/mod.rs
@@ -143,7 +143,7 @@ pub(crate) mod testing {
                     id: source_id,
                     name: ViperSourceName::try_from(format!("ViperSource-{source_id}"))?,
                     url: Url::parse("http://localhost")?,
-                    kind: ViperSourceKind::default(),
+                    kind: ViperSourceKind::Http,
                 };
 
                 resource_manager.insert(source_id, source_descriptor.clone()).await?;

--- a/opendut-carl/src/manager/mod.rs
+++ b/opendut-carl/src/manager/mod.rs
@@ -128,7 +128,7 @@ pub(crate) mod testing {
     #[cfg(feature = "viper")]
     mod viper {
         use super::*;
-        use opendut_model::viper::{ViperRunDeployment, ViperRunId, ViperSourceDescriptor, ViperSourceId, ViperSourceName, ViperTestRunDescriptor, ViperTestId, ViperTestName, ViperParameterName, ViperBindingValue};
+        use opendut_model::viper::{ViperRunDeployment, ViperRunId, ViperSourceDescriptor, ViperSourceId, ViperSourceKind, ViperSourceName, ViperTestRunDescriptor, ViperTestId, ViperTestName, ViperParameterName, ViperBindingValue};
         use url::Url;
         use std::collections::HashMap;
 
@@ -143,6 +143,7 @@ pub(crate) mod testing {
                     id: source_id,
                     name: ViperSourceName::try_from(format!("ViperSource-{source_id}"))?,
                     url: Url::parse("http://localhost")?,
+                    kind: ViperSourceKind::default(),
                 };
 
                 resource_manager.insert(source_id, source_descriptor.clone()).await?;

--- a/opendut-carl/src/manager/test_manager/get_viper_test_suite_parameters.rs
+++ b/opendut-carl/src/manager/test_manager/get_viper_test_suite_parameters.rs
@@ -36,10 +36,8 @@ async fn discover_suite(source: ViperSourceDescriptor) -> Result<Option<ViperTes
 
     let handle = tokio::task::spawn_blocking(move || {
         tokio::runtime::Handle::current().block_on(async move {
-            #[allow(clippy::needless_update)]
             let viper_runtime = ViperRuntime::new(ViperOptions {
                 source_loaders: vec![Box::new(HttpSourceLoader)],
-                ..Default::default()
             }).map_err(|_| GetViperTestSuiteParametersError::ViperRuntime { source_id, source_name: source_name.clone() })?;
 
             let compilation = viper_runtime.compile(&source, &mut emitter::drain(), &IdentifierFilter::default()).await

--- a/opendut-carl/src/manager/test_manager/get_viper_test_suite_parameters.rs
+++ b/opendut-carl/src/manager/test_manager/get_viper_test_suite_parameters.rs
@@ -25,7 +25,7 @@ impl Resources<'_> {
 
 
 async fn discover_suite(source: ViperSourceDescriptor) -> Result<Option<ViperTestSuiteParameters>, GetViperTestSuiteParametersError>  {
-    let ViperSourceDescriptor { id: source_id, name: source_name, url } = source;
+    let ViperSourceDescriptor { id: source_id, name: source_name, url, .. } = source;
 
     let test_suite_identifier = TestSuiteIdentifier::try_from(source_name.value())
         .expect("Conversion of source name to TestSuiteIdentifier failed."); //FIXME ViperSourceDescriptor should use TestSuiteIdentifier directly, making this conversion obsolete

--- a/opendut-carl/src/manager/test_manager/get_viper_test_suite_parameters.rs
+++ b/opendut-carl/src/manager/test_manager/get_viper_test_suite_parameters.rs
@@ -36,8 +36,11 @@ async fn discover_suite(source: ViperSourceDescriptor) -> Result<Option<ViperTes
 
     let handle = tokio::task::spawn_blocking(move || {
         tokio::runtime::Handle::current().block_on(async move {
+            // The ..Default::default() is needed here because ViperOptions has additional fields (e.g. container_runtime) under other feature flags. Removing it breaks the --all-features build.
+            #[allow(clippy::needless_update)]
             let viper_runtime = ViperRuntime::new(ViperOptions {
                 source_loaders: vec![Box::new(HttpSourceLoader)],
+                ..Default::default()
             }).map_err(|_| GetViperTestSuiteParametersError::ViperRuntime { source_id, source_name: source_name.clone() })?;
 
             let compilation = viper_runtime.compile(&source, &mut emitter::drain(), &IdentifierFilter::default()).await

--- a/opendut-carl/src/manager/test_manager/get_viper_test_suite_parameters.rs
+++ b/opendut-carl/src/manager/test_manager/get_viper_test_suite_parameters.rs
@@ -36,6 +36,7 @@ async fn discover_suite(source: ViperSourceDescriptor) -> Result<Option<ViperTes
 
     let handle = tokio::task::spawn_blocking(move || {
         tokio::runtime::Handle::current().block_on(async move {
+            #[allow(clippy::needless_update)]
             let viper_runtime = ViperRuntime::new(ViperOptions {
                 source_loaders: vec![Box::new(HttpSourceLoader)],
                 ..Default::default()

--- a/opendut-lea/src/viper_sources/configurator/components/mod.rs
+++ b/opendut-lea/src/viper_sources/configurator/components/mod.rs
@@ -1,3 +1,5 @@
+mod viper_source_kind_select;
 mod controls;
 
+pub use viper_source_kind_select::ViperSourceKindSelect;
 pub use controls::Controls;

--- a/opendut-lea/src/viper_sources/configurator/components/viper_source_kind_select.rs
+++ b/opendut-lea/src/viper_sources/configurator/components/viper_source_kind_select.rs
@@ -1,5 +1,5 @@
 use leptos::prelude::*;
-use opendut_lea_components::{SelectionOption, UserInputValue, UserSelect};
+use opendut_lea_components::{SelectionOption, UserSelect};
 use crate::viper_sources::configurator::types::UserViperSourceConfiguration;
 
 #[component]
@@ -27,7 +27,7 @@ pub fn ViperSourceKindSelect(viper_source_configuration: RwSignal<UserViperSourc
         <UserSelect
             options
             initial_option
-            getter=getter.into()
+            getter=getter
             setter=setter
             label="Source Kind"
         />

--- a/opendut-lea/src/viper_sources/configurator/components/viper_source_kind_select.rs
+++ b/opendut-lea/src/viper_sources/configurator/components/viper_source_kind_select.rs
@@ -1,0 +1,51 @@
+use leptos::prelude::*;
+use opendut_model::viper::ViperSourceKind;
+use crate::viper_sources::configurator::types::UserViperSourceConfiguration;
+
+#[component]
+pub fn ViperSourceKindSelect(viper_source_configuration: RwSignal<UserViperSourceConfiguration>) -> impl IntoView {
+
+    let (getter, setter) = create_slice(viper_source_configuration,
+        |config| {
+            config.kind.clone()
+        },
+        |config, input| {
+            config.kind = input;
+        }
+    );
+
+    let selected_value = move || {
+        match getter.get() {
+            ViperSourceKind::Git => "git".to_string(),
+            ViperSourceKind::Http => "http".to_string(),
+        }
+    };
+
+    view! {
+        <div class="field">
+            <label class="label">"Source Kind"</label>
+            <div class="control">
+                <div class="select">
+                    <select
+                        aria-label="Source Kind"
+                        prop:value=selected_value
+                        on:change=move |ev| {
+                            let target_value = event_target_value(&ev);
+                            match target_value.as_str() {
+                                "git" => setter.set(ViperSourceKind::Git),
+                                _ => setter.set(ViperSourceKind::Http),
+                            }
+                        }
+                    >
+                        <option value="http" selected=move || matches!(getter.get(), ViperSourceKind::Http)>
+                            "HTTP"
+                        </option>
+                        <option value="git" selected=move || matches!(getter.get(), ViperSourceKind::Git)>
+                            "Git"
+                        </option>
+                    </select>
+                </div>
+            </div>
+        </div>
+    }
+}

--- a/opendut-lea/src/viper_sources/configurator/components/viper_source_kind_select.rs
+++ b/opendut-lea/src/viper_sources/configurator/components/viper_source_kind_select.rs
@@ -1,5 +1,5 @@
 use leptos::prelude::*;
-use opendut_model::viper::ViperSourceKind;
+use opendut_lea_components::{SelectionOption, UserInputValue, UserSelect};
 use crate::viper_sources::configurator::types::UserViperSourceConfiguration;
 
 #[component]
@@ -7,45 +7,29 @@ pub fn ViperSourceKindSelect(viper_source_configuration: RwSignal<UserViperSourc
 
     let (getter, setter) = create_slice(viper_source_configuration,
         |config| {
-            config.kind.clone()
+            Clone::clone(&config.kind)
         },
         |config, input| {
             config.kind = input;
         }
     );
 
-    let selected_value = move || {
-        match getter.get() {
-            ViperSourceKind::Git => "git".to_string(),
-            ViperSourceKind::Http => "http".to_string(),
-        }
-    };
+    let options = Signal::derive(move || {
+        vec![
+            SelectionOption { display_name: String::from("HTTP"), value: String::from("HTTP") },
+            SelectionOption { display_name: String::from("Git"), value: String::from("Git") },
+        ]
+    });
+
+    let initial_option = Signal::derive(|| String::from("Select source kind"));
 
     view! {
-        <div class="field">
-            <label class="label">"Source Kind"</label>
-            <div class="control">
-                <div class="select">
-                    <select
-                        aria-label="Source Kind"
-                        prop:value=selected_value
-                        on:change=move |ev| {
-                            let target_value = event_target_value(&ev);
-                            match target_value.as_str() {
-                                "git" => setter.set(ViperSourceKind::Git),
-                                _ => setter.set(ViperSourceKind::Http),
-                            }
-                        }
-                    >
-                        <option value="http" selected=move || matches!(getter.get(), ViperSourceKind::Http)>
-                            "HTTP"
-                        </option>
-                        <option value="git" selected=move || matches!(getter.get(), ViperSourceKind::Git)>
-                            "Git"
-                        </option>
-                    </select>
-                </div>
-            </div>
-        </div>
+        <UserSelect
+            options
+            initial_option
+            getter=getter.into()
+            setter=setter
+            label="Source Kind"
+        />
     }
 }

--- a/opendut-lea/src/viper_sources/configurator/mod.rs
+++ b/opendut-lea/src/viper_sources/configurator/mod.rs
@@ -6,7 +6,7 @@ use leptos::prelude::*;
 use leptos_router::hooks::{use_navigate, use_params_map};
 use opendut_lea_components::{BasePageContainer, Breadcrumb, LoadingSpinner, UserInputError, UserInputValue};
 use opendut_lea_components::tabs::{Tab, Tabs};
-use opendut_model::viper::ViperSourceId;
+use opendut_model::viper::{ViperSourceId, ViperSourceKind};
 use crate::app::use_app_globals;
 use crate::components::use_active_tab;
 use crate::routing::{navigate_to, WellKnownRoutes};
@@ -46,6 +46,7 @@ pub fn ViperSourceConfigurator() -> impl IntoView {
                 id: viper_source_id,
                 name: UserInputValue::Left(UserInputError::from("Enter a valid VIPER source name.")),
                 url: UserInputValue::Left(UserInputError::from("Enter a valid VIPER source url.")),
+                kind: ViperSourceKind::default(),
                 is_new: true,
             }
         );
@@ -57,6 +58,7 @@ pub fn ViperSourceConfigurator() -> impl IntoView {
                     viper_source_configuration.update(|user_configuration| {
                         user_configuration.name = UserInputValue::Right(configuration.name.value().to_owned());
                         user_configuration.url = UserInputValue::Right(configuration.url.to_string());
+                        user_configuration.kind = configuration.kind;
                     })
                 }
             }

--- a/opendut-lea/src/viper_sources/configurator/mod.rs
+++ b/opendut-lea/src/viper_sources/configurator/mod.rs
@@ -6,7 +6,7 @@ use leptos::prelude::*;
 use leptos_router::hooks::{use_navigate, use_params_map};
 use opendut_lea_components::{BasePageContainer, Breadcrumb, LoadingSpinner, UserInputError, UserInputValue};
 use opendut_lea_components::tabs::{Tab, Tabs};
-use opendut_model::viper::{ViperSourceId, ViperSourceKind};
+use opendut_model::viper::ViperSourceId;
 use crate::app::use_app_globals;
 use crate::components::use_active_tab;
 use crate::routing::{navigate_to, WellKnownRoutes};
@@ -46,7 +46,7 @@ pub fn ViperSourceConfigurator() -> impl IntoView {
                 id: viper_source_id,
                 name: UserInputValue::Left(UserInputError::from("Enter a valid VIPER source name.")),
                 url: UserInputValue::Left(UserInputError::from("Enter a valid VIPER source url.")),
-                kind: ViperSourceKind::default(),
+                kind: UserInputValue::Left(UserInputError::from("Select source kind")),
                 is_new: true,
             }
         );
@@ -58,7 +58,10 @@ pub fn ViperSourceConfigurator() -> impl IntoView {
                     viper_source_configuration.update(|user_configuration| {
                         user_configuration.name = UserInputValue::Right(configuration.name.value().to_owned());
                         user_configuration.url = UserInputValue::Right(configuration.url.to_string());
-                        user_configuration.kind = configuration.kind;
+                        user_configuration.kind = UserInputValue::Right(match configuration.kind {
+                            opendut_model::viper::ViperSourceKind::Git => String::from("Git"),
+                            opendut_model::viper::ViperSourceKind::Http => String::from("HTTP"),
+                        });
                     })
                 }
             }
@@ -68,6 +71,7 @@ pub fn ViperSourceConfigurator() -> impl IntoView {
             viper_source_configuration.with(|source_configuration| {
                 source_configuration.name.is_right()
                 && source_configuration.url.is_right()
+                && source_configuration.kind.is_right()
             })
         });
 

--- a/opendut-lea/src/viper_sources/configurator/tabs/general/mod.rs
+++ b/opendut-lea/src/viper_sources/configurator/tabs/general/mod.rs
@@ -1,5 +1,6 @@
 use leptos::prelude::*;
 use opendut_lea_components::ReadOnlyInput;
+use crate::viper_sources::configurator::components::ViperSourceKindSelect;
 use crate::viper_sources::configurator::tabs::general::name_input::ViperSourceNameInput;
 use crate::viper_sources::configurator::tabs::general::url_input::ViperSourceUrlInput;
 use crate::viper_sources::configurator::types::UserViperSourceConfiguration;
@@ -22,6 +23,9 @@ pub fn GeneralTab(viper_source_configuration: RwSignal<UserViperSourceConfigurat
                 viper_source_configuration
             />
             <ViperSourceUrlInput
+                viper_source_configuration
+            />
+            <ViperSourceKindSelect
                 viper_source_configuration
             />
         </div>

--- a/opendut-lea/src/viper_sources/configurator/types/mod.rs
+++ b/opendut-lea/src/viper_sources/configurator/types/mod.rs
@@ -11,6 +11,8 @@ pub enum ViperSourceMisconfigurationError {
     InvalidSourceName,
     #[error("Invalid viper source URL")]
     InvalidSourceUrl,
+    #[error("Invalid viper source kind")]
+    InvalidSourceKind,
 }
 
 #[derive(Clone, Debug)]
@@ -18,7 +20,7 @@ pub struct UserViperSourceConfiguration {
     pub id: ViperSourceId,
     pub name: UserInputValue,
     pub url: UserInputValue,
-    pub kind: ViperSourceKind,
+    pub kind: UserInputValue,
     pub is_new: bool,
 }
 
@@ -42,12 +44,23 @@ impl TryFrom<UserViperSourceConfiguration> for ViperSourceDescriptor {
                     .map_err(|_| ViperSourceMisconfigurationError::InvalidSourceUrl)
             })?;
 
+        let kind = configuration
+            .kind
+            .right_ok_or(ViperSourceMisconfigurationError::InvalidSourceKind)
+            .and_then(|value| {
+                match value.as_str() {
+                    "Git" => Ok(ViperSourceKind::Git),
+                    "HTTP" => Ok(ViperSourceKind::Http),
+                    _ => Err(ViperSourceMisconfigurationError::InvalidSourceKind),
+                }
+            })?;
+
         Ok(
             ViperSourceDescriptor {
                 id: configuration.id,
                 name,
                 url,
-                kind: configuration.kind,
+                kind,
             }
         )
     }

--- a/opendut-lea/src/viper_sources/configurator/types/mod.rs
+++ b/opendut-lea/src/viper_sources/configurator/types/mod.rs
@@ -2,7 +2,7 @@ pub mod validation;
 
 use url::Url;
 use opendut_lea_components::UserInputValue;
-use opendut_model::viper::{ViperSourceDescriptor, ViperSourceId, ViperSourceName};
+use opendut_model::viper::{ViperSourceDescriptor, ViperSourceId, ViperSourceKind, ViperSourceName};
 
 #[derive(thiserror::Error, Clone, Debug)]
 #[allow(clippy::enum_variant_names)]
@@ -18,6 +18,7 @@ pub struct UserViperSourceConfiguration {
     pub id: ViperSourceId,
     pub name: UserInputValue,
     pub url: UserInputValue,
+    pub kind: ViperSourceKind,
     pub is_new: bool,
 }
 
@@ -46,6 +47,7 @@ impl TryFrom<UserViperSourceConfiguration> for ViperSourceDescriptor {
                 id: configuration.id,
                 name,
                 url,
+                kind: configuration.kind,
             }
         )
     }

--- a/opendut-lea/src/viper_sources/configurator/types/validation.rs
+++ b/opendut-lea/src/viper_sources/configurator/types/validation.rs
@@ -4,5 +4,6 @@ impl UserViperSourceConfiguration {
     pub fn is_valid(&self) -> bool {
         self.name.is_right()
             && self.url.is_right()
+            && self.kind.is_right()
     }
 }

--- a/opendut-lea/src/viper_tests/configurator/tabs/source/source_selector.rs
+++ b/opendut-lea/src/viper_tests/configurator/tabs/source/source_selector.rs
@@ -38,7 +38,7 @@ pub fn ViperTestSourceSelector(viper_test_run_descriptor: RwSignal<UserViperTest
             });
 
             let rows = viper_sources.iter().map(|viper_source_descriptor| {
-                let ViperSourceDescriptor { id, name, url } = viper_source_descriptor;
+                let ViperSourceDescriptor { id, name, url, .. } = viper_source_descriptor;
                 let id = id.to_owned();
                 let name = name.to_string();
                 let url = url.to_string();

--- a/opendut-model/proto/opendut/model/viper/source.proto
+++ b/opendut-model/proto/opendut/model/viper/source.proto
@@ -6,18 +6,19 @@ import "opendut/model/util/net.proto";
 import "opendut/model/util/uuid.proto";
 
 
-enum ViperSourceKind {
-  VIPER_SOURCE_KIND_UNSPECIFIED = 0;
-  VIPER_SOURCE_KIND_GIT = 1;
-  VIPER_SOURCE_KIND_HTTP = 2;
-}
-
 message ViperSourceDescriptor {
   ViperSourceId id = 1;
   ViperSourceName name = 2;
   opendut.model.util.Url url = 3;
-  ViperSourceKind kind = 4;
+  oneof kind {
+    GitViperSource git = 4;
+    HttpViperSource http = 5;
+  }
 }
+
+message GitViperSource {}
+
+message HttpViperSource {}
 
 message ViperSourceId {
   opendut.model.util.Uuid uuid = 1;

--- a/opendut-model/proto/opendut/model/viper/source.proto
+++ b/opendut-model/proto/opendut/model/viper/source.proto
@@ -6,10 +6,17 @@ import "opendut/model/util/net.proto";
 import "opendut/model/util/uuid.proto";
 
 
+enum ViperSourceKind {
+  VIPER_SOURCE_KIND_UNSPECIFIED = 0;
+  VIPER_SOURCE_KIND_GIT = 1;
+  VIPER_SOURCE_KIND_HTTP = 2;
+}
+
 message ViperSourceDescriptor {
   ViperSourceId id = 1;
   ViperSourceName name = 2;
   opendut.model.util.Url url = 3;
+  ViperSourceKind kind = 4;
 }
 
 message ViperSourceId {

--- a/opendut-model/proto/opendut/model/viper/source.proto
+++ b/opendut-model/proto/opendut/model/viper/source.proto
@@ -11,14 +11,14 @@ message ViperSourceDescriptor {
   ViperSourceName name = 2;
   opendut.model.util.Url url = 3;
   oneof kind {
-    GitViperSource git = 4;
-    HttpViperSource http = 5;
+    ViperSourceKindGit git = 4;
+    ViperSourceKindHttp http = 5;
   }
 }
 
-message GitViperSource {}
+message ViperSourceKindGit {}
 
-message HttpViperSource {}
+message ViperSourceKindHttp {}
 
 message ViperSourceId {
   opendut.model.util.Uuid uuid = 1;

--- a/opendut-model/src/proto/viper.rs
+++ b/opendut-model/src/proto/viper.rs
@@ -49,10 +49,15 @@ mod conversions {
         type Proto = ViperSourceDescriptor;
 
         fn from(value: Model) -> Proto {
+            let kind = match value.kind {
+                crate::viper::ViperSourceKind::Git => ViperSourceKind::Git,
+                crate::viper::ViperSourceKind::Http => ViperSourceKind::Http,
+            };
             Proto {
                 id: Some(value.id.into()),
                 name: Some(value.name.into()),
                 url: Some(value.url.into()),
+                kind: kind.into(),
             }
         }
 
@@ -66,7 +71,13 @@ mod conversions {
             let url = extract!(value.url)?
                 .try_into()?;
 
-            Ok(Model { id, name, url })
+            let kind = match ViperSourceKind::try_from(value.kind) {
+                Ok(ViperSourceKind::Git) => crate::viper::ViperSourceKind::Git,
+                Ok(ViperSourceKind::Http) => crate::viper::ViperSourceKind::Http,
+                _ => return Err(ErrorBuilder::message("ViperSourceKind is unspecified or invalid")),
+            };
+
+            Ok(Model { id, name, url, kind })
         }
     }
 

--- a/opendut-model/src/proto/viper.rs
+++ b/opendut-model/src/proto/viper.rs
@@ -50,14 +50,18 @@ mod conversions {
 
         fn from(value: Model) -> Proto {
             let kind = match value.kind {
-                crate::viper::ViperSourceKind::Git => ViperSourceKind::Git,
-                crate::viper::ViperSourceKind::Http => ViperSourceKind::Http,
+                crate::viper::ViperSourceKind::Git => {
+                    viper_source_descriptor::Kind::Git(GitViperSource {})
+                }
+                crate::viper::ViperSourceKind::Http => {
+                    viper_source_descriptor::Kind::Http(HttpViperSource {})
+                }
             };
             Proto {
                 id: Some(value.id.into()),
                 name: Some(value.name.into()),
                 url: Some(value.url.into()),
-                kind: kind.into(),
+                kind: Some(kind),
             }
         }
 
@@ -71,10 +75,9 @@ mod conversions {
             let url = extract!(value.url)?
                 .try_into()?;
 
-            let kind = match ViperSourceKind::try_from(value.kind) {
-                Ok(ViperSourceKind::Git) => crate::viper::ViperSourceKind::Git,
-                Ok(ViperSourceKind::Http) => crate::viper::ViperSourceKind::Http,
-                _ => return Err(ErrorBuilder::message("ViperSourceKind is unspecified or invalid")),
+            let kind = match extract!(value.kind)? {
+                viper_source_descriptor::Kind::Git(_) => crate::viper::ViperSourceKind::Git,
+                viper_source_descriptor::Kind::Http(_) => crate::viper::ViperSourceKind::Http,
             };
 
             Ok(Model { id, name, url, kind })

--- a/opendut-model/src/proto/viper.rs
+++ b/opendut-model/src/proto/viper.rs
@@ -51,10 +51,10 @@ mod conversions {
         fn from(value: Model) -> Proto {
             let kind = match value.kind {
                 crate::viper::ViperSourceKind::Git => {
-                    viper_source_descriptor::Kind::Git(GitViperSource {})
+                    viper_source_descriptor::Kind::Git(ViperSourceKindGit {})
                 }
                 crate::viper::ViperSourceKind::Http => {
-                    viper_source_descriptor::Kind::Http(HttpViperSource {})
+                    viper_source_descriptor::Kind::Http(ViperSourceKindHttp {})
                 }
             };
             Proto {

--- a/opendut-model/src/viper/source.rs
+++ b/opendut-model/src/viper/source.rs
@@ -104,18 +104,12 @@ impl FromStr for ViperSourceName {
 }
 
 
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub enum ViperSourceKind {
     Git,
+    #[default]
     Http,
 }
-
-impl Default for ViperSourceKind {
-    fn default() -> Self {
-        Self::Http
-    }
-}
-
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ViperSourceDescriptor {

--- a/opendut-model/src/viper/source.rs
+++ b/opendut-model/src/viper/source.rs
@@ -105,8 +105,22 @@ impl FromStr for ViperSourceName {
 
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ViperSourceKind {
+    Git,
+    Http,
+}
+
+impl Default for ViperSourceKind {
+    fn default() -> Self {
+        Self::Http
+    }
+}
+
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ViperSourceDescriptor {
     pub id: ViperSourceId,
     pub name: ViperSourceName,
     pub url: Url,
+    pub kind: ViperSourceKind,
 }

--- a/opendut-model/src/viper/source.rs
+++ b/opendut-model/src/viper/source.rs
@@ -104,10 +104,9 @@ impl FromStr for ViperSourceName {
 }
 
 
-#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub enum ViperSourceKind {
     Git,
-    #[default]
     Http,
 }
 


### PR DESCRIPTION
Add ViperSourceKind (Git/HTTP) to model, proto, and LEA UI

<img width="1850" height="968" alt="image" src="https://github.com/user-attachments/assets/cfbfe008-338c-49a8-8d0b-d5eb2078d47d" />
- Added ViperSourceKind enum with Git and Http variants to the model
- Added ViperSourceKind proto enum and kind field to ViperSourceDescriptor
- Added Source Type dropdown to the viper source configurator UI
- Dropdown shows 'Git' and 'HTTP' options, defaults to HTTP


Resolves: #360 