### PR TITLE
overview table empty state for all tables

### DIFF
--- a/opendut-lea/src/clusters/overview/mod.rs
+++ b/opendut-lea/src/clusters/overview/mod.rs
@@ -96,22 +96,30 @@ pub fn ClustersOverview() -> impl IntoView {
                                 .map(|cluster_deployment| cluster_deployment.id)
                                 .collect::<Vec<_>>();
 
-                            view! {
-                                <For
-                                    each = move || clusters.clone()
-                                    key = |cluster| cluster.id
-                                    children = { move |cluster_descriptor: ClusterDescriptor| {
-                                        let cluster_id = cluster_descriptor.id;
-                                        view! {
-                                            <Row
-                                                cluster_descriptor=RwSignal::new(cluster_descriptor)
-                                                is_deployed = RwSignal::new(IsDeployed(deployed_clusters.contains(&cluster_id)))
-                                                on_deployment_changed=move || refetch_cluster_deployments.notify()
-                                                on_delete
-                                            />
-                                        }
-                                    }}
-                                />
+                            if clusters.is_empty() {
+                                view! {
+                                    <tr>
+                                        <td colspan="4" class="has-text-centered">"No clusters have been created yet"</td>
+                                    </tr>
+                                }.into_any()
+                            } else {
+                                view! {
+                                    <For
+                                        each = move || clusters.clone()
+                                        key = |cluster| cluster.id
+                                        children = { move |cluster_descriptor: ClusterDescriptor| {
+                                            let cluster_id = cluster_descriptor.id;
+                                            view! {
+                                                <Row
+                                                    cluster_descriptor=RwSignal::new(cluster_descriptor)
+                                                    is_deployed = RwSignal::new(IsDeployed(deployed_clusters.contains(&cluster_id)))
+                                                    on_deployment_changed=move || refetch_cluster_deployments.notify()
+                                                    on_delete
+                                                />
+                                            }
+                                        }}
+                                    />
+                                }.into_any()
                             }
                         })
                     }}

--- a/opendut-lea/src/clusters/overview/mod.rs
+++ b/opendut-lea/src/clusters/overview/mod.rs
@@ -99,7 +99,7 @@ pub fn ClustersOverview() -> impl IntoView {
                             if clusters.is_empty() {
                                 view! {
                                     <tr>
-                                        <td colspan="4" class="has-text-centered">"No clusters have been created yet"</td>
+                                        <td colspan="999" class="has-text-centered">"No clusters have been created yet"</td>
                                     </tr>
                                 }.into_any()
                             } else {

--- a/opendut-lea/src/peers/overview/mod.rs
+++ b/opendut-lea/src/peers/overview/mod.rs
@@ -106,7 +106,7 @@ pub fn PeersOverview() -> impl IntoView {
                     if peers.is_empty() {
                         view! {
                             <tr>
-                                <td colspan="4" class="has-text-centered">"No peers have been created yet"</td>
+                                <td colspan="999" class="has-text-centered">"No peers have been created yet"</td>
                             </tr>
                         }.into_any()
                     } else {

--- a/opendut-lea/src/peers/overview/mod.rs
+++ b/opendut-lea/src/peers/overview/mod.rs
@@ -102,25 +102,33 @@ pub fn PeersOverview() -> impl IntoView {
                 { move || Suspend::new(async move {
                     let peers = registered_peers.await;
                     let configured_clusters = configured_clusters.await;
-                    
-                    view! {
-                        <For
-                            each = move || peers.clone()
-                            key = |(peer, _)| peer.id
-                            children = { move |(peer_descriptor, peer_state)| {
-                                let on_delete = move || {
-                                    refetch_registered_peers.notify();
-                                };
-                                view! {
-                                    <Row
-                                        peer_descriptor=RwSignal::new(peer_descriptor)
-                                        peer_state=RwSignal::new(peer_state)
-                                        cluster_descriptor=RwSignal::new(configured_clusters.clone())
-                                        on_delete
-                                    />
-                                }
-                            }}
-                        />
+
+                    if peers.is_empty() {
+                        view! {
+                            <tr>
+                                <td colspan="4" class="has-text-centered">"No peers have been created yet"</td>
+                            </tr>
+                        }.into_any()
+                    } else {
+                        view! {
+                            <For
+                                each = move || peers.clone()
+                                key = |(peer, _)| peer.id
+                                children = { move |(peer_descriptor, peer_state)| {
+                                    let on_delete = move || {
+                                        refetch_registered_peers.notify();
+                                    };
+                                    view! {
+                                        <Row
+                                            peer_descriptor=RwSignal::new(peer_descriptor)
+                                            peer_state=RwSignal::new(peer_state)
+                                            cluster_descriptor=RwSignal::new(configured_clusters.clone())
+                                            on_delete
+                                        />
+                                    }
+                                }}
+                            />
+                        }.into_any()
                     }
                 })}
             </OverviewTable>

--- a/opendut-lea/src/viper_sources/overview/mod.rs
+++ b/opendut-lea/src/viper_sources/overview/mod.rs
@@ -70,24 +70,33 @@ pub fn ViperSourcesOverview() -> impl IntoView {
             <OverviewTable headings=table_headings>
                 { move || Suspend::new(async move {
                     let viper_sources = viper_sources.await;
-                    view! {
-                        <For
-                            each = move || viper_sources.clone()
-                            key = |viper_source| viper_source.id
-                            children = { move |viper_source_descriptor| {
 
-                                let on_delete = move || {
-                                    refetch_viper_sources.notify();
-                                };
+                    if viper_sources.is_empty() {
+                        view! {
+                            <tr>
+                                <td colspan="3" class="has-text-centered">"No viper sources have been created yet"</td>
+                            </tr>
+                        }.into_any()
+                    } else {
+                        view! {
+                            <For
+                                each = move || viper_sources.clone()
+                                key = |viper_source| viper_source.id
+                                children = { move |viper_source_descriptor| {
 
-                                view! {
-                                    <Row
-                                        viper_source_descriptor=RwSignal::new(viper_source_descriptor)
-                                        on_delete
-                                    />
-                                }
-                            }}
-                        />
+                                    let on_delete = move || {
+                                        refetch_viper_sources.notify();
+                                    };
+
+                                    view! {
+                                        <Row
+                                            viper_source_descriptor=RwSignal::new(viper_source_descriptor)
+                                            on_delete
+                                        />
+                                    }
+                                }}
+                            />
+                        }.into_any()
                     }
                 })}
             </OverviewTable>

--- a/opendut-lea/src/viper_sources/overview/mod.rs
+++ b/opendut-lea/src/viper_sources/overview/mod.rs
@@ -74,7 +74,7 @@ pub fn ViperSourcesOverview() -> impl IntoView {
                     if viper_sources.is_empty() {
                         view! {
                             <tr>
-                                <td colspan="3" class="has-text-centered">"No viper sources have been created yet"</td>
+                                <td colspan="999" class="has-text-centered">"No VIPER sources have been created yet"</td>
                             </tr>
                         }.into_any()
                     } else {

--- a/opendut-lea/src/viper_tests/overview/mod.rs
+++ b/opendut-lea/src/viper_tests/overview/mod.rs
@@ -69,24 +69,33 @@ pub fn ViperTestsOverview() -> impl IntoView {
         <OverviewTable headings=table_headings>
             { move || Suspend::new(async move {
                     let viper_tests = viper_tests.await;
-                    view! {
-                        <For
-                            each = move || viper_tests.clone()
-                            key = |viper_tests| viper_tests.id
-                            children = { move |viper_test_run_descriptor| {
 
-                                let on_delete = move || {
-                                    refetch_viper_tests.notify();
-                                };
+                    if viper_tests.is_empty() {
+                        view! {
+                            <tr>
+                                <td colspan="3" class="has-text-centered">"No viper tests have been created yet"</td>
+                            </tr>
+                        }.into_any()
+                    } else {
+                        view! {
+                            <For
+                                each = move || viper_tests.clone()
+                                key = |viper_tests| viper_tests.id
+                                children = { move |viper_test_run_descriptor| {
 
-                                view! {
-                                    <Row
-                                        viper_test_run_descriptor=RwSignal::new(viper_test_run_descriptor)
-                                        on_delete
-                                    />
-                                }
-                            }}
-                        />
+                                    let on_delete = move || {
+                                        refetch_viper_tests.notify();
+                                    };
+
+                                    view! {
+                                        <Row
+                                            viper_test_run_descriptor=RwSignal::new(viper_test_run_descriptor)
+                                            on_delete
+                                        />
+                                    }
+                                }}
+                            />
+                        }.into_any()
                     }
                 })
             }

--- a/opendut-lea/src/viper_tests/overview/mod.rs
+++ b/opendut-lea/src/viper_tests/overview/mod.rs
@@ -73,7 +73,7 @@ pub fn ViperTestsOverview() -> impl IntoView {
                     if viper_tests.is_empty() {
                         view! {
                             <tr>
-                                <td colspan="3" class="has-text-centered">"No viper tests have been created yet"</td>
+                                <td colspan="999" class="has-text-centered">"No VIPER tests have been created yet"</td>
                             </tr>
                         }.into_any()
                     } else {


### PR DESCRIPTION
All four overview pages now have the empty state handling. Here's a summary of what was done:

Peers overview - shows "No peers have been created yet" spanning 4 columns when the peer list is empty
Clusters overview - shows "No clusters have been created yet" spanning 4 columns when the cluster list is empty
Viper sources overview - shows "No viper sources have been created yet" spanning 3 columns when the sources list is empty
Viper tests overview - shows "No viper tests have been created yet" spanning 3 columns when the tests list is empty