### PR TITLE
Changed type of `ViperSourceDescriptor::name` to `ViperTestSuiteIdentifier`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4540,6 +4540,7 @@ dependencies = [
  "opendut-auth",
  "opendut-model",
  "opendut-util",
+ "opendut-viper-rt",
  "prost",
  "protobuf-src",
  "repo_path",

--- a/opendut-carl/opendut-carl-api/Cargo.toml
+++ b/opendut-carl/opendut-carl-api/Cargo.toml
@@ -30,12 +30,16 @@ wasm-client = [
     "dep:tonic-web-wasm-client",
     "dep:tracing",
 ]
-viper = ["opendut-model/viper"]
+viper = [
+    "dep:opendut-viper-rt",
+    "opendut-model/viper",
+]
 
 [dependencies]
 opendut-auth = { workspace = true, optional = true }
 opendut-model = { workspace = true }
 opendut-util = { workspace = true, features = ["future", "proto"] }
+opendut-viper-rt = { workspace = true, features = ["proto"], optional = true }
 
 anyhow = { workspace = true, optional = true }
 config = { workspace = true, optional = true }

--- a/opendut-carl/opendut-carl-api/proto/opendut/carl/services/test-manager.proto
+++ b/opendut-carl/opendut-carl-api/proto/opendut/carl/services/test-manager.proto
@@ -8,6 +8,7 @@ import "opendut/model/viper/test.proto";
 import "opendut/model/viper_test_id.proto";
 import "opendut/model/viper/source.proto";
 import "opendut/model/viper/suite.proto";
+import "opendut/viper/rt/test_suite.proto";
 
 service TestManager {
   rpc StoreViperSourceDescriptor(StoreViperSourceDescriptorRequest) returns (StoreViperSourceDescriptorResponse) {}
@@ -59,7 +60,7 @@ message StoreViperSourceDescriptorFailure {
 
 message StoreViperSourceDescriptorFailureInternal {
   opendut.model.viper.ViperSourceId source_id = 1;
-  opendut.model.viper.ViperSourceName source_name = 2;
+  opendut.viper.rt.test_suite.ViperTestSuiteIdentifier source_name = 2;
   string cause = 3;
 }
 
@@ -96,7 +97,7 @@ message DeleteViperSourceDescriptorFailureSourceNotFound {
 
 message DeleteViperSourceDescriptorFailureInternal {
   opendut.model.viper.ViperSourceId source_id = 1;
-  optional opendut.model.viper.ViperSourceName source_name = 2;
+  optional opendut.viper.rt.test_suite.ViperTestSuiteIdentifier source_name = 2;
   string cause = 3;
 }
 
@@ -206,12 +207,12 @@ message GetViperTestSuiteParametersFailureSourceNotFound {
 
 message GetViperTestSuiteParametersFailureCompilation {
   opendut.model.viper.ViperSourceId source_id = 1;
-  opendut.model.viper.ViperSourceName source_name = 2;
+  opendut.viper.rt.test_suite.ViperTestSuiteIdentifier source_name = 2;
 }
 
 message GetViperTestSuiteParametersFailureViperRuntime {
   opendut.model.viper.ViperSourceId source_id = 1;
-  opendut.model.viper.ViperSourceName source_name = 2;
+  opendut.viper.rt.test_suite.ViperTestSuiteIdentifier source_name = 2;
 }
 
 message GetViperTestSuiteParametersFailureInternal {

--- a/opendut-carl/opendut-carl-api/src/carl/viper.rs
+++ b/opendut-carl/opendut-carl-api/src/carl/viper.rs
@@ -1,7 +1,7 @@
 #[cfg(any(feature = "client", feature = "wasm-client"))]
 pub use client::*;
 
-use opendut_model::viper::{ViperTestId, ViperSourceId, ViperSourceName, ViperRunId};
+use opendut_model::viper::{ViperTestId, ViperSourceId, ViperRunId, ViperTestSuiteIdentifier};
 use opendut_model::format::{format_id_with_name, format_id_with_optional_name};
 
 
@@ -14,7 +14,7 @@ pub enum StoreViperSourceDescriptorError {
     #[error("VIPER source {source} could not be created, due to internal errors:\n  {cause}", source=format_id_with_name(source_id, source_name))]
     Internal {
         source_id: ViperSourceId,
-        source_name: ViperSourceName,
+        source_name: ViperTestSuiteIdentifier,
         cause: String
     }
 }
@@ -33,7 +33,7 @@ pub enum DeleteViperSourceDescriptorError {
     #[error("VIPER source {source} deleted with internal errors:\n  {cause}", source=format_id_with_optional_name(source_id, source_name))]
     Internal {
         source_id: ViperSourceId,
-        source_name: Option<ViperSourceName>,
+        source_name: Option<ViperTestSuiteIdentifier>,
         cause: String,
     }
 }
@@ -73,12 +73,12 @@ pub enum GetViperTestSuiteParametersError {
     #[error("Compilation failed while getting VIPER test suite descriptor for source {source_name} <{source_id}>.")]
     Compilation {
         source_id: ViperSourceId,
-        source_name: ViperSourceName,
+        source_name: ViperTestSuiteIdentifier,
     },
     #[error("Error while initializing VIPER runtime for VIPER test source {source_name} with the ID <{source_id}>.")]
     ViperRuntime {
         source_id: ViperSourceId,
-        source_name: ViperSourceName,
+        source_name: ViperTestSuiteIdentifier,
     },
     #[error("An internal error occurred while fetching the VIPER test suite descriptor for source <{source_id}>:\n  {cause}")]
     Internal {

--- a/opendut-carl/opendut-carl-api/src/proto/services/test_manager.rs
+++ b/opendut-carl/opendut-carl-api/src/proto/services/test_manager.rs
@@ -1,4 +1,4 @@
-use opendut_model::viper::ViperSourceName;
+use opendut_model::viper::ViperTestSuiteIdentifier;
 use opendut_util::conversion;
 use opendut_util::proto::ConversionResult;
 
@@ -86,7 +86,7 @@ conversion! {
             }
             delete_viper_source_descriptor_failure::Error::Internal(error) => {
                 let source_id = extract!(error.source_id)?.try_into()?;
-                let source_name: Option<ViperSourceName> = error.source_name
+                let source_name: Option<ViperTestSuiteIdentifier> = error.source_name
                     .map(TryInto::try_into)
                     .transpose()?;
                 let cause = error.cause;

--- a/opendut-carl/src/manager/mod.rs
+++ b/opendut-carl/src/manager/mod.rs
@@ -128,7 +128,7 @@ pub(crate) mod testing {
     #[cfg(feature = "viper")]
     mod viper {
         use super::*;
-        use opendut_model::viper::{ViperRunDeployment, ViperRunId, ViperSourceDescriptor, ViperSourceId, ViperSourceKind, ViperSourceName, ViperTestRunDescriptor, ViperTestId, ViperTestName, ViperParameterName, ViperBindingValue};
+        use opendut_model::viper::{ViperRunDeployment, ViperRunId, ViperSourceDescriptor, ViperSourceId, ViperSourceKind, ViperTestSuiteIdentifier, ViperTestRunDescriptor, ViperTestId, ViperTestName, ViperParameterName, ViperBindingValue};
         use url::Url;
         use std::collections::HashMap;
 
@@ -141,7 +141,7 @@ pub(crate) mod testing {
                 let source_id = ViperSourceId::random();
                 let source_descriptor = ViperSourceDescriptor {
                     id: source_id,
-                    name: ViperSourceName::try_from(format!("ViperSource-{source_id}"))?,
+                    name: ViperTestSuiteIdentifier::try_from(format!("ViperSource-{source_id}"))?,
                     url: Url::parse("http://localhost")?,
                     kind: ViperSourceKind::Http,
                 };

--- a/opendut-carl/src/manager/test_manager/delete_viper_source_descriptor.rs
+++ b/opendut-carl/src/manager/test_manager/delete_viper_source_descriptor.rs
@@ -1,6 +1,6 @@
-use opendut_model::{format::format_id_with_optional_name, viper::{ViperSourceDescriptor, ViperSourceId, ViperSourceName, ViperTestRunDescriptor, ViperTestId}};
+use opendut_model::{format::format_id_with_optional_name, viper::{ViperSourceDescriptor, ViperSourceId, ViperTestRunDescriptor, ViperTestId}};
 use tracing::debug;
-
+use opendut_model::viper::ViperTestSuiteIdentifier;
 use crate::resource::{api::resources::Resources, persistence::error::PersistenceError, storage::ResourcesStorageApi};
 
 
@@ -46,7 +46,7 @@ pub enum DeleteViperSourceDescriptorError {
     #[error("Error when accessing persistence while deleting VIPER source descriptor for source {source}", source=format_id_with_optional_name(source_id, source_name))]
     Persistence {
         source_id: ViperSourceId,
-        source_name: Option<ViperSourceName>,
+        source_name: Option<ViperTestSuiteIdentifier>,
         #[source] cause: PersistenceError,
     },
 }

--- a/opendut-carl/src/manager/test_manager/get_viper_test_suite_parameters.rs
+++ b/opendut-carl/src/manager/test_manager/get_viper_test_suite_parameters.rs
@@ -1,6 +1,5 @@
 use tracing::debug;
-use opendut_model::viper::{ViperSourceDescriptor, ViperSourceId, ViperSourceName, ViperTestSuiteParameters};
-use opendut_viper_rt::common::TestSuiteIdentifier;
+use opendut_model::viper::{ViperSourceDescriptor, ViperSourceId, ViperTestSuiteIdentifier, ViperTestSuiteParameters};
 use opendut_viper_rt::compile::{IdentifierFilter};
 use opendut_viper_rt::events::emitter;
 use opendut_viper_rt::source::Source;
@@ -25,12 +24,9 @@ impl Resources<'_> {
 
 
 async fn discover_suite(source: ViperSourceDescriptor) -> Result<Option<ViperTestSuiteParameters>, GetViperTestSuiteParametersError>  {
-    let ViperSourceDescriptor { id: source_id, name: source_name, url, .. } = source;
+    let ViperSourceDescriptor { id: source_id, name: test_suite_identifier, url, .. } = source;
 
-    let test_suite_identifier = TestSuiteIdentifier::try_from(source_name.value())
-        .expect("Conversion of source name to TestSuiteIdentifier failed."); //FIXME ViperSourceDescriptor should use TestSuiteIdentifier directly, making this conversion obsolete
-
-    let source = Source::from_url(test_suite_identifier, url);
+    let source = Source::from_url(Clone::clone(&test_suite_identifier), url);
 
     debug!("Calling VIPER to compile source into test suite.");
 
@@ -41,10 +37,10 @@ async fn discover_suite(source: ViperSourceDescriptor) -> Result<Option<ViperTes
             let viper_runtime = ViperRuntime::new(ViperOptions {
                 source_loaders: vec![Box::new(HttpSourceLoader)],
                 ..Default::default()
-            }).map_err(|_| GetViperTestSuiteParametersError::ViperRuntime { source_id, source_name: source_name.clone() })?;
+            }).map_err(|_| GetViperTestSuiteParametersError::ViperRuntime { source_id, source_name: Clone::clone(&test_suite_identifier) })?;
 
             let compilation = viper_runtime.compile(&source, &mut emitter::drain(), &IdentifierFilter::default()).await
-                .map_err(|_| GetViperTestSuiteParametersError::Compilation { source_id, source_name: source_name.clone() })?;
+                .map_err(|_| GetViperTestSuiteParametersError::Compilation { source_id, source_name: Clone::clone(&test_suite_identifier) })?;
 
             Ok((compilation.identifier().to_owned(), compilation.parameters().to_owned()))
         })
@@ -67,7 +63,7 @@ pub enum GetViperTestSuiteParametersError {
     #[error("Compilation failed while getting VIPER test suite descriptor for source {source_name} with ID <{source_id}>.")]
     Compilation {
         source_id: ViperSourceId,
-        source_name: ViperSourceName,
+        source_name: ViperTestSuiteIdentifier,
     },
     #[error("Async task failed when {when} while getting VIPER test suite descriptor for source <{source_id}>.")]
     TaskJoin {
@@ -78,7 +74,7 @@ pub enum GetViperTestSuiteParametersError {
     #[error("Error while initializing VIPER runtime for VIPER test source {source_name} with ID <{source_id}>.")]
     ViperRuntime {
         source_id: ViperSourceId,
-        source_name: ViperSourceName,
+        source_name: ViperTestSuiteIdentifier,
     },
     #[error("Error when accessing persistence while getting VIPER test suite descriptor for source <{source_id}>")]
     Persistence {

--- a/opendut-lea/src/viper_sources/configurator/mod.rs
+++ b/opendut-lea/src/viper_sources/configurator/mod.rs
@@ -56,7 +56,7 @@ pub fn ViperSourceConfigurator() -> impl IntoView {
             async move {
                 if let Ok(configuration) = carl.viper.get_viper_source_descriptor(viper_source_id).await {
                     viper_source_configuration.update(|user_configuration| {
-                        user_configuration.name = UserInputValue::Right(configuration.name.value().to_owned());
+                        user_configuration.name = UserInputValue::Right(configuration.name.to_string());
                         user_configuration.url = UserInputValue::Right(configuration.url.to_string());
                         user_configuration.kind = UserInputValue::Right(match configuration.kind {
                             opendut_model::viper::ViperSourceKind::Git => String::from("Git"),

--- a/opendut-lea/src/viper_sources/configurator/tabs/general/name_input.rs
+++ b/opendut-lea/src/viper_sources/configurator/tabs/general/name_input.rs
@@ -1,6 +1,5 @@
 use leptos::prelude::*;
-
-use opendut_model::viper::{IllegalViperSourceName, ViperSourceName};
+use opendut_model::viper::{InvalidViperTestSuiteIdentifierErrorKind, ViperTestSuiteIdentifier};
 use crate::components::{UserInput, UserInputValue};
 use crate::viper_sources::configurator::types::UserViperSourceConfiguration;
 
@@ -17,30 +16,21 @@ pub fn ViperSourceNameInput(viper_source_configuration: RwSignal<UserViperSource
     );
 
     let validator = |input: String| {
-        match ViperSourceName::try_from(input.clone()) {
+        match ViperTestSuiteIdentifier::try_from(input.clone()) {
             Ok(_) => {
                 UserInputValue::Right(input)
             }
             Err(cause) => {
-                match cause {
-                    IllegalViperSourceName::TooShort { expected, actual, value } => {
-                        if actual > 0 {
-                            UserInputValue::Both(format!("A VIPER source name must be at least {expected} characters long."), value)
-                        }
-                        else {
-                            UserInputValue::Both("Enter a VIPER viper source name.".to_string(), value)
-                        }
+                match cause.kind {
+                    InvalidViperTestSuiteIdentifierErrorKind::Empty => {
+                        UserInputValue::Both("Enter a VIPER source name.".to_string(), cause.value)
                     }
-                    IllegalViperSourceName::TooLong { expected, value, .. } => {
-                        UserInputValue::Both(format!("A VIPER source name must be at most {expected} characters long."), value)
-                    },
-                    IllegalViperSourceName::InvalidStartEndCharacter { value } => {
-                        UserInputValue::Both("The VIPER source name starts/ends with an invalid character. \
-                        Valid characters are a-z, A-Z and 0-9.".to_string(), value)
+                    InvalidViperTestSuiteIdentifierErrorKind::IllegalTestSuiteIdentifierCharacter { character } => {
+                        UserInputValue::Both(format!("The VIPER source name contains an invalid character: '{character}'"), cause.value)
                     }
-                    IllegalViperSourceName::InvalidCharacter { value } => {
-                        UserInputValue::Both("The VIPER source name contains invalid characters.".to_string(), value)
-                    },
+                    _ => {
+                        UserInputValue::Both("The VIPER source name is invalid.".to_string(), cause.value)
+                    }
                 }
             }
         }

--- a/opendut-lea/src/viper_sources/configurator/types/mod.rs
+++ b/opendut-lea/src/viper_sources/configurator/types/mod.rs
@@ -2,7 +2,7 @@ pub mod validation;
 
 use url::Url;
 use opendut_lea_components::UserInputValue;
-use opendut_model::viper::{ViperSourceDescriptor, ViperSourceId, ViperSourceKind, ViperSourceName};
+use opendut_model::viper::{ViperSourceDescriptor, ViperSourceId, ViperSourceKind, ViperTestSuiteIdentifier};
 
 #[derive(thiserror::Error, Clone, Debug)]
 #[allow(clippy::enum_variant_names)]
@@ -32,7 +32,7 @@ impl TryFrom<UserViperSourceConfiguration> for ViperSourceDescriptor {
             .name
             .right_ok_or(ViperSourceMisconfigurationError::InvalidSourceName)
             .and_then(|name| {
-                ViperSourceName::try_from(name)
+                ViperTestSuiteIdentifier::try_from(name)
                     .map_err(|_| ViperSourceMisconfigurationError::InvalidSourceName)
             })?;
 

--- a/opendut-lea/src/viper_sources/overview/mod.rs
+++ b/opendut-lea/src/viper_sources/overview/mod.rs
@@ -27,8 +27,8 @@ pub fn ViperSourcesOverview() -> impl IntoView {
                     .expect("Failed to request the list of VIPER sources");
 
                 viper_sources.sort_by(|viper_source_a, viper_source_b| {
-                    viper_source_a.name.value().to_lowercase()
-                        .cmp(&viper_source_b.name.value().to_lowercase())
+                    viper_source_a.name.to_string().to_lowercase()
+                        .cmp(&viper_source_b.name.to_string().to_lowercase())
                 });
 
                 viper_sources

--- a/opendut-lea/src/viper_tests/configurator/tabs/parameters/mod.rs
+++ b/opendut-lea/src/viper_tests/configurator/tabs/parameters/mod.rs
@@ -117,7 +117,7 @@ pub fn ParametersTab(
                             }.into_any()
                         },
                         GetViperTestSuiteParametersError::Compilation { source_id, source_name } => {
-                            let source_name = source_name.value();
+                            let source_name = source_name.to_string();
                             let source_href = create_source_href(&source_id);
                             view! {
                                 <p class="help has-text-danger">
@@ -127,7 +127,7 @@ pub fn ParametersTab(
                             }.into_any()
                         },
                         GetViperTestSuiteParametersError::ViperRuntime { source_id, source_name } => {
-                            let source_name = source_name.value();
+                            let source_name = source_name.to_string();
                             let source_href = create_source_href(&source_id);
                             view! {
                                 <p class="help has-text-danger">

--- a/opendut-lea/src/viper_tests/configurator/tabs/source/source_selector.rs
+++ b/opendut-lea/src/viper_tests/configurator/tabs/source/source_selector.rs
@@ -33,8 +33,8 @@ pub fn ViperTestSourceSelector(viper_test_run_descriptor: RwSignal<UserViperTest
     let viper_sources = Signal::derive(move || {
         if let Some(mut viper_sources) = viper_sources.get() {
             viper_sources.sort_by(|viper_source_a, viper_source_b| {
-                viper_source_a.name.value().to_lowercase()
-                    .cmp(&viper_source_b.name.value().to_lowercase())
+                viper_source_a.name.to_string().to_lowercase()
+                    .cmp(&viper_source_b.name.to_string().to_lowercase())
             });
 
             let rows = viper_sources.iter().map(|viper_source_descriptor| {

--- a/opendut-model/proto/opendut/model/viper/source.proto
+++ b/opendut-model/proto/opendut/model/viper/source.proto
@@ -4,11 +4,12 @@ package opendut.model.viper;
 
 import "opendut/model/util/net.proto";
 import "opendut/model/util/uuid.proto";
+import "opendut/viper/rt/test_suite.proto";
 
 
 message ViperSourceDescriptor {
   ViperSourceId id = 1;
-  ViperSourceName name = 2;
+  opendut.viper.rt.test_suite.ViperTestSuiteIdentifier name = 2;
   opendut.model.util.Url url = 3;
   oneof kind {
     ViperSourceKindGit git = 4;
@@ -22,8 +23,4 @@ message ViperSourceKindHttp {}
 
 message ViperSourceId {
   opendut.model.util.Uuid uuid = 1;
-}
-
-message ViperSourceName {
-  string value = 1;
 }

--- a/opendut-model/src/proto/viper.rs
+++ b/opendut-model/src/proto/viper.rs
@@ -28,21 +28,6 @@ mod conversions {
         }
     }
 
-    conversion! {
-        type Model = crate::viper::ViperSourceName;
-        type Proto = ViperSourceName;
-
-        fn from(value: Model) -> Proto {
-            Proto {
-                value: value.0
-            }
-        }
-
-        fn try_from(value: Proto) -> ConversionResult<Model> {
-            Model::try_from(value.value)
-                .map_err(|cause| ErrorBuilder::message(cause.to_string()))
-        }
-    }
 
     conversion! {
         type Model = crate::viper::ViperSourceDescriptor;

--- a/opendut-model/src/viper/mod.rs
+++ b/opendut-model/src/viper/mod.rs
@@ -8,6 +8,8 @@ pub use test::*;
 pub use source::*;
 pub use suite::*;
 pub use opendut_viper_rt::common::TestSuiteIdentifier as ViperTestSuiteIdentifier;
+pub use opendut_viper_rt::common::InvalidIdentifierError as InvalidViperTestSuiteIdentifierError;
+pub use opendut_viper_rt::common::InvalidIdentifierErrorKind as InvalidViperTestSuiteIdentifierErrorKind;
 pub use opendut_viper_rt::compile::InvalidTextParameterValueError;
 pub use opendut_viper_rt::compile::InvalidTextParameterValueErrorKind;
 pub use opendut_viper_rt::compile::InvalidNumberParameterValueError;

--- a/opendut-model/src/viper/source.rs
+++ b/opendut-model/src/viper/source.rs
@@ -1,119 +1,20 @@
-use std::fmt;
-use std::ops::Not;
-use std::str::FromStr;
-use serde::{Deserialize, Serialize};
 use url::Url;
 use crate::create_id_type;
-
+use crate::viper::ViperTestSuiteIdentifier;
 
 create_id_type!(ViperSourceId);
 
 
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
-pub struct ViperSourceName(pub(crate) String);
-
-impl ViperSourceName {
-    pub const MIN_LENGTH: usize = 4;
-    pub const MAX_LENGTH: usize = 64;
-
-    pub fn value(&self) -> &str {
-        &self.0
-    }
-}
-
-#[derive(thiserror::Error, Clone, Debug)]
-pub enum IllegalViperSourceName {
-    #[error(
-        "Test suite source name '{value}' is too short. Expected at least {expected} characters, got {actual}."
-    )]
-    TooShort {
-        value: String,
-        expected: usize,
-        actual: usize,
-    },
-    #[error(
-        "Test suite source name '{value}' is too long. Expected at most {expected} characters, got {actual}."
-    )]
-    TooLong {
-        value: String,
-        expected: usize,
-        actual: usize,
-    },
-    #[error("Test suite source name '{value}' contains invalid characters.")]
-    InvalidCharacter { value: String },
-    #[error("Test suite source name '{value}' contains invalid start or end characters.")]
-    InvalidStartEndCharacter { value: String },
-}
-
-impl From<ViperSourceName> for String {
-    fn from(value: ViperSourceName) -> Self {
-        value.0
-    }
-}
-
-impl TryFrom<String> for ViperSourceName {
-    type Error = IllegalViperSourceName;
-
-    fn try_from(value: String) -> Result<Self, Self::Error> {
-        let length = value.len();
-        if length < Self::MIN_LENGTH {
-            Err(IllegalViperSourceName::TooShort {
-                value,
-                expected: Self::MIN_LENGTH,
-                actual: length,
-            })
-        } else if length > Self::MAX_LENGTH {
-            Err(IllegalViperSourceName::TooLong {
-                value,
-                expected: Self::MAX_LENGTH,
-                actual: length,
-            })
-        } else if crate::util::invalid_start_and_end_of_a_name(&value) {
-            Err(IllegalViperSourceName::InvalidStartEndCharacter { value })
-        } else if value
-            .chars()
-            .any(|c| crate::util::valid_characters_in_name(&c).not())
-        {
-            Err(IllegalViperSourceName::InvalidCharacter { value })
-        } else {
-            Ok(Self(value))
-        }
-    }
-}
-
-impl TryFrom<&str> for ViperSourceName {
-    type Error = IllegalViperSourceName;
-
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
-        ViperSourceName::try_from(value.to_owned())
-    }
-}
-
-impl fmt::Display for ViperSourceName {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.0)
-    }
-}
-
-impl FromStr for ViperSourceName {
-    type Err = IllegalViperSourceName;
-
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
-        Self::try_from(value)
-    }
-}
-
-
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum ViperSourceKind {
     Git,
     Http,
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ViperSourceDescriptor {
     pub id: ViperSourceId,
-    pub name: ViperSourceName,
+    pub name: ViperTestSuiteIdentifier,
     pub url: Url,
     pub kind: ViperSourceKind,
 }

--- a/opendut-viper/viper-rt/src/lib.rs
+++ b/opendut-viper/viper-rt/src/lib.rs
@@ -117,6 +117,10 @@ pub mod common {
         TestCaseIdentifier,
         TestSuiteIdentifier,
     };
+    pub use crate::runtime::types::naming::error::{
+        InvalidIdentifierError,
+        InvalidIdentifierErrorKind,
+    };
     pub mod error {
         pub use crate::runtime::types::py::error::{
             PythonReflectionError,

--- a/opendut-viper/viper-rt/src/runtime/types/naming/mod.rs
+++ b/opendut-viper/viper-rt/src/runtime/types/naming/mod.rs
@@ -54,7 +54,7 @@ pub trait Identifier : Debug + Display {
 ///     Ok(())
 /// }
 /// ```
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Eq)]
 pub struct TestSuiteIdentifier {
     value: String
 }


### PR DESCRIPTION
## Discussion
The type-change of `ViperSourceDescriptor::name` (`ViperSourceName` → `ViperTestSuiteIdentifier`) also affected the validation.
- **Previous:** Only names between 4-64 chars were allowed and InvalidStartEndCharacters exists
- **Now:** The name must not be empty, but the length can be any amount of characters (1-∞)
- **Both:** Invalid characters are handled in both versions

### How to continue?
- Leave it like that (→ can be merged now)
- Adapt the validation in VIPER (maybe complicated for the VIPER-CLI where the `TestSuiteIdentifier` represents the file name)
- Check length of user input only in LEA