### PR TITLE
Pre-fetch source code for test execution in EDGAR

### DIFF
--- a/opendut-lea/src/viper_sources/components/delete_viper_source_button.rs
+++ b/opendut-lea/src/viper_sources/components/delete_viper_source_button.rs
@@ -38,7 +38,7 @@ where F: Fn() + Clone + Send + 'static {
 
             match result {
                 Ok(_) => {
-                    info!("Successfully deleted viper source: {}", viper_source_id.get());
+                    info!("Successfully deleted viper source: {}", viper_source_id.get_untracked());
                     on_delete();
                     toaster.toast(
                         Toast::builder()
@@ -47,7 +47,7 @@ where F: Fn() + Clone + Send + 'static {
                     );
                 }
                 Err(cause) => {
-                    error!("Failed to delete viper source <{}>, due to error: {cause}", viper_source_id.get());
+                    error!("Failed to delete viper source <{}>, due to error: {cause}", viper_source_id.get_untracked());
                     toaster.toast(
                         Toast::builder()
                             .simple(cause.to_string())

--- a/opendut-lea/src/viper_sources/components/delete_viper_source_button.rs
+++ b/opendut-lea/src/viper_sources/components/delete_viper_source_button.rs
@@ -38,7 +38,7 @@ where F: Fn() + Clone + Send + 'static {
 
             match result {
                 Ok(_) => {
-                    info!("Successfully deleted viper source: {:?}", viper_source_id);
+                    info!("Successfully deleted viper source: {}", viper_source_id.get());
                     on_delete();
                     toaster.toast(
                         Toast::builder()
@@ -47,10 +47,10 @@ where F: Fn() + Clone + Send + 'static {
                     );
                 }
                 Err(cause) => {
-                    error!("Failed to delete viper source <{:?}>, due to error: {cause:?}", viper_source_id);
+                    error!("Failed to delete viper source <{}>, due to error: {cause}", viper_source_id.get());
                     toaster.toast(
                         Toast::builder()
-                            .simple("Failed to delete viper source!")
+                            .simple(cause.to_string())
                             .error()
                     );
                 }

--- a/opendut-viper/viper-rt/src/runtime/compile/mod.rs
+++ b/opendut-viper/viper-rt/src/runtime/compile/mod.rs
@@ -3,7 +3,7 @@ mod inspect;
 mod prepare;
 mod py;
 
-use crate::compile::{Compilation, CompileEvent, IdentifierFilter};
+use crate::compile::{Compilation, CompileEvent, IdentifierFilter, SourceCode};
 use crate::runtime::compile::inspect::inspect;
 use crate::runtime::compile::prepare::prepare_source_code;
 use crate::runtime::compile::py::{compile_source_code, create_interpreter};
@@ -13,6 +13,13 @@ use crate::runtime::types::compile::error::{CompilationError, CompileResult};
 use crate::source::Source;
 use tracing::{debug, error, info};
 use crate::runtime::types::compile::filter::FilterError;
+
+pub async fn fetch_source_code (
+    source: &Source,
+    context: &Context,
+) -> CompileResult<SourceCode> {
+    prepare_source_code(source, context).await
+}
 
 pub async fn compile_tree<Emitter>(
     sources: Vec<(Source, Emitter)>,

--- a/opendut-viper/viper-rt/src/runtime/mod.rs
+++ b/opendut-viper/viper-rt/src/runtime/mod.rs
@@ -83,6 +83,14 @@ impl ViperRuntime {
         compile::compile(source, &self.context, emitter, identifier_filter).await
     }
 
+    #[cfg(feature = "compile")]
+    pub async fn fetch_source_code(
+        &self,
+        source: &types::source::Source
+    ) -> types::compile::error::CompileResult<crate::compile::SourceCode> {
+        compile::fetch_source_code(source, &self.context).await
+    }
+
     #[cfg(feature = "run")]
     pub async fn run(
         &self,


### PR DESCRIPTION
Addressing issue #523

- [x] Split VIPER's compile() function to allow fetching source code without compiling. Make this `fetch_source()` available in the public API of VIPER. 
**Note:** Added a function called `fetch_source_code()` to the `ViperRuntime`, which addresses this task.

