### PR TITLE
UI Error Handling when fetching VIPER parameters

### DIFF
--- a/opendut-carl/opendut-carl-api/proto/opendut/carl/services/test-manager.proto
+++ b/opendut-carl/opendut-carl-api/proto/opendut/carl/services/test-manager.proto
@@ -206,10 +206,12 @@ message GetViperTestSuiteParametersFailureSourceNotFound {
 
 message GetViperTestSuiteParametersFailureCompilation {
   opendut.model.viper.ViperSourceId source_id = 1;
+  opendut.model.viper.ViperSourceName source_name = 2;
 }
 
 message GetViperTestSuiteParametersFailureViperRuntime {
   opendut.model.viper.ViperSourceId source_id = 1;
+  opendut.model.viper.ViperSourceName source_name = 2;
 }
 
 message GetViperTestSuiteParametersFailureInternal {

--- a/opendut-carl/opendut-carl-api/src/carl/viper.rs
+++ b/opendut-carl/opendut-carl-api/src/carl/viper.rs
@@ -64,19 +64,21 @@ pub enum ListViperSourceDescriptorsError {
 // ViperTestSuiteParameters
 //
 
-#[derive(thiserror::Error, Debug)]
+#[derive(thiserror::Error, Debug, Clone)]
 pub enum GetViperTestSuiteParametersError {
-    #[error("A VIPER source with ID <{source_id}> could not be found, while fetching VIPER test suite descriptor.")]
+    #[error("The VIPER source <{source_id}> could not be found, while fetching VIPER test suite descriptor.")]
     SourceNotFound {
         source_id: ViperSourceId,
     },
-    #[error("Compilation failed while getting VIPER test suite descriptor for source <{source_id}>.")]
+    #[error("Compilation failed while getting VIPER test suite descriptor for source {source_name} <{source_id}>.")]
     Compilation {
         source_id: ViperSourceId,
+        source_name: ViperSourceName,
     },
-    #[error("Error while initializing VIPER runtime for VIPER test source <{source_id}>.")]
+    #[error("Error while initializing VIPER runtime for VIPER test source {source_name} with the ID <{source_id}>.")]
     ViperRuntime {
         source_id: ViperSourceId,
+        source_name: ViperSourceName,
     },
     #[error("An internal error occurred while fetching the VIPER test suite descriptor for source <{source_id}>:\n  {cause}")]
     Internal {

--- a/opendut-carl/opendut-carl-api/src/proto/services/test_manager.rs
+++ b/opendut-carl/opendut-carl-api/src/proto/services/test_manager.rs
@@ -194,19 +194,21 @@ conversion! {
 
     fn from(value: Model) -> Proto {
         let proto_error = match value {
-            Model::SourceNotFound { source_id } => {
+            Model::SourceNotFound { source_id} => {
                 get_viper_test_suite_parameters_failure::Error::SourceNotFound(GetViperTestSuiteParametersFailureSourceNotFound {
                     source_id: Some(source_id.into()),
                 })
             }
-            Model::Compilation { source_id } => {
+            Model::Compilation { source_id, source_name } => {
                 get_viper_test_suite_parameters_failure::Error::Compilation(GetViperTestSuiteParametersFailureCompilation {
                     source_id: Some(source_id.into()),
+                    source_name: Some(source_name.into()),
                 })
             }
-            Model::ViperRuntime { source_id } => {
+            Model::ViperRuntime { source_id, source_name } => {
                 get_viper_test_suite_parameters_failure::Error::ViperRuntime(GetViperTestSuiteParametersFailureViperRuntime {
                     source_id: Some(source_id.into()),
+                    source_name: Some(source_name.into()),
                 })
             }
             Model::Internal { source_id, cause } => {
@@ -232,13 +234,15 @@ conversion! {
             }
             get_viper_test_suite_parameters_failure::Error::Compilation(error) => {
                 let source_id = extract!(error.source_id)?.try_into()?;
+                let source_name = extract!(error.source_name)?.try_into()?;
                 
-                Ok(Model::Compilation { source_id })
+                Ok(Model::Compilation { source_id, source_name })
             },
             get_viper_test_suite_parameters_failure::Error::ViperRuntime(error) => {
                 let source_id = extract!(error.source_id)?.try_into()?;
+                let source_name = extract!(error.source_name)?.try_into()?;
                 
-                Ok(Model::ViperRuntime{ source_id })
+                Ok(Model::ViperRuntime{ source_id, source_name })
             }
             get_viper_test_suite_parameters_failure::Error::Internal(error) => {
                 let source_id = extract!(error.source_id)?.try_into()?;

--- a/opendut-carl/src/manager/grpc/error.rs
+++ b/opendut-carl/src/manager/grpc/error.rs
@@ -228,15 +228,15 @@ mod test_manager {
     impl From<test_manager::get_viper_test_suite_parameters::GetViperTestSuiteParametersError> for GetViperTestSuiteParametersError {
         fn from(value: test_manager::get_viper_test_suite_parameters::GetViperTestSuiteParametersError) -> Self {
             match value {
-                test_manager::get_viper_test_suite_parameters::GetViperTestSuiteParametersError::Compilation { source_id } => 
-                    Self::Compilation { source_id },
+                test_manager::get_viper_test_suite_parameters::GetViperTestSuiteParametersError::Compilation { source_id, source_name } =>
+                    Self::Compilation { source_id, source_name },
                 test_manager::get_viper_test_suite_parameters::GetViperTestSuiteParametersError::TaskJoin { source_id, when, cause: _ } =>
                     Self::Internal {
                         source_id,
                         cause: format!("Internal error when {when} to completion while retrieving VIPER test suite descriptor"),
                     },
-                test_manager::get_viper_test_suite_parameters::GetViperTestSuiteParametersError::ViperRuntime { source_id } => 
-                    Self::ViperRuntime { source_id },
+                test_manager::get_viper_test_suite_parameters::GetViperTestSuiteParametersError::ViperRuntime { source_id, source_name } => 
+                    Self::ViperRuntime { source_id, source_name },
                 test_manager::get_viper_test_suite_parameters::GetViperTestSuiteParametersError::Persistence { source_id, cause: _ } =>
                     Self::Internal {
                         source_id,

--- a/opendut-carl/src/manager/test_manager/get_viper_test_suite_parameters.rs
+++ b/opendut-carl/src/manager/test_manager/get_viper_test_suite_parameters.rs
@@ -1,5 +1,5 @@
 use tracing::debug;
-use opendut_model::viper::{ViperSourceDescriptor, ViperSourceId, ViperTestSuiteParameters};
+use opendut_model::viper::{ViperSourceDescriptor, ViperSourceId, ViperSourceName, ViperTestSuiteParameters};
 use opendut_viper_rt::common::TestSuiteIdentifier;
 use opendut_viper_rt::compile::{IdentifierFilter};
 use opendut_viper_rt::events::emitter;
@@ -25,12 +25,12 @@ impl Resources<'_> {
 
 
 async fn discover_suite(source: ViperSourceDescriptor) -> Result<Option<ViperTestSuiteParameters>, GetViperTestSuiteParametersError>  {
-    let ViperSourceDescriptor { id: source_id, name, url } = source;
+    let ViperSourceDescriptor { id: source_id, name: source_name, url } = source;
 
-    let name = TestSuiteIdentifier::try_from(name.value())
+    let test_suite_identifier = TestSuiteIdentifier::try_from(source_name.value())
         .expect("Conversion of source name to TestSuiteIdentifier failed."); //FIXME ViperSourceDescriptor should use TestSuiteIdentifier directly, making this conversion obsolete
 
-    let source = Source::from_url(name, url);
+    let source = Source::from_url(test_suite_identifier, url);
 
     debug!("Calling VIPER to compile source into test suite.");
 
@@ -39,10 +39,10 @@ async fn discover_suite(source: ViperSourceDescriptor) -> Result<Option<ViperTes
             let viper_runtime = ViperRuntime::new(ViperOptions {
                 source_loaders: vec![Box::new(HttpSourceLoader)],
                 ..Default::default()
-            }).map_err(|_| GetViperTestSuiteParametersError::ViperRuntime { source_id })?;
+            }).map_err(|_| GetViperTestSuiteParametersError::ViperRuntime { source_id, source_name: source_name.clone() })?;
 
             let compilation = viper_runtime.compile(&source, &mut emitter::drain(), &IdentifierFilter::default()).await
-                .map_err(|_| GetViperTestSuiteParametersError::Compilation { source_id })?;
+                .map_err(|_| GetViperTestSuiteParametersError::Compilation { source_id, source_name: source_name.clone() })?;
 
             Ok((compilation.identifier().to_owned(), compilation.parameters().to_owned()))
         })
@@ -62,9 +62,10 @@ async fn discover_suite(source: ViperSourceDescriptor) -> Result<Option<ViperTes
 
 #[derive(thiserror::Error, Debug)]
 pub enum GetViperTestSuiteParametersError {
-    #[error("Compilation failed while getting VIPER test suite descriptor for source <{source_id}>.")]
+    #[error("Compilation failed while getting VIPER test suite descriptor for source {source_name} with ID <{source_id}>.")]
     Compilation {
         source_id: ViperSourceId,
+        source_name: ViperSourceName,
     },
     #[error("Async task failed when {when} while getting VIPER test suite descriptor for source <{source_id}>.")]
     TaskJoin {
@@ -72,9 +73,10 @@ pub enum GetViperTestSuiteParametersError {
         when: &'static str,
         #[source] cause: tokio::task::JoinError,
     },
-    #[error("Error while initializing VIPER runtime for VIPER test source <{source_id}>.")]
+    #[error("Error while initializing VIPER runtime for VIPER test source {source_name} with ID <{source_id}>.")]
     ViperRuntime {
         source_id: ViperSourceId,
+        source_name: ViperSourceName,
     },
     #[error("Error when accessing persistence while getting VIPER test suite descriptor for source <{source_id}>")]
     Persistence {

--- a/opendut-lea/src/viper_tests/configurator/mod.rs
+++ b/opendut-lea/src/viper_tests/configurator/mod.rs
@@ -1,6 +1,8 @@
 use std::collections::HashMap;
 use leptos::prelude::*;
 use leptos_router::hooks::{use_navigate, use_params_map};
+use opendut_carl_api::carl::ClientError;
+use opendut_carl_api::carl::viper::GetViperTestSuiteParametersError;
 use opendut_lea_components::{BasePageContainer, Breadcrumb, LoadingSpinner, UserInputError, UserInputValue};
 use opendut_lea_components::tabs::{Tab, Tabs};
 use opendut_model::viper::{ViperParameterDescriptor, ViperParameterName, ViperTestId, ViperTestRunDescriptor};
@@ -100,42 +102,53 @@ pub fn ViperTestConfigurator() -> impl IntoView {
 
             async move {
                 if let Some(source_id) = source_id {
-                    let test_suite_descriptor = carl.viper.get_viper_test_suite_parameters(source_id).await
-                        .expect("Failed to request the viper test suite descriptor."); // Todo: Error-Handling
+                    let result = carl.viper.get_viper_test_suite_parameters(source_id).await;
 
-                    viper_test_run_descriptor.update(|user_configuration| {
-                        let mut new_parameters: HashMap<ViperParameterName, ViperBindingValueInput> = HashMap::new();
+                    match result {
+                        Ok(test_suite_descriptor) => {
+                            viper_test_run_descriptor.update(|user_configuration| {
+                                let mut new_parameters: HashMap<ViperParameterName, ViperBindingValueInput> = HashMap::new();
 
-                        for parameter in test_suite_descriptor.parameters.iter() {
-                            let parameter_name = parameter.name().clone();
+                                for parameter in test_suite_descriptor.parameters.iter() {
+                                    let parameter_name = parameter.name().clone();
 
-                            let value = user_configuration
-                                .parameters
-                                .get(&parameter_name)
-                                .cloned()
-                                .unwrap_or_else(|| {
-                                    match parameter {
-                                        ViperParameterDescriptor::BooleanParameter { .. } => {
-                                            // Todo: Remove this match arm, when backend/VIPER forces default parameters for `BooleanParameter`.
-                                            ViperBindingValueInput::Right(None)
-                                        }
-                                        _ if parameter.has_default_value() => {
-                                            ViperBindingValueInput::Right(None)
-                                        }
-                                        _ => {
-                                            ViperBindingValueInput::Left(String::from("Please enter a value."))
-                                        }
-                                    }
-                                });
+                                    let value = user_configuration
+                                        .parameters
+                                        .get(&parameter_name)
+                                        .cloned()
+                                        .unwrap_or_else(|| {
+                                            match parameter {
+                                                ViperParameterDescriptor::BooleanParameter { .. } => {
+                                                    // Todo: Remove this match arm, when backend/VIPER forces default parameters for `BooleanParameter`.
+                                                    ViperBindingValueInput::Right(None)
+                                                }
+                                                _ if parameter.has_default_value() => {
+                                                    ViperBindingValueInput::Right(None)
+                                                }
+                                                _ => {
+                                                    ViperBindingValueInput::Left(String::from("Please enter a value."))
+                                                }
+                                            }
+                                        });
 
-                            new_parameters.insert(parameter_name, value);
+                                    new_parameters.insert(parameter_name, value);
+                                }
+                                user_configuration.parameters = new_parameters;
+                            });
+
+                            Ok(test_suite_descriptor.parameters)
+                        },
+                        Err(client_error) => {
+                            match client_error {
+                                ClientError::UsageError(error) => {
+                                    Err(SourceFetchError::GetParameterError(error))
+                                }
+                                _ => panic!("Failed to request the viper test suite descriptor.")
+                            }
                         }
-                        user_configuration.parameters = new_parameters;
-                    });
-
-                    Some(test_suite_descriptor.parameters)
+                    }
                 } else {
-                    None
+                    Err(SourceFetchError::NoSourceSelected)
                 }
             }
         })
@@ -203,14 +216,13 @@ pub fn ViperTestConfigurator() -> impl IntoView {
                 {
                     move || Suspend::new(async move {
                         viper_test_run_descriptor_resource.await;
-                        let parameters = parameters.await;
-
+                        let parameter_result = parameters.await;
                         view! {
                             <Tabs tabs active_tab=Signal::derive(move || active_tab.get().as_str())>
                                 { move || match active_tab.get() {
                                     TabIdentifier::General => view! { <GeneralTab viper_test_run_descriptor /> }.into_any(),
                                     TabIdentifier::ViperSource => view! { <SourceTab viper_test_run_descriptor /> }.into_any(),
-                                    TabIdentifier::Parameters => view! { <ParametersTab viper_test_run_descriptor parameters=parameters.clone() /> }.into_any(),
+                                    TabIdentifier::Parameters => view! { <ParametersTab viper_test_run_descriptor parameter_result=parameter_result.clone() /> }.into_any(),
                                     TabIdentifier::Cluster => view! { <ClusterTab viper_test_run_descriptor /> }.into_any(),
                                 }}
                             </Tabs>
@@ -220,4 +232,10 @@ pub fn ViperTestConfigurator() -> impl IntoView {
             </Suspense>
         </BasePageContainer>
     }
+}
+
+#[derive(Debug, Clone)]
+enum SourceFetchError {
+    NoSourceSelected,
+    GetParameterError(GetViperTestSuiteParametersError),
 }

--- a/opendut-lea/src/viper_tests/configurator/tabs/parameters/mod.rs
+++ b/opendut-lea/src/viper_tests/configurator/tabs/parameters/mod.rs
@@ -3,7 +3,9 @@ mod number;
 mod text;
 
 use leptos::prelude::*;
-use opendut_model::viper::{ViperParameterDescriptor, ViperParameterDescriptors};
+use opendut_carl_api::carl::viper::GetViperTestSuiteParametersError;
+use opendut_model::viper::{ViperParameterDescriptor, ViperParameterDescriptors, ViperSourceId};
+use crate::viper_tests::configurator::SourceFetchError;
 use crate::viper_tests::configurator::tabs::parameters::boolean::BooleanParameterInput;
 use crate::viper_tests::configurator::tabs::parameters::number::NumberParameterInput;
 use crate::viper_tests::configurator::tabs::parameters::text::TextParameterInput;
@@ -12,88 +14,142 @@ use crate::viper_tests::configurator::types::{UserViperTestRunDescriptor, ViperB
 #[component]
 pub fn ParametersTab(
     viper_test_run_descriptor: RwSignal<UserViperTestRunDescriptor>,
-    parameters: Option<ViperParameterDescriptors>,
+    parameter_result: Result<ViperParameterDescriptors, SourceFetchError>,
 ) -> impl IntoView {
 
-    view! {
-        <For
-            each=move || parameters.clone().unwrap_or_default()
-            key=|parameter_descriptor| Clone::clone(parameter_descriptor.name())
-            children=move |parameter_descriptor| {
+    match parameter_result {
+        Ok(parameters) => {
+            view! {
+                <For
+                    each=move || parameters.clone()
+                    key=|parameter_descriptor| Clone::clone(parameter_descriptor.name())
+                    children=move |parameter_descriptor| {
 
-                let (test_run_getter, test_run_setter) = viper_test_run_descriptor.split();
+                        let (test_run_getter, test_run_setter) = viper_test_run_descriptor.split();
 
-                let test_run_getter = {
-                    let parameter_descriptor = Clone::clone(&parameter_descriptor);
-                    Signal::derive(move || {
-                        test_run_getter.get().parameters.get(parameter_descriptor.name()).cloned()
-                    })
-                };
+                        let test_run_getter = {
+                            let parameter_descriptor = Clone::clone(&parameter_descriptor);
+                            Signal::derive(move || {
+                                test_run_getter.get().parameters.get(parameter_descriptor.name()).cloned()
+                            })
+                        };
 
-                let test_run_setter = {
-                    let parameter_descriptor = Clone::clone(&parameter_descriptor);
-                    SignalSetter::map(move |value: ViperBindingValueInput| {
-                        test_run_setter.update(|test_run| {
-                            test_run.parameters.insert(Clone::clone(parameter_descriptor.name()), value);
-                        })
-                    })
-                };
+                        let test_run_setter = {
+                            let parameter_descriptor = Clone::clone(&parameter_descriptor);
+                            SignalSetter::map(move |value: ViperBindingValueInput| {
+                                test_run_setter.update(|test_run| {
+                                    test_run.parameters.insert(Clone::clone(parameter_descriptor.name()), value);
+                                })
+                            })
+                        };
 
-                let use_default_value = {
-                    let has_value = matches!(test_run_getter.get_untracked(), Some(ViperBindingValueInput::Right(None)));
-                    RwSignal::new(has_value)
-                };
+                        let use_default_value = {
+                            let has_value = matches!(test_run_getter.get_untracked(), Some(ViperBindingValueInput::Right(None)));
+                            RwSignal::new(has_value)
+                        };
 
-                Effect::new(move || {
-                    if use_default_value.get() {
-                        test_run_setter.set(ViperBindingValueInput::Right(None));
+                        Effect::new(move || {
+                            if use_default_value.get() {
+                                test_run_setter.set(ViperBindingValueInput::Right(None));
+                            }
+                        });
+
+                        let cloned_parameter_descriptor = Clone::clone(&parameter_descriptor);
+
+                        match parameter_descriptor {
+                            ViperParameterDescriptor::BooleanParameter { name, info, default } => {
+                                let default = default.unwrap_or(false);
+                                view! {
+                                    <BooleanParameterInput
+                                        getter=test_run_getter
+                                        setter=test_run_setter
+                                        name=name.to_string()
+                                        display_name=info.display_name
+                                        description=info.description
+                                        use_default_value
+                                        default_value=default
+                                    />
+                                    <hr />
+                                }.into_any()
+                            }
+                            ViperParameterDescriptor::NumberParameter { default, .. } => {
+                                view! {
+                                    <NumberParameterInput
+                                        parameter_descriptor
+                                        getter=test_run_getter
+                                        setter=test_run_setter
+                                        use_default_value
+                                        default_value=default
+                                    />
+                                    <hr />
+                                }.into_any()
+                            }
+                            ViperParameterDescriptor::TextParameter { default, .. } => {
+                                view! {
+                                    <TextParameterInput
+                                        parameter_descriptor=cloned_parameter_descriptor
+                                        getter=test_run_getter
+                                        setter=test_run_setter
+                                        use_default_value
+                                        default_value=default
+                                    />
+                                    <hr />
+                                }.into_any()
+                            }
+                        }
                     }
-                });
-
-                let cloned_parameter_descriptor = Clone::clone(&parameter_descriptor);
-
-                match parameter_descriptor {
-                    ViperParameterDescriptor::BooleanParameter { name, info, default } => {
-                        let default = default.unwrap_or(false);
-                        view! {
-                            <BooleanParameterInput
-                                getter=test_run_getter
-                                setter=test_run_setter
-                                name=name.to_string()
-                                display_name=info.display_name
-                                description=info.description
-                                use_default_value
-                                default_value=default
-                            />
-                            <hr />
-                        }.into_any()
-                    }
-                    ViperParameterDescriptor::NumberParameter { default, .. } => {
-                        view! {
-                            <NumberParameterInput
-                                parameter_descriptor
-                                getter=test_run_getter
-                                setter=test_run_setter
-                                use_default_value
-                                default_value=default
-                            />
-                            <hr />
-                        }.into_any()
-                    }
-                    ViperParameterDescriptor::TextParameter { default, .. } => {
-                        view! {
-                            <TextParameterInput
-                                parameter_descriptor=cloned_parameter_descriptor
-                                getter=test_run_getter
-                                setter=test_run_setter
-                                use_default_value
-                                default_value=default
-                            />
-                            <hr />
-                        }.into_any()
+                />
+            }.into_any()
+        }
+        Err(fetch_error) => {
+            match fetch_error {
+                SourceFetchError::NoSourceSelected => {
+                    view! { <p class="help has-text-danger"> "No VIPER source selected." </p> }.into_any()
+                }
+                SourceFetchError::GetParameterError(error) => {
+                    let create_source_href = move |id: &ViperSourceId| {
+                        format!("/viper_sources/{id}/configure/general")
+                    };
+                    match error {
+                        GetViperTestSuiteParametersError::SourceNotFound { .. } => {
+                            view! {
+                                <p class="help has-text-danger"> "Selected VIPER source not found." </p>
+                            }.into_any()
+                        },
+                        GetViperTestSuiteParametersError::Compilation { source_id, source_name } => {
+                            let source_name = source_name.value();
+                            let source_href = create_source_href(&source_id);
+                            view! {
+                                <p class="help has-text-danger">
+                                    "Compilation failed for the selected VIPER Source. Please check the Source "
+                                    <a href=source_href> {source_name} </a>.
+                                </p>
+                            }.into_any()
+                        },
+                        GetViperTestSuiteParametersError::ViperRuntime { source_id, source_name } => {
+                            let source_name = source_name.value();
+                            let source_href = create_source_href(&source_id);
+                            view! {
+                                <p class="help has-text-danger">
+                                    "Error while initializing VIPER runtime for VIPER test source "
+                                    <a href=source_href> {source_name} </a>.
+                                </p>
+                            }.into_any()
+                        },
+                        GetViperTestSuiteParametersError::Internal { source_id, cause } => {
+                            let source_href = create_source_href(&source_id);
+                            view! {
+                                <p class="help has-text-danger">
+                                    "An internal error occurred while fetching the VIPER test suite descriptor for the "
+                                    <a href=source_href> selected source </a>:
+                                    <br />
+                                    {cause}
+                                </p>
+                            }.into_any()
+                        },
                     }
                 }
             }
-        />
+        }
     }
 }


### PR DESCRIPTION
## Changes
Display an error string when fetching VIPER parameters causes an error (e. g. Source not found or Compile error).

<img width="1310" height="271" alt="image" src="https://github.com/user-attachments/assets/15df05cc-27b2-4af3-aa26-49433253d409" />

## Solved Issue

This PR should finish the issue #361
