### PR TITLE
Add PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,10 @@
+
+
+## Checklist
+<!--
+Mark all that apply. Not all checkboxes need to be checked.
+-->
+
+- [ ] I have added or updated automated tests.
+- [ ] I have tested my changes manually.
+- [ ] I have added or updated documentation.


### PR DESCRIPTION
Add a simple pull request checklist to help remind contributors of good code standards, they may want to apply and so code reviewers can quickly know, in case something wasn't done that they might deem sensible.

Inspired by the PR template of [CDA](https://github.com/eclipse-opensovd/classic-diagnostic-adapter/).

Will need to be merged onto `main` following this merge, to actually make it active, according to the documentation: https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository