### PR TITLE
Improved Toast when failing to delete a Viper Source

### DIFF
--- a/opendut-lea/src/viper_sources/components/delete_viper_source_button.rs
+++ b/opendut-lea/src/viper_sources/components/delete_viper_source_button.rs
@@ -38,7 +38,7 @@ where F: Fn() + Clone + Send + 'static {
 
             match result {
                 Ok(_) => {
-                    info!("Successfully deleted viper source: {}", viper_source_id.get());
+                    info!("Successfully deleted viper source: {}", viper_source_id.get_untracked());
                     on_delete();
                     toaster.toast(
                         Toast::builder()
@@ -47,7 +47,7 @@ where F: Fn() + Clone + Send + 'static {
                     );
                 }
                 Err(cause) => {
-                    error!("Failed to delete viper source <{}>, due to error: {cause}", viper_source_id.get());
+                    error!("Failed to delete viper source <{}>, due to error: {cause}", viper_source_id.get_untracked());
                     toaster.toast(
                         Toast::builder()
                             .simple(cause.to_string())

--- a/opendut-lea/src/viper_sources/components/delete_viper_source_button.rs
+++ b/opendut-lea/src/viper_sources/components/delete_viper_source_button.rs
@@ -38,7 +38,7 @@ where F: Fn() + Clone + Send + 'static {
 
             match result {
                 Ok(_) => {
-                    info!("Successfully deleted viper source: {:?}", viper_source_id);
+                    info!("Successfully deleted viper source: {}", viper_source_id.get());
                     on_delete();
                     toaster.toast(
                         Toast::builder()
@@ -47,10 +47,10 @@ where F: Fn() + Clone + Send + 'static {
                     );
                 }
                 Err(cause) => {
-                    error!("Failed to delete viper source <{:?}>, due to error: {cause:?}", viper_source_id);
+                    error!("Failed to delete viper source <{}>, due to error: {cause}", viper_source_id.get());
                     toaster.toast(
                         Toast::builder()
-                            .simple("Failed to delete viper source!")
+                            .simple(cause.to_string())
                             .error()
                     );
                 }


### PR DESCRIPTION
Display the exact cause in the toast instead of a fix string ("Failed to delete viper source!") when failing to delete a `ViperSource`.

<img width="1604" height="706" alt="image" src="https://github.com/user-attachments/assets/c391692f-a57b-4191-a019-d6537a87a7af" />

