### PR TITLE
Can port mismatch

### DIFF
--- a/.ci/deploy/testenv/edgar/scripts/pingall_can.py
+++ b/.ci/deploy/testenv/edgar/scripts/pingall_can.py
@@ -1,24 +1,28 @@
-import time, random, sys
+import argparse
+import random
+import sys
+import time
+
 import can
 
-interface = "socketcan"
-channel = "vcan0"
+# https://python-can.readthedocs.io/en/stable/configuration.html#interface-names
+CAN_INTERFACE_BACKEND = "socketcan"
+CAN_CHANNEL_NAME = "vcan0"  # the network interface name when socketcan is used
 
-ping_arbid = 0x333
-responder_lifetime = 20
-response_timeout = 2
-n_pings = 5
-ping_sleep = 1
+PING_ARBITRATION_ID = 0x333
+RESPONDER_LIFETIME_SECONDS = 20
+RESPONSE_TIMEOUT_SECONDS = 2
+NUMBER_OF_PINGS = 5
+PING_SLEEP_DELAY_SECONDS = 1
 
 
-def respond_to_pings():
-    bus = can.Bus(channel=channel, interface=interface)
+def run_ping_responder(can_bus):
     start_time = time.time()
-    while time.time() < start_time + responder_lifetime:
-        msg = bus.recv(1)
+    while time.time() < start_time + RESPONDER_LIFETIME_SECONDS:
+        msg = can_bus.recv(1)
         if msg is None:
             continue
-        if msg.arbitration_id == ping_arbid:
+        if msg.arbitration_id == PING_ARBITRATION_ID:
             ping_payload = int.from_bytes(msg.data, byteorder="big", signed=False)
             if ping_payload % 2 == 1:
                 # for ping requests, (payload % 2 == 0), for ping responses, (payload % 2 == 1)
@@ -26,33 +30,32 @@ def respond_to_pings():
             resp_data = ping_payload + 1
 
             resp = can.Message(
-                arbitration_id=ping_arbid,
+                arbitration_id=PING_ARBITRATION_ID,
                 data=resp_data.to_bytes(8, byteorder="big"),
                 is_extended_id=False,
             )
-            bus.send(resp)
-    bus.shutdown()
+            can_bus.send(resp)
 
 
-def send_ping(bus):
+def send_ping(can_bus):
     ping_payload_int = random.randrange(0, 2**64 - 1, step=2)
     expected_resp_payload = (ping_payload_int + 1).to_bytes(8, byteorder="big")
 
     msg = can.Message(
-        arbitration_id=ping_arbid,
+        arbitration_id=PING_ARBITRATION_ID,
         data=ping_payload_int.to_bytes(8, byteorder="big"),
         is_extended_id=False,
     )
     send_time = time.time()
-    bus.send(msg)
+    can_bus.send(msg)
 
-    while time.time() < send_time + response_timeout:
-        msg = bus.recv(1)
+    while time.time() < send_time + RESPONSE_TIMEOUT_SECONDS:
+        msg = can_bus.recv(1)
         recv_time = time.time()
         if msg is None:
             continue
         if (
-            msg.arbitration_id == ping_arbid
+            msg.arbitration_id == PING_ARBITRATION_ID
             and bytes(msg.data) == expected_resp_payload
         ):
             latency = int((recv_time - send_time) * 1000)
@@ -61,21 +64,20 @@ def send_ping(bus):
     return None
 
 
-def run_ping():
+def run_ping_sender(can_bus):
     print("Checking whether other peer responds to CAN pings...")
     latencies = []
 
-    with can.Bus(channel=channel, interface=interface) as bus:
-        for _ in range(n_pings):
-            if (latency := send_ping(bus)) is not None:
-                latencies.append(latency)
-            time.sleep(ping_sleep)
+    for _ in range(NUMBER_OF_PINGS):
+        if (latency := send_ping(can_bus)) is not None:
+            latencies.append(latency)
+        time.sleep(PING_SLEEP_DELAY_SECONDS)
 
-    if len(latencies):
+    if latencies:
         avg = int(sum(latencies) / len(latencies))
         lowest = min(latencies)
         highest = max(latencies)
-        loss_percent = int(((n_pings - len(latencies)) / n_pings) * 100)
+        loss_percent = int(((NUMBER_OF_PINGS - len(latencies)) / NUMBER_OF_PINGS) * 100)
         unit = " ms"
     else:
         avg, lowest, highest = "n.a.", "n.a.", "n.a."
@@ -83,19 +85,25 @@ def run_ping():
         unit = ""
 
     print(
-        f"CAN ping stats (n={n_pings}): avg: {avg}{unit}, lowest: {lowest}{unit}, highest: {highest}{unit}, loss: {loss_percent}%"
+        f"CAN ping stats (n={NUMBER_OF_PINGS}): avg: {avg}{unit}, lowest: {lowest}{unit}, highest: {highest}{unit}, loss: {loss_percent}%"
     )
 
     # Make this script exit with a code indicating error if not all ping messages went through
     if loss_percent > 0:
-        sys.exit(1)
+        print("Error: CAN messages were lost during ping test.")
+        return False
+
+    return True
 
 
 if __name__ == "__main__":
-    runtype = sys.argv[1]
-    if runtype == "sender":
-        run_ping()
-    elif runtype == "responder":
-        respond_to_pings()
-    else:
-        print("Invalid argument, must be 'sender' or 'responder'.")
+    parser = argparse.ArgumentParser(description="CAN ping test utility")
+    parser.add_argument("runtype", choices=["sender", "responder"], help="Run as 'sender' or 'responder'")
+    args = parser.parse_args()
+
+    with can.Bus(channel=CAN_CHANNEL_NAME, interface=CAN_INTERFACE_BACKEND) as can_bus:
+        if args.runtype == "sender":
+            if not run_ping_sender(can_bus):
+                sys.exit(1)
+        elif args.runtype == "responder":
+            run_ping_responder(can_bus)

--- a/.ci/deploy/testenv/edgar/scripts/pingall_can.py
+++ b/.ci/deploy/testenv/edgar/scripts/pingall_can.py
@@ -63,13 +63,13 @@ def send_ping(bus):
 
 def run_ping():
     print("Checking whether other peer responds to CAN pings...")
-    bus = can.Bus(channel=channel, interface=interface)
-
     latencies = []
-    for _ in range(n_pings):
-        if (latency := send_ping(bus)) is not None:
-            latencies.append(latency)
-        time.sleep(ping_sleep)
+
+    with can.Bus(channel=channel, interface=interface) as bus:
+        for _ in range(n_pings):
+            if (latency := send_ping(bus)) is not None:
+                latencies.append(latency)
+            time.sleep(ping_sleep)
 
     if len(latencies):
         avg = int(sum(latencies) / len(latencies))
@@ -86,7 +86,9 @@ def run_ping():
         f"CAN ping stats (n={n_pings}): avg: {avg}{unit}, lowest: {lowest}{unit}, highest: {highest}{unit}, loss: {loss_percent}%"
     )
 
-    bus.shutdown()
+    # Make this script exit with a code indicating error if not all ping messages went through
+    if loss_percent > 0:
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/.ci/deploy/testenv/edgar/scripts/pingall_can.py
+++ b/.ci/deploy/testenv/edgar/scripts/pingall_can.py
@@ -96,9 +96,24 @@ def run_ping_sender(can_bus):
     return True
 
 
+def run_listener(can_bus):
+    print("Listening for CAN ping messages (Ctrl+C to stop)...")
+    try:
+        while True:
+            msg = can_bus.recv(1)
+            if msg is None:
+                continue
+            if msg.arbitration_id == PING_ARBITRATION_ID:
+                payload = int.from_bytes(msg.data, byteorder="big")
+                msg_type = "response" if payload % 2 == 1 else "request"
+                print(f"Received CAN ping {msg_type}: payload={payload:#018x}")
+    except KeyboardInterrupt:
+        print("Listener stopped.")
+
+
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="CAN ping test utility")
-    parser.add_argument("runtype", choices=["sender", "responder"], help="Run as 'sender' or 'responder'")
+    parser.add_argument("runtype", choices=["sender", "responder", "listener"], help="Run as 'sender', 'responder', or 'listener'")
     args = parser.parse_args()
 
     with can.Bus(channel=CAN_CHANNEL_NAME, interface=CAN_INTERFACE_BACKEND) as can_bus:
@@ -107,3 +122,5 @@ if __name__ == "__main__":
                 sys.exit(1)
         elif args.runtype == "responder":
             run_ping_responder(can_bus)
+        elif args.runtype == "listener":
+            run_listener(can_bus)

--- a/doc/src/changelog.md
+++ b/doc/src/changelog.md
@@ -8,15 +8,26 @@ When upgrading between versions of CARL, do not skip versions,
 since migrations are only provided from one version to the next.
 Always create a database backup before upgrading CARL.
 
-## Unreleased 
+## [v0.10.2] - 2026-06-11
 
-TBD
+### Fixed
+
+* CARL, EDGAR: CAN connections between peers were broken due to a port assignment error
+  In v0.10.0, the clients used the leader port instead of the common follower port for the connection.
+  In v0.10.1, the leader and follower peer were configured with the leader port instead of each follower's port. Only two peers in a cluster could work with CAN.
+
+### Changed
+
+* CARL API: The `CanConnection` protobuf message now uses a single `port` field, replacing the former `remote_port` and `local_port` fields.
+  Both fields always held the same value (the follower's assigned port), so the split was redundant and was the root cause of the bug above.
+  The old `local_port` field (proto field 4) is kept as deprecated for one release cycle to allow rolling upgrades between CARL and EDGAR instances.
+* Localenv: The CAN ping test script now exits with a non-zero error code on failure, making it usable in automated tests.
 
 
 ## [v0.10.1] - 2026-06-03
 
 ### Fixed
-* Connections via CAN should work again, after fixes for two issues:
+* Connections via CAN should work again, at least with two peers, after fixes for two issues:
   * <https://github.com/eclipse-opendut/opendut/pull/494>
   * <https://github.com/eclipse-opendut/opendut/issues/518>
 * EDGAR: Don't use the operating system's certificate management anymore, making EDGAR more portable across distributions.

--- a/doc/src/development/release/publishing-a-release.md
+++ b/doc/src/development/release/publishing-a-release.md
@@ -7,6 +7,7 @@ This is a checklist for the steps to take to create a release for public usage.
 * [ ] Increment version number in workspace `Cargo.toml`.
 * [ ] Run `cargo ci check` to update all `Cargo.lock` files.
 * [ ] Increment the version of the CARL container used in CI/CD deployments (in the `.ci/` folder).
+  * Compose file: `.ci/deploy/localenv/docker-compose.yml`
 * [ ] Create commit and push to `development`.
 * [ ] Open PR from `development` to `main`.
 * [ ] Merge PR once its checks have succeeded.

--- a/opendut-carl/src/manager/cluster_manager/mod.rs
+++ b/opendut-carl/src/manager/cluster_manager/mod.rs
@@ -257,7 +257,7 @@ impl ClusterManager {
 
         let can_server_ports = self.determine_can_server_ports(&member_ids, cluster_id)?;
 
-        // determine CAN ports for cluster assignment
+        // Determine CAN ports for cluster assignment
         let member_assignments: Vec<Result<(PeerId, PeerClusterAssignment), RolloutClusterError>> = {
             let assignment_futures = std::iter::zip(member_ids, can_server_ports)
                 .map(|(peer_id, can_server_port)| {

--- a/opendut-carl/src/manager/cluster_manager/mod.rs
+++ b/opendut-carl/src/manager/cluster_manager/mod.rs
@@ -257,6 +257,7 @@ impl ClusterManager {
 
         let can_server_ports = self.determine_can_server_ports(&member_ids, cluster_id)?;
 
+        // determine CAN ports for cluster assignment
         let member_assignments: Vec<Result<(PeerId, PeerClusterAssignment), RolloutClusterError>> = {
             let assignment_futures = std::iter::zip(member_ids, can_server_ports)
                 .map(|(peer_id, can_server_port)| {

--- a/opendut-carl/src/manager/peer_manager/assign_cluster/assignment.rs
+++ b/opendut-carl/src/manager/peer_manager/assign_cluster/assignment.rs
@@ -6,6 +6,7 @@ use opendut_model::peer::PeerId;
 use opendut_model::util::Port;
 
 
+/// Cluster assignments are determined in ClusterManager here opendut_carl::manager::cluster_manager::rollout_cluster
 #[derive(Clone, Debug, PartialEq, Eq, Serialize)]
 pub struct ClusterAssignment {
     pub id: ClusterId,

--- a/opendut-carl/src/manager/peer_manager/assign_cluster/assignment.rs
+++ b/opendut-carl/src/manager/peer_manager/assign_cluster/assignment.rs
@@ -6,7 +6,9 @@ use opendut_model::peer::PeerId;
 use opendut_model::util::Port;
 
 
-/// Cluster assignments are determined in ClusterManager here opendut_carl::manager::cluster_manager::rollout_cluster
+/// Cluster assignments are determined in ClusterManager here [`crate::manager::cluster_manager::ClusterManager::rollout_cluster`]
+/// The ports defined in the [`PeerClusterAssignment`] are used in the can manager in EDGAR opendut-edgar/src/service/can/can_manager.rs
+/// CAN connection parameters are defined in the model [`opendut_model::peer::configuration::parameter::CanConnection`]
 #[derive(Clone, Debug, PartialEq, Eq, Serialize)]
 pub struct ClusterAssignment {
     pub id: ClusterId,

--- a/opendut-carl/src/manager/peer_manager/assign_cluster/configuration.rs
+++ b/opendut-carl/src/manager/peer_manager/assign_cluster/configuration.rs
@@ -77,36 +77,33 @@ pub(super) fn update_peer_configuration(
                 .ok_or(AssignClusterError::PeerNotFound(cluster_assignment.leader))?;
 
             if cluster_assignment.leader == peer_descriptor.id {
-                let remote_peers = cluster_assignment.non_leader_assignments();
-
-                let expected_can_connections = remote_peers.into_iter()
-                    .map(|(remote_peer_id, remote_assignment)| {
-                        parameter::CanConnection {
-                            can_interface_name: can_bridge.clone(),
-                            local_is_server: true,
-                            remote_peer_id,
-                            remote_ip: remote_assignment.vpn_address,
-                            remote_port: remote_assignment.can_server_port,
-                            local_port: remote_assignment.can_server_port, // EDGAR leader opens listening ports for each follower in CanManager::fill_cannelloni_cmd()
+                // Leader: open one listening connection per follower, each on the follower's assigned port.
+                let expected_can_connections = cluster_assignment.non_leader_assignments()
+                    .into_iter()
+                    .map(|(follower_id, follower_assignment)| {
+                        can_connection_for_leader(
+                            can_bridge.clone(),
+                            follower_id,
+                            follower_assignment.vpn_address,
+                            follower_assignment.can_server_port,
                             buffer_timeout_microseconds,
-                        }
+                        )
                     });
                 can_connections.set_all_present(expected_can_connections, can_dependencies.clone());
-            }
-            else {
+            } else {
+                // Follower: connect to the leader using this peer's own assigned port.
                 let local_assignment = cluster_assignment.assignments.get(&peer_descriptor.id)
                     .ok_or(AssignClusterError::PeerNotFound(peer_descriptor.id))?;
 
-                let can_connection = parameter::CanConnection {
-                    can_interface_name: can_bridge.clone(),
-                    local_is_server: false,
-                    remote_peer_id: cluster_assignment.leader,
-                    remote_ip: leader_assignment.vpn_address,
-                    remote_port: local_assignment.can_server_port,  // EDGAR peer opens connection to this port
-                    local_port: local_assignment.can_server_port,
-                    buffer_timeout_microseconds,
-                };
-                let expected_can_connections = vec![can_connection];
+                let expected_can_connections = vec![
+                    can_connection_for_follower(
+                        can_bridge.clone(),
+                        cluster_assignment.leader,
+                        leader_assignment.vpn_address,
+                        local_assignment.can_server_port,
+                        buffer_timeout_microseconds,
+                    )
+                ];
                 can_connections.set_all_present(expected_can_connections, can_dependencies.clone());
             }
         }
@@ -231,3 +228,46 @@ fn require_ipv4_for_gre(ip_address: IpAddr) -> Result<Ipv4Addr, AssignClusterErr
         IpAddr::V6(_) => Err(AssignClusterError::Ipv6NotSupported),
     }
 }
+
+/// Build a [`parameter::CanConnection`] for the **leader** side of a CAN tunnel.
+///
+/// The leader acts as the SCTP server and listens on `follower_port`.
+/// The follower is identified by `follower_id` and reachable at `follower_ip`.
+fn can_connection_for_leader(
+    can_interface_name: NetworkInterfaceName,
+    follower_id: PeerId,
+    follower_ip: IpAddr,
+    follower_port: opendut_model::util::Port,
+    buffer_timeout_microseconds: u64,
+) -> parameter::CanConnection {
+    parameter::CanConnection {
+        can_interface_name,
+        local_is_server: true,
+        remote_peer_id: follower_id,
+        remote_ip: follower_ip,
+        port: follower_port,
+        buffer_timeout_microseconds,
+    }
+}
+
+/// Build a [`parameter::CanConnection`] for a **follower** side of a CAN tunnel.
+///
+/// The follower acts as the SCTP client and connects to the leader at `leader_ip:my_port`,
+/// where `my_port` is this follower's own assigned port (`PeerClusterAssignment::can_server_port`).
+fn can_connection_for_follower(
+    can_interface_name: NetworkInterfaceName,
+    leader_id: PeerId,
+    leader_ip: IpAddr,
+    my_port: opendut_model::util::Port,
+    buffer_timeout_microseconds: u64,
+) -> parameter::CanConnection {
+    parameter::CanConnection {
+        can_interface_name,
+        local_is_server: false,
+        remote_peer_id: leader_id,
+        remote_ip: leader_ip,
+        port: my_port,
+        buffer_timeout_microseconds,
+    }
+}
+

--- a/opendut-carl/src/manager/peer_manager/assign_cluster/configuration.rs
+++ b/opendut-carl/src/manager/peer_manager/assign_cluster/configuration.rs
@@ -87,7 +87,7 @@ pub(super) fn update_peer_configuration(
                             remote_peer_id,
                             remote_ip: remote_assignment.vpn_address,
                             remote_port: remote_assignment.can_server_port,
-                            local_port: leader_assignment.can_server_port,
+                            local_port: remote_assignment.can_server_port, // EDGAR leader opens listening ports for each client in CanManager::fill_cannelloni_cmd()
                             buffer_timeout_microseconds,
                         }
                     });
@@ -102,7 +102,7 @@ pub(super) fn update_peer_configuration(
                     local_is_server: false,
                     remote_peer_id: cluster_assignment.leader,
                     remote_ip: leader_assignment.vpn_address,
-                    remote_port: leader_assignment.can_server_port,
+                    remote_port: local_assignment.can_server_port,  // EDGAR peer opens connection to this port
                     local_port: local_assignment.can_server_port,
                     buffer_timeout_microseconds,
                 };

--- a/opendut-carl/src/manager/peer_manager/assign_cluster/configuration.rs
+++ b/opendut-carl/src/manager/peer_manager/assign_cluster/configuration.rs
@@ -87,7 +87,7 @@ pub(super) fn update_peer_configuration(
                             remote_peer_id,
                             remote_ip: remote_assignment.vpn_address,
                             remote_port: remote_assignment.can_server_port,
-                            local_port: remote_assignment.can_server_port, // EDGAR leader opens listening ports for each client in CanManager::fill_cannelloni_cmd()
+                            local_port: remote_assignment.can_server_port, // EDGAR leader opens listening ports for each follower in CanManager::fill_cannelloni_cmd()
                             buffer_timeout_microseconds,
                         }
                     });

--- a/opendut-edgar/src/service/can/can_manager.rs
+++ b/opendut-edgar/src/service/can/can_manager.rs
@@ -28,7 +28,7 @@ impl CanManager {
 
     pub async fn spawn_process(&self, parameter: &CanConnection) -> anyhow::Result<()> {
         let name = if parameter.local_is_server {
-            format!("cannelloni-server-on-port-{}", parameter.local_port)
+            format!("cannelloni-server-on-port-{}", parameter.port)
         } else {
             format!("cannelloni-to-leader-peer-{}", parameter.remote_peer_id)
         };
@@ -47,7 +47,7 @@ impl CanManager {
             .with_output_config(OutputConfig::Capture);
 
         let process_id = if parameter.local_is_server {
-            let local_port = parameter.local_port.0;
+            let local_port = parameter.port.0;
             let log_function = create_process_log_function!("opendut-cannelloni-server", local_port=local_port);
             AsyncProcessManager::spawn_process(self.process_manager.clone(), config, log_function).await?
         } else {
@@ -99,13 +99,8 @@ impl CanManager {
     ///
     /// Cannelloni is expected to be replaced with open1722, see https://github.com/eclipse-opendut/opendut/issues/306
     fn fill_cannelloni_cmd(parameter: &CanConnection, cmd: &mut Command) {
-        let instance_type = if parameter.local_is_server {"s"} else {"c"}; // act as server or client
-        let port_arg = if parameter.local_is_server {"-l"} else {"-r"};  // listening port or remote port
-        let port = if parameter.local_is_server {
-            parameter.local_port
-        } else {
-            parameter.remote_port
-        };
+        let instance_type = if parameter.local_is_server { "s" } else { "c" }; // act as server or client
+        let port_arg = if parameter.local_is_server { "-l" } else { "-r" }; // listening port or remote port
 
         cmd.arg("-I")
             .arg(parameter.can_interface_name.name())
@@ -116,7 +111,7 @@ impl CanManager {
             .arg("-R")  // remote IP address
             .arg(parameter.remote_ip.to_string())
             .arg(port_arg)
-            .arg(port.to_string())
+            .arg(parameter.port.to_string())
             .stderr(Stdio::piped())
             .stdout(Stdio::piped());
     }

--- a/opendut-edgar/src/service/can/can_manager.rs
+++ b/opendut-edgar/src/service/can/can_manager.rs
@@ -91,14 +91,13 @@ impl CanManager {
         }
     }
 
-    /*
-     cannelloni with SCTP transport for CAN bus tunneling
-
-     With SCTP it is possible to use cannelloni over lossy connections where packet loss and re-ordering is very likely.
-     The SCTP implementation uses the server-client model (for now). One instance binds on a fixed port and the other instance (client) connects to it.
-
-     https://github.com/mguentner/cannelloni?tab=readme-ov-file#sctp
-     */
+    /// cannelloni with SCTP transport for CAN bus tunneling
+    ///
+    /// With SCTP it is possible to use cannelloni over lossy connections where packet loss and re-ordering is very likely.
+    /// The SCTP implementation uses the server-client model (for now). One instance binds on a fixed port and the other instance (client) connects to it.
+    /// https://github.com/mguentner/cannelloni?tab=readme-ov-file#sctp
+    ///
+    /// Cannelloni is expected to be replaced with open1722, see https://github.com/eclipse-opendut/opendut/issues/306
     fn fill_cannelloni_cmd(parameter: &CanConnection, cmd: &mut Command) {
         let instance_type = if parameter.local_is_server {"s"} else {"c"}; // act as server or client
         let port_arg = if parameter.local_is_server {"-l"} else {"-r"};  // listening port or remote port

--- a/opendut-model/proto/opendut/model/peer/configuration/parameter.proto
+++ b/opendut-model/proto/opendut/model/peer/configuration/parameter.proto
@@ -36,8 +36,13 @@ message RemotePeerConnectionCheck {
 message CanConnection {
   opendut.model.peer.PeerId remote_peer_id = 1;
   opendut.model.util.IpAddress remote_ip = 2;
-  opendut.model.util.Port remote_port = 3;
-  opendut.model.util.Port local_port = 4;
+  // The single port used for this CAN tunnel.
+  // The leader (server) listens on this port; the follower (client) connects to it.
+  // Both sides use the follower's assigned can_server_port, so local and remote port are always identical.
+  opendut.model.util.Port port = 3;
+  // Deprecated: always equal to `port` (field 3). Kept so that a new CARL can still be decoded by an
+  // old EDGAR whose generated conversion uses extract!(value.local_port). Remove after one release cycle.
+  opendut.model.util.Port local_port = 4 [deprecated = true];
   opendut.model.util.NetworkInterfaceName can_interface_name = 5;
   bool local_is_server = 6;
   // Additional configuration parameters

--- a/opendut-model/src/peer/configuration/parameter.rs
+++ b/opendut-model/src/peer/configuration/parameter.rs
@@ -64,26 +64,28 @@ impl Display for RemotePeerConnectionCheck {
 }
 
 
-/// The following struct defines the relevant information to form a CAN connection over TCP using cannelloni
+/// The relevant information to form a CAN tunnel between the leader and a follower peer.
 ///
-/// Cannelloni is expected to be replaced with open1722, see https://github.com/eclipse-opendut/opendut/issues/306
-/// Leader peer (PEER_LEADER_IP):
-///     connection to Peer A: acf-can-bridge --canif <PEER_LEADER_CAN_BRIDGE>     -u -p <PEER_FOLLOWER_A_LOCAL_PORT>  --dst-nw-addr <PEER_FOLLOWER_A_IP:PEER_FOLLOWER_A_REMOTE_PORT>
-///     connection to Peer B: acf-can-bridge --canif <PEER_LEADER_CAN_BRIDGE>     -u -p <PEER_FOLLOWER_B_LOCAL_PORT>  --dst-nw-addr <PEER_FOLLOWER_B_IP:PEER_FOLLOWER_B_REMOTE_PORT>
-/// Follower Peer A (PEER_FOLLOWER_A_IP): acf-can-bridge --canif <PEER_FOLLOWER_A_CAN_BRIDGE> -u -p <PEER_FOLLOWER_A_REMOTE_PORT> --dst-nw-addr <PEER_LEADER_IP:PEER_FOLLOWER_A_LOCAL_PORT>
-/// Follower Peer B (PEER_FOLLOWER_B_IP): acf-can-bridge --canif <PEER_FOLLOWER_B_CAN_BRIDGE> -u -p <PEER_FOLLOWER_B_REMOTE_PORT> --dst-nw-addr <PEER_LEADER_IP:PEER_FOLLOWER_B_LOCAL_PORT>
+/// Each follower is assigned a unique `port` (see `PeerClusterAssignment::can_server_port`).
+/// Both sides of the tunnel use this same port number:
+///   - The leader (server) binds/listens on `port` for this follower.
+///   - The follower (client) connects to the leader's IP on `port`.
 ///
-/// Ideally local port and remote port are the same, these were added to ensure we can handle it otherwise.
+/// This maps directly to both cannelloni (current) and acf-can-bridge / open1722 (future):
+///   Leader:   cannelloni -S s -l <port> -R <follower_ip>  (or acf-can-bridge -u -p <port> --dst-nw-addr <follower_ip:port>)
+///   Follower: cannelloni -S c -r <port> -R <leader_ip>   (or acf-can-bridge -u -p <port> --dst-nw-addr <leader_ip:port>)
+///
+/// See also: https://github.com/eclipse-opendut/opendut/issues/306
 #[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize)]
 pub struct CanConnection {
     pub remote_peer_id: PeerId,
     pub remote_ip: IpAddr,
-    /// Local listening port for server.
-    pub local_port: Port,
-    /// Remote port to connect to.
-    pub remote_port: Port,
+    /// The port for this CAN tunnel.
+    /// The leader listens on it; the follower connects to it.
+    /// Always equal to the follower peer's `PeerClusterAssignment::can_server_port`.
+    pub port: Port,
     pub can_interface_name: NetworkInterfaceName,
-    /// starts a CAN server for other peers to connect to
+    /// `true` on the leader (acts as server); `false` on the follower (acts as client).
     pub local_is_server: bool,
     pub buffer_timeout_microseconds: u64,
 }

--- a/opendut-model/src/peer/configuration/parameter.rs
+++ b/opendut-model/src/peer/configuration/parameter.rs
@@ -63,14 +63,25 @@ impl Display for RemotePeerConnectionCheck {
     }
 }
 
+
+/// The following struct defines the relevant information to form a CAN connection over TCP using cannelloni
+///
+/// Cannelloni is expected to be replaced with open1722, see https://github.com/eclipse-opendut/opendut/issues/306
+/// Leader peer (PEER_LEADER_IP):
+///     connection to Peer A: acf-can-bridge --canif <PEER_LEADER_CAN_BRIDGE>     -u -p <PEER_FOLLOWER_A_LOCAL_PORT>  --dst-nw-addr <PEER_FOLLOWER_A_IP:PEER_FOLLOWER_A_REMOTE_PORT>
+///     connection to Peer B: acf-can-bridge --canif <PEER_LEADER_CAN_BRIDGE>     -u -p <PEER_FOLLOWER_B_LOCAL_PORT>  --dst-nw-addr <PEER_FOLLOWER_B_IP:PEER_FOLLOWER_B_REMOTE_PORT>
+/// Follower Peer A (PEER_FOLLOWER_A_IP): acf-can-bridge --canif <PEER_FOLLOWER_A_CAN_BRIDGE> -u -p <PEER_FOLLOWER_A_REMOTE_PORT> --dst-nw-addr <PEER_LEADER_IP:PEER_FOLLOWER_A_LOCAL_PORT>
+/// Follower Peer B (PEER_FOLLOWER_B_IP): acf-can-bridge --canif <PEER_FOLLOWER_B_CAN_BRIDGE> -u -p <PEER_FOLLOWER_B_REMOTE_PORT> --dst-nw-addr <PEER_LEADER_IP:PEER_FOLLOWER_B_LOCAL_PORT>
+///
+/// Ideally local port and remote port are the same, these were added to ensure we can handle it otherwise.
 #[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize)]
 pub struct CanConnection {
     pub remote_peer_id: PeerId,
     pub remote_ip: IpAddr,
-    /// Remote port to connect to
-    pub remote_port: Port,
-    /// Local listening port for server
+    /// Local listening port for server.
     pub local_port: Port,
+    /// Remote port to connect to.
+    pub remote_port: Port,
     pub can_interface_name: NetworkInterfaceName,
     /// starts a CAN server for other peers to connect to
     pub local_is_server: bool,

--- a/opendut-model/src/peer/configuration/parameter.rs
+++ b/opendut-model/src/peer/configuration/parameter.rs
@@ -67,7 +67,9 @@ impl Display for RemotePeerConnectionCheck {
 pub struct CanConnection {
     pub remote_peer_id: PeerId,
     pub remote_ip: IpAddr,
+    /// Remote port to connect to
     pub remote_port: Port,
+    /// Local listening port for server
     pub local_port: Port,
     pub can_interface_name: NetworkInterfaceName,
     /// starts a CAN server for other peers to connect to

--- a/opendut-model/src/proto/peer/configuration/parameter.rs
+++ b/opendut-model/src/proto/peer/configuration/parameter.rs
@@ -138,8 +138,12 @@ conversion! {
         Proto {
             remote_peer_id: Some(value.remote_peer_id.into()),
             remote_ip: Some(value.remote_ip.into()),
-            remote_port: Some(value.remote_port.into()),
-            local_port: Some(value.local_port.into()),
+            port: Some(value.port.into()),
+            // Deprecated field kept for backwards compatibility with old EDGAR instances that still use
+            // extract!(value.local_port) in their generated conversion. Always equal to `port`.
+            // TODO: remove after one release cycle once all EDGAR instances run >= this version.
+            #[allow(deprecated)]
+            local_port: Some(value.port.into()),
             can_interface_name: Some(value.can_interface_name.into()),
             local_is_server: value.local_is_server,
             buffer_timeout_microseconds: value.buffer_timeout_microseconds,
@@ -149,15 +153,14 @@ conversion! {
     fn try_from(value: Proto) -> ConversionResult<Model> {
         let remote_peer_id = extract!(value.remote_peer_id)?.try_into()?;
         let remote_ip = extract!(value.remote_ip)?.try_into()?;
-        let remote_port = extract!(value.remote_port)?.try_into()?;
-        let local_port = extract!(value.local_port)?.try_into()?;
+        let port = extract!(value.port)?.try_into()?;
+        // `local_port` (field 4) is deprecated and always equal to `port`; intentionally ignored here.
         let can_interface_name = extract!(value.can_interface_name)?.try_into()?;
 
         Ok(Model {
             remote_peer_id,
             remote_ip,
-            remote_port,
-            local_port,
+            port,
             can_interface_name,
             local_is_server: value.local_is_server,
             buffer_timeout_microseconds: value.buffer_timeout_microseconds,


### PR DESCRIPTION
was still present after #518.

This PR includes:
- Fix CI to fail when CAN connection does not work in `cargo testenv cluster start`
- Fix port mismatch in CAN connection, used by EDGAR, and peer configuration in CARL
- Deprecate double port definition for the sake of simplicity aka KISS principle


Background can be investigated in the details:

<details>
The following shows the current problem:

```
# Clients are connecting to the wrong port!
vagrant@opendut-vm:/vagrant$ ps axu | grep cannelloni
root       66881  0.0  0.0 154228  3704 ?        Sl   07:46   0:00 cannelloni -I br-vcan-opendut -S c -t 100 -R 100.77.188.219 -r 10004
root       66923  0.0  0.0 154228  3652 ?        Sl   07:46   0:00 cannelloni -I br-vcan-opendut -S c -t 100 -R 100.77.188.219 -r 10004
root       66962  0.0  0.0 154228  3644 ?        Sl   07:46   0:00 cannelloni -I br-vcan-opendut -S c -t 100 -R 100.77.188.219 -r 10004
root       67088  0.0  0.0 154228  3464 ?        Sl   07:46   0:00 cannelloni -I br-vcan-opendut -S c -t 100 -R 100.77.188.219 -r 10004
# Servers running at the leader are listening to respective ports
root       67317  0.0  0.0 154228  3464 ?        Sl   07:46   0:00 cannelloni -I br-vcan-opendut -S s -t 100 -R 100.77.44.254 -l 10000
root       67318  0.0  0.0 154228  3616 ?        Sl   07:46   0:00 cannelloni -I br-vcan-opendut -S s -t 100 -R 100.77.249.100 -l 10001
root       67341  0.0  0.0 154228  3528 ?        Sl   07:46   0:00 cannelloni -I br-vcan-opendut -S s -t 100 -R 100.77.88.121 -l 10003
root       67344  0.0  0.0 154228  3652 ?        Sl   07:46   0:00 cannelloni -I br-vcan-opendut -S s -t 100 -R 100.77.104.76 -l 10002
```
- Test with `candump`, both vcan devices are in the cluster configured
```
# listener
candump opendut-vcan0
candump opendut-vcan1
# sender
cansend opendut-vcan0 01a#01020304
cansend opendut-vcan1 01a#01020304
```
- Make script fail `.ci/deploy/testenv/edgar/scripts/pingall_can.py`:
```
    # Make this script exit with a code indicating error if not all ping messages went through
    if loss_percent > 0:
        sys.exit(1)
```
</details>