### PR TITLE
LEA: Disable Deploy-Toggle, if cluster can't be deployed

### DIFF
--- a/opendut-lea/opendut-lea-components/src/health.rs
+++ b/opendut-lea/opendut-lea-components/src/health.rs
@@ -1,5 +1,5 @@
 use leptos::prelude::*;
-use crate::tooltip::Tooltip;
+use crate::tooltip::{Tooltip, TooltipDirection};
 
 pub struct State {
     pub kind: StateKind,
@@ -15,7 +15,10 @@ pub enum StateKind {
 }
 
 #[component]
-pub fn Health(state: Signal<State>) -> impl IntoView {
+pub fn Health(
+    state: Signal<State>,
+    #[prop(optional)] tooltip_direction: TooltipDirection,
+) -> impl IntoView {
 
     let health_class = move || state.with(|state| {
         match state.kind {
@@ -39,7 +42,7 @@ pub fn Health(state: Signal<State>) -> impl IntoView {
 
     view! {
         <div class="is-flex is-justify-content-center">
-            <Tooltip text=tooltip_content>
+            <Tooltip text=tooltip_content direction=tooltip_direction>
                 <div class=health_class />
             </Tooltip>
         </div>

--- a/opendut-lea/opendut-lea-components/src/health.rs
+++ b/opendut-lea/opendut-lea-components/src/health.rs
@@ -17,7 +17,7 @@ pub enum StateKind {
 #[component]
 pub fn Health(state: Signal<State>) -> impl IntoView {
 
-    let classes = move || state.with(|state| {
+    let health_class = move || state.with(|state| {
         match state.kind {
             StateKind::Unknown => "health-light",
             StateKind::Red => "health-light red",
@@ -26,14 +26,21 @@ pub fn Health(state: Signal<State>) -> impl IntoView {
         }
     });
 
-    let tool_tip_text = Signal::derive(move || state.with(|state| {
+    let tooltip_text = Signal::derive(move || state.with(|state| {
         Clone::clone(&state.text)
     }));
+    
+    let tooltip_content = Box::new(move || {
+        view! {
+            <p> { tooltip_text } </p>
+
+        }.into_any()
+    });
 
     view! {
         <div class="is-flex is-justify-content-center">
-            <Tooltip text=tool_tip_text>
-                <div class=classes />
+            <Tooltip text=tooltip_content>
+                <div class=health_class />
             </Tooltip>
         </div>
     }

--- a/opendut-lea/opendut-lea-components/src/tooltip.rs
+++ b/opendut-lea/opendut-lea-components/src/tooltip.rs
@@ -1,6 +1,6 @@
 use leptos::prelude::*;
 
-#[derive(Default)]
+#[derive(Default, Clone, Copy)]
 pub enum TooltipDirection {
     #[default]
     Left,

--- a/opendut-lea/opendut-lea-components/src/tooltip.rs
+++ b/opendut-lea/opendut-lea-components/src/tooltip.rs
@@ -1,6 +1,8 @@
 use leptos::prelude::*;
 
+#[derive(Default)]
 pub enum TooltipDirection {
+    #[default]
     Left,
     Right,
     Up,
@@ -21,7 +23,7 @@ impl TooltipDirection {
 #[component]
 pub fn Tooltip(
     #[prop(into)] text: Signal<String>,
-    #[prop(into, default=Signal::from(TooltipDirection::Left))] direction: Signal<TooltipDirection>,
+    #[prop(into, optional)] direction: Signal<TooltipDirection>,
     #[prop(into, default=Signal::from(false))] is_hidden: Signal<bool>,
     children: Children
 ) -> impl IntoView {

--- a/opendut-lea/opendut-lea-components/src/tooltip.rs
+++ b/opendut-lea/opendut-lea-components/src/tooltip.rs
@@ -20,9 +20,11 @@ impl TooltipDirection {
     }
 }
 
+pub type TooltipContent = Box<dyn FnOnce() -> AnyView + Send>;
+
 #[component]
 pub fn Tooltip(
-    #[prop(into)] text: Signal<String>,
+    text: TooltipContent,
     #[prop(into, optional)] direction: Signal<TooltipDirection>,
     #[prop(into, default=Signal::from(false))] is_hidden: Signal<bool>,
     children: Children
@@ -36,7 +38,7 @@ pub fn Tooltip(
             <div class="tooltip-container" class=("is-hidden", move || is_hidden.get())>
                 <div class="tooltip-content p-0">
                     <div class="tooltip-item p-3">
-                        { text }
+                        { text() }
                     </div>
                 </div>
             </div>

--- a/opendut-lea/src/clusters/components/cluster_health.rs
+++ b/opendut-lea/src/clusters/components/cluster_health.rs
@@ -1,10 +1,12 @@
 use leptos::prelude::*;
 use opendut_lea_components::health::{self, Health};
+use opendut_lea_components::tooltip::TooltipDirection;
 use opendut_model::cluster::state::ClusterState;
 
 #[component]
 pub fn ClusterHealth(
-    #[prop(into)] state: Signal<ClusterState>
+    #[prop(into)] state: Signal<ClusterState>,
+    #[prop(optional)] tooltip_direction: TooltipDirection
 ) -> impl IntoView {
     let _ = state;
 
@@ -17,6 +19,9 @@ pub fn ClusterHealth(
     });
 
     view! {
-        <Health state=health_state />
+        <Health
+            state=health_state
+            tooltip_direction
+        />
     }
 }

--- a/opendut-lea/src/clusters/components/delete_cluster_button.rs
+++ b/opendut-lea/src/clusters/components/delete_cluster_button.rs
@@ -69,9 +69,15 @@ where F: Fn() + Clone + Send + 'static {
         !matches!(button_state.get(), ButtonState::Disabled)
     });
 
+    let tooltip_content = Box::new(move || {
+        view! {
+            Cluster can not be deleted while it is deployed.
+        }.into_any()
+    });
+
     view! {
         <Tooltip
-            text="Cluster can not be deleted while it is deployed."
+            text=tooltip_content
             direction=TooltipDirection::Right
             is_hidden=hide_tooltip
         >

--- a/opendut-lea/src/clusters/components/deploy_toggle.rs
+++ b/opendut-lea/src/clusters/components/deploy_toggle.rs
@@ -15,6 +15,7 @@ use crate::components::{Toast, use_toaster};
 #[component]
 pub fn DeployToggle<OnDeploymentChanged>(
     #[prop(into)] cluster_id: Signal<ClusterId>,
+    #[prop(into, default=Signal::from(false))] is_new_cluster: Signal<bool>,
     #[prop(into)] is_deployed: Signal<IsDeployed>,
     on_deployment_changed: OnDeploymentChanged,
 ) -> impl IntoView
@@ -103,11 +104,17 @@ where
 
     let blocked_cluster_deployment_error_message = {
         let carl = globals.client.clone();
-        let cluster_id = cluster_id.get();
+        let cluster_id = cluster_id.get_untracked();
 
         LocalResource::new(move || {
             let mut carl = carl.clone();
+
             async move {
+
+                if is_new_cluster.get() {
+                    return None;
+                }
+
                 let state = carl.cluster.list_cluster_peer_states(cluster_id).await
                     .expect("Failed to request the list of cluster's peer state.");
                 match state {
@@ -153,7 +160,10 @@ where
         });
 
         let tooltip_text = Signal::derive(move || {
-            if let Some(error_message) = error_message.as_ref()
+            if is_new_cluster.get() {
+                String::from("Save the cluster first.")
+            }
+            else if let Some(error_message) = error_message.as_ref()
                 && show_error.get() {
                     String::from(error_message)
             }
@@ -161,12 +171,12 @@ where
                 String::from("Deployment requested")
             }
             else {
-                String::from("Undeployed".to_string())
+                String::from("Undeployed")
             }
         });
 
         let toggle_state = Signal::derive(move || {
-            if show_error.get() {
+            if show_error.get() || is_new_cluster.get() {
                 ToggleState::Disabled
             } else {
                 ToggleState::Enabled

--- a/opendut-lea/src/clusters/components/deploy_toggle.rs
+++ b/opendut-lea/src/clusters/components/deploy_toggle.rs
@@ -185,8 +185,14 @@ where
                 }
             });
 
+            let tooltip_content = Box::new(move || {
+                view! {
+                    { tooltip_text }
+                }.into_any()
+            });
+
             view! {
-                <Tooltip text=tooltip_text>
+                <Tooltip text=tooltip_content>
                     <Toggle
                         is_active=is_deployed
                         state=toggle_state

--- a/opendut-lea/src/clusters/components/deploy_toggle.rs
+++ b/opendut-lea/src/clusters/components/deploy_toggle.rs
@@ -108,10 +108,11 @@ where
 
         LocalResource::new(move || {
             let mut carl = carl.clone();
+            let is_new_cluster = is_new_cluster.get();
+            let _ = is_deployed.get();
 
             async move {
-
-                if is_new_cluster.get() {
+                if is_new_cluster {
                     return None;
                 }
 
@@ -150,49 +151,51 @@ where
         })
     };
 
-    Suspend::new(async move {
-        let error_message = blocked_cluster_deployment_error_message.await;
+    move || {
+        let on_deploy = on_deploy.clone();
+        let on_undeploy = on_undeploy.clone();
 
-        let is_deployed = Signal::derive(move || is_deployed.get().0);
-        let show_error = Signal::derive({
-            let error_message = error_message.clone();
-            move || error_message.is_some() && !is_deployed.get()
-        });
+        Suspend::new(async move {
+            let error_message = blocked_cluster_deployment_error_message.await;
 
-        let tooltip_text = Signal::derive(move || {
-            if is_new_cluster.get() {
-                String::from("Save the cluster first.")
-            }
-            else if let Some(error_message) = error_message.as_ref()
-                && show_error.get() {
+            let is_deployed = Signal::derive(move || is_deployed.get().0);
+            let show_error = Signal::derive({
+                let error_message = error_message.clone();
+                move || error_message.is_some() && !is_deployed.get()
+            });
+
+            let tooltip_text = Signal::derive(move || {
+                if is_new_cluster.get() {
+                    String::from("Save the cluster first.")
+                } else if let Some(error_message) = error_message.as_ref()
+                    && show_error.get() {
                     String::from(error_message)
-            }
-            else if is_deployed.get() {
-                String::from("Deployment requested")
-            }
-            else {
-                String::from("Undeployed")
-            }
-        });
+                } else if is_deployed.get() {
+                    String::from("Deployment requested")
+                } else {
+                    String::from("Undeployed")
+                }
+            });
 
-        let toggle_state = Signal::derive(move || {
-            if show_error.get() || is_new_cluster.get() {
-                ToggleState::Disabled
-            } else {
-                ToggleState::Enabled
-            }
-        });
+            let toggle_state = Signal::derive(move || {
+                if show_error.get() || is_new_cluster.get() {
+                    ToggleState::Disabled
+                } else {
+                    ToggleState::Enabled
+                }
+            });
 
-        view! {
-            <Tooltip text=tooltip_text>
-                <Toggle
-                    is_active=is_deployed
-                    state=toggle_state
-                    on_action=move || {
-                        if is_deployed.get() { on_undeploy() } else { on_deploy() }
-                    }
-                />
-            </Tooltip>
-        }
-    })
+            view! {
+                <Tooltip text=tooltip_text>
+                    <Toggle
+                        is_active=is_deployed
+                        state=toggle_state
+                        on_action=move || {
+                            if is_deployed.get() { on_undeploy() } else { on_deploy() }
+                        }
+                    />
+                </Tooltip>
+            }
+        })
+    }
 }

--- a/opendut-lea/src/clusters/components/deploy_toggle.rs
+++ b/opendut-lea/src/clusters/components/deploy_toggle.rs
@@ -206,8 +206,8 @@ fn DeploymentTooltipContent(
             }.into_any();
         }
 
-        if !is_deployed.get() {
-            if let Some(blocked_deployment) = blocked_deployment.as_ref() {
+        if !is_deployed.get()
+            && let Some(blocked_deployment) = blocked_deployment.as_ref() {
                 return match blocked_deployment {
                     BlockedDeployment::Peers(peers) => {
                         let amount = peers.len();
@@ -219,7 +219,7 @@ fn DeploymentTooltipContent(
                         };
 
                         let peer_links = peers
-                            .into_iter()
+                            .iter()
                             .enumerate()
                             .map(|(index, peer_id)| {
                                 let href = format!("/peers/{peer_id}/configure/general");
@@ -244,7 +244,7 @@ fn DeploymentTooltipContent(
                     }
                 };
             }
-        }
+
 
         if is_deployed.get() {
             view! { "Deployment requested" }.into_any()

--- a/opendut-lea/src/clusters/components/deploy_toggle.rs
+++ b/opendut-lea/src/clusters/components/deploy_toggle.rs
@@ -3,11 +3,11 @@ use std::sync::Arc;
 use leptos::prelude::*;
 use tracing::{debug, error};
 use opendut_carl_api::carl::ClientError;
-use opendut_carl_api::carl::cluster::StoreClusterDeploymentError;
+use opendut_carl_api::carl::cluster::{ListClusterPeerStatesResponse, StoreClusterDeploymentError};
 use opendut_lea_components::tooltip::Tooltip;
 use opendut_lea_components::{Toggle, ToggleState};
 use opendut_model::cluster::{ClusterDeployment, ClusterId};
-
+use opendut_model::peer::state::PeerMemberState;
 use crate::app::use_app_globals;
 use crate::clusters::IsDeployed;
 use crate::components::{Toast, use_toaster};
@@ -101,23 +101,88 @@ where
         }
     };
 
-    let tooltip_text = Signal::derive(move || {
-        if is_deployed.get().0 {
-            "Deployment requested".to_string()
-        } else {
-            "Undeployed".to_string()
-        }
-    });
+    let blocked_cluster_deployment_error_message = {
+        let carl = globals.client.clone();
+        let cluster_id = cluster_id.get();
 
-    view! {
-        <Tooltip text=tooltip_text>
-            <Toggle
-                is_active=Signal::derive(move || is_deployed.get().0)
-                state=ToggleState::Enabled
-                on_action=move || {
-                    if is_deployed.get().0 { on_undeploy() } else { on_deploy() }
+        LocalResource::new(move || {
+            let mut carl = carl.clone();
+            async move {
+                let state = carl.cluster.list_cluster_peer_states(cluster_id).await
+                    .expect("Failed to request the list of cluster's peer state.");
+                match state {
+                    ListClusterPeerStatesResponse::Success { peer_states } => {
+                        let invalid_peers = peer_states
+                            .iter()
+                            .filter(|(_, peer_state)| {
+                                matches!(&peer_state.member, PeerMemberState::Blocked { .. })
+                            })
+                            .map(|(peer_id, _)| peer_id.to_string())
+                            .collect::<Vec<_>>();
+
+                        if invalid_peers.is_empty() {
+                            None
+                        } else {
+                            let amount_of_used_peers = invalid_peers.len();
+                            let display_amount = if amount_of_used_peers > 1 {
+                                format!("{amount_of_used_peers} Peers are")
+                            } else {
+                                format!("{amount_of_used_peers} Peer is")
+                            };
+                            Some(format!(
+                                "Failed to store cluster deployment! \n{display_amount} already in use: {}",
+                                invalid_peers.join(", ")
+                            ))
+                        }
+                    }
+                    ListClusterPeerStatesResponse::Failure { message } => {
+                        Some(message)
+                    }
                 }
-            />
-        </Tooltip>
-    }
+            }
+        })
+    };
+
+    Suspend::new(async move {
+        let error_message = blocked_cluster_deployment_error_message.await;
+
+        let is_deployed = Signal::derive(move || is_deployed.get().0);
+        let show_error = Signal::derive({
+            let error_message = error_message.clone();
+            move || error_message.is_some() && !is_deployed.get()
+        });
+
+        let tooltip_text = Signal::derive(move || {
+            if let Some(error_message) = error_message.as_ref()
+                && show_error.get() {
+                    String::from(error_message)
+            }
+            else if is_deployed.get() {
+                String::from("Deployment requested")
+            }
+            else {
+                String::from("Undeployed".to_string())
+            }
+        });
+
+        let toggle_state = Signal::derive(move || {
+            if show_error.get() {
+                ToggleState::Disabled
+            } else {
+                ToggleState::Enabled
+            }
+        });
+
+        view! {
+            <Tooltip text=tooltip_text>
+                <Toggle
+                    is_active=is_deployed
+                    state=toggle_state
+                    on_action=move || {
+                        if is_deployed.get() { on_undeploy() } else { on_deploy() }
+                    }
+                />
+            </Tooltip>
+        }
+    })
 }

--- a/opendut-lea/src/clusters/components/deploy_toggle.rs
+++ b/opendut-lea/src/clusters/components/deploy_toggle.rs
@@ -7,6 +7,7 @@ use opendut_carl_api::carl::cluster::{ListClusterPeerStatesResponse, StoreCluste
 use opendut_lea_components::tooltip::{Tooltip, TooltipDirection};
 use opendut_lea_components::{Toggle, ToggleState};
 use opendut_model::cluster::{ClusterDeployment, ClusterId};
+use opendut_model::peer::PeerId;
 use opendut_model::peer::state::PeerMemberState;
 use crate::app::use_app_globals;
 use crate::clusters::IsDeployed;
@@ -103,7 +104,7 @@ where
         }
     };
 
-    let blocked_cluster_deployment_error_message = {
+    let blocked_cluster_deployment = {
         let carl = globals.client.clone();
         let cluster_id = cluster_id.get_untracked();
 
@@ -117,35 +118,25 @@ where
                     return None;
                 }
 
-                let state = carl.cluster.list_cluster_peer_states(cluster_id).await
+                let states = carl.cluster.list_cluster_peer_states(cluster_id).await
                     .expect("Failed to request the list of cluster's peer state.");
-                match state {
+                match states {
                     ListClusterPeerStatesResponse::Success { peer_states } => {
-                        let invalid_peers = peer_states
-                            .iter()
+                        let invalid_peers = peer_states.iter()
                             .filter(|(_, peer_state)| {
                                 matches!(&peer_state.member, PeerMemberState::Blocked { .. })
                             })
-                            .map(|(peer_id, _)| peer_id.to_string())
+                            .map(|(peer_id, _)| peer_id.to_owned())
                             .collect::<Vec<_>>();
 
                         if invalid_peers.is_empty() {
                             None
                         } else {
-                            let amount_of_used_peers = invalid_peers.len();
-                            let display_amount = if amount_of_used_peers > 1 {
-                                format!("{amount_of_used_peers} Peers are")
-                            } else {
-                                format!("{amount_of_used_peers} Peer is")
-                            };
-                            Some(format!(
-                                "Failed to store cluster deployment! \n{display_amount} already in use: {}",
-                                invalid_peers.join(", ")
-                            ))
+                            Some(BlockedDeployment::Peers(invalid_peers))
                         }
                     }
                     ListClusterPeerStatesResponse::Failure { message } => {
-                        Some(message)
+                        Some(BlockedDeployment::Message(message))
                     }
                 }
             }
@@ -157,25 +148,13 @@ where
         let on_undeploy = on_undeploy.clone();
 
         Suspend::new(async move {
-            let error_message = blocked_cluster_deployment_error_message.await;
+            let blocked_deployment = blocked_cluster_deployment.await;
 
             let is_deployed = Signal::derive(move || is_deployed.get().0);
-            let show_error = Signal::derive({
-                let error_message = error_message.clone();
-                move || error_message.is_some() && !is_deployed.get()
-            });
 
-            let tooltip_text = Signal::derive(move || {
-                if is_new_cluster.get() {
-                    String::from("Save the cluster first.")
-                } else if let Some(error_message) = error_message.as_ref()
-                    && show_error.get() {
-                    String::from(error_message)
-                } else if is_deployed.get() {
-                    String::from("Deployment requested")
-                } else {
-                    String::from("Undeployed")
-                }
+            let show_error = Signal::derive({
+                let blocked_deployment = blocked_deployment.clone();
+                move || blocked_deployment.is_some() && !is_deployed.get()
             });
 
             let toggle_state = Signal::derive(move || {
@@ -188,7 +167,7 @@ where
 
             let tooltip_content = Box::new(move || {
                 view! {
-                    { tooltip_text }
+                    <DeploymentTooltipContent is_new_cluster is_deployed blocked_deployment />
                 }.into_any()
             });
 
@@ -204,5 +183,73 @@ where
                 </Tooltip>
             }
         })
+    }
+}
+
+#[derive(Clone)]
+enum BlockedDeployment {
+    Peers(Vec<PeerId>),
+    Message(String),
+}
+
+#[component]
+fn DeploymentTooltipContent(
+    is_new_cluster: Signal<bool>,
+    is_deployed: Signal<bool>,
+    blocked_deployment: Option<BlockedDeployment>,
+) -> impl IntoView {
+
+    move || {
+        if is_new_cluster.get() {
+            return view! {
+                "Save the cluster first."
+            }.into_any();
+        }
+
+        if !is_deployed.get() {
+            if let Some(blocked_deployment) = blocked_deployment.as_ref() {
+                return match blocked_deployment {
+                    BlockedDeployment::Peers(peers) => {
+                        let amount = peers.len();
+
+                        let message = if amount == 1 {
+                            "1 Peer is already in use:".to_string()
+                        } else {
+                            format!("{amount} Peers are already in use:")
+                        };
+
+                        let peer_links = peers
+                            .into_iter()
+                            .enumerate()
+                            .map(|(index, peer_id)| {
+                                let href = format!("/peers/{peer_id}/configure/general");
+
+                                view! {
+                                    <span>
+                                        {if index == 0 { "" } else { ", " }}
+                                        <a href=href>{peer_id.to_string()}</a>
+                                    </span>
+                                }
+                            })
+                            .collect_view();
+
+                        view! {
+                            <span>{message} " " {peer_links}</span>
+                        }
+                            .into_any()
+                    }
+
+                    BlockedDeployment::Message(message) => {
+                        view! { { message.to_owned() } }.into_any()
+                    }
+                };
+            }
+        }
+
+        if is_deployed.get() {
+            view! { "Deployment requested" }.into_any()
+        } else {
+            view! { "Undeployed" }.into_any()
+        }
     }
 }

--- a/opendut-lea/src/clusters/components/deploy_toggle.rs
+++ b/opendut-lea/src/clusters/components/deploy_toggle.rs
@@ -4,7 +4,7 @@ use leptos::prelude::*;
 use tracing::{debug, error};
 use opendut_carl_api::carl::ClientError;
 use opendut_carl_api::carl::cluster::{ListClusterPeerStatesResponse, StoreClusterDeploymentError};
-use opendut_lea_components::tooltip::Tooltip;
+use opendut_lea_components::tooltip::{Tooltip, TooltipDirection};
 use opendut_lea_components::{Toggle, ToggleState};
 use opendut_model::cluster::{ClusterDeployment, ClusterId};
 use opendut_model::peer::state::PeerMemberState;
@@ -18,6 +18,7 @@ pub fn DeployToggle<OnDeploymentChanged>(
     #[prop(into, default=Signal::from(false))] is_new_cluster: Signal<bool>,
     #[prop(into)] is_deployed: Signal<IsDeployed>,
     on_deployment_changed: OnDeploymentChanged,
+    #[prop(optional)] tooltip_direction: TooltipDirection,
 ) -> impl IntoView
 where
     OnDeploymentChanged: Fn() + Clone + Send + 'static,
@@ -192,7 +193,7 @@ where
             });
 
             view! {
-                <Tooltip text=tooltip_content>
+                <Tooltip text=tooltip_content direction=tooltip_direction>
                     <Toggle
                         is_active=is_deployed
                         state=toggle_state

--- a/opendut-lea/src/clusters/configurator/components/controls.rs
+++ b/opendut-lea/src/clusters/configurator/components/controls.rs
@@ -144,9 +144,15 @@ fn SaveClusterButton(
         !deployed_signal.get().0
     });
 
+    let tooltip_content = Box::new(move || {
+        view! {
+            Cluster can not be updated while it is deployed.
+        }.into_any()
+    });
+
     view! {
         <Tooltip
-            text="Cluster can not be updated while it is deployed."
+            text=tooltip_content
             direction=TooltipDirection::Right
             is_hidden=hide_tooltip
         >

--- a/opendut-lea/src/clusters/configurator/components/controls.rs
+++ b/opendut-lea/src/clusters/configurator/components/controls.rs
@@ -37,6 +37,8 @@ where
             navigate_to(WellKnownRoutes::ClustersOverview, use_navigate.clone());
         }
     };
+    
+    let tooltip_direction = TooltipDirection::Right;
 
     view! {
         <div class="is-flex is-align-items-center">
@@ -46,10 +48,11 @@ where
                     is_new_cluster
                     is_deployed=deployed_signal
                     on_deployment_changed
+                    tooltip_direction
                 />
             </div>
             <div class="px-2" />
-            <ClusterHealth state=cluster_state />
+            <ClusterHealth state=cluster_state tooltip_direction />
             <div class="px-2" />
             <SaveClusterButton
                 cluster_descriptor

--- a/opendut-lea/src/clusters/configurator/components/controls.rs
+++ b/opendut-lea/src/clusters/configurator/components/controls.rs
@@ -40,16 +40,15 @@ where
 
     view! {
         <div class="is-flex is-align-items-center">
-            <div class=("is-hidden", move || is_new_cluster.get())>
+            <div class="is-flex is-align-items-center">
                 <DeployToggle
                     cluster_id
+                    is_new_cluster
                     is_deployed=deployed_signal
                     on_deployment_changed
                 />
             </div>
-            <div class=("is-hidden", move || is_new_cluster.get())>
-                <div class="px-2" />
-            </div>
+            <div class="px-2" />
             <ClusterHealth state=cluster_state />
             <div class="px-2" />
             <SaveClusterButton

--- a/opendut-lea/src/peers/components/delete_peer_button.rs
+++ b/opendut-lea/src/peers/components/delete_peer_button.rs
@@ -69,9 +69,15 @@ where F: Fn() + Clone + Send + 'static {
         !matches!(button_state.get(), ButtonState::Disabled)
     });
 
+    let tooltip_content = Box::new(move || {
+        view! {
+            Peer can not be deleted while it is configured in a cluster.
+        }.into_any()
+    });
+
     view! {
         <Tooltip
-            text="Peer can not be deleted while it is configured in a cluster."
+            text=tooltip_content
             direction=TooltipDirection::Right
             is_hidden=hide_tooltip
         >

--- a/opendut-lea/src/peers/configurator/tabs/devices/device_panel.rs
+++ b/opendut-lea/src/peers/configurator/tabs/devices/device_panel.rs
@@ -34,7 +34,6 @@ where
                     <ReadOnlyInput label="ID" value=device_id_string />
                     <DeviceNameInput device_configuration />
                     <DeviceInterfaceInput user_peer_descriptor device_configuration />
-                    <DeviceInterfaceInput user_peer_descriptor device_configuration />
                     <DeviceTagInput device_configuration />
                     <DeviceDescriptionInput device_configuration />
                 </div>

--- a/opendut-lea/src/viper_tests/components/duplicate_viper_test_button.rs
+++ b/opendut-lea/src/viper_tests/components/duplicate_viper_test_button.rs
@@ -63,8 +63,14 @@ pub fn DuplicateViperTestButton(
         })
     };
 
+    let tooltip_content = Box::new(move || {
+        view! {
+            Duplicate Test Run.
+        }.into_any()
+    });
+
     view! {
-        <Tooltip text="Duplicate Test Run" direction=TooltipDirection::Right>
+        <Tooltip text=tooltip_content direction=TooltipDirection::Right>
             <IconButton
                 icon=FontAwesomeIcon::Duplicate
                 color=ButtonColor::White


### PR DESCRIPTION
Addresses issues #503 and #504

## Changes
- Display a `Tooltip` + disable the `Toggle` if the cluster cannot be deployed, due to blocked peers 
    ->This works in the `ClusterOverview` and in the `ClusterConfigurator`
- Disable the toggle in the `ClusterConfigurator` as long as the cluster is not saved


## UI
My cursor disappeared in this screeshot again :cry: (it's hovering over the toggle with the tooltip)

<img width="1385" height="419" alt="image" src="https://github.com/user-attachments/assets/1331fbdb-4c2e-47b9-a9a4-f49fb7dffeac" />

<img width="1385" height="461" alt="image" src="https://github.com/user-attachments/assets/b2599c74-057a-44bf-9203-ad18b09d567a" />

## Checklist

- [ ] I have added or updated automated tests.
- [x] I have tested my changes manually.
- [ ] I have added or updated documentation.
