### PR TITLE
Issue 394 restrict edgar api access

### DIFF
--- a/.ci/deploy/localenv/data/keycloak/provision.sh
+++ b/.ci/deploy/localenv/data/keycloak/provision.sh
@@ -59,6 +59,15 @@ main() {
   create_secret_client "opendut-cleo-client" "$OPENDUT_CLEO_NETWORK_OIDC_CLIENT_SECRET" "$REALM_OPENDUT"
   create_secret_client "opendut-edgar-client" "$OPENDUT_EDGAR_NETWORK_OIDC_CLIENT_SECRET" "$REALM_OPENDUT"
 
+  # Create API access scopes for authorization
+  create_client_scope "opendut-admin-api" "none" "$REALM_OPENDUT"
+  create_client_scope "opendut-edge-api" "none" "$REALM_OPENDUT"
+
+  # Assign API scopes to clients
+  add_client_scope_to_client "opendut-lea-client" "opendut-admin-api" "$REALM_OPENDUT"
+  add_client_scope_to_client "opendut-cleo-client" "opendut-admin-api" "$REALM_OPENDUT"
+  add_client_scope_to_client "opendut-edgar-client" "opendut-edge-api" "$REALM_OPENDUT"
+
   # Create keycloak client privileges for openDuT-CARL
   create_realm_role carl-admin "$REALM_OPENDUT"
   # Add role carl-admin to client opendut-carl-client

--- a/.ci/deploy/localenv/data/keycloak/provision.sh
+++ b/.ci/deploy/localenv/data/keycloak/provision.sh
@@ -59,9 +59,13 @@ main() {
   create_secret_client "opendut-cleo-client" "$OPENDUT_CLEO_NETWORK_OIDC_CLIENT_SECRET" "$REALM_OPENDUT"
   create_secret_client "opendut-edgar-client" "$OPENDUT_EDGAR_NETWORK_OIDC_CLIENT_SECRET" "$REALM_OPENDUT"
 
-  # Create API access scopes for authorization
-  create_client_scope "opendut-admin-api" "none" "$REALM_OPENDUT"
-  create_client_scope "opendut-edge-api" "none" "$REALM_OPENDUT"
+  # Create API access scopes for authorization.
+  # Type "default" means Keycloak automatically includes the scope in every token
+  # issued to a client that has it assigned, without the client needing to request it
+  # explicitly. This is required for service-account clients (EDGAR, CLEO) using the
+  # client_credentials grant, which cannot enumerate scopes in the token request.
+  create_client_scope "opendut-admin-api" "default" "$REALM_OPENDUT"
+  create_client_scope "opendut-edge-api" "default" "$REALM_OPENDUT"
 
   # Assign API scopes to clients
   add_client_scope_to_client "opendut-lea-client" "opendut-admin-api" "$REALM_OPENDUT"

--- a/.ci/deploy/localenv/docker-compose.yml
+++ b/.ci/deploy/localenv/docker-compose.yml
@@ -446,6 +446,8 @@ services:
       - OPENDUT_CARL_NETWORK_OIDC_CLIENT_ID=opendut-carl-client
       - OPENDUT_CARL_NETWORK_OIDC_CLIENT_SECRET
       - OPENDUT_CARL_NETWORK_OIDC_LEA_ISSUER_URL=https://${OPENDUT_DOMAIN_AUTH}/realms/opendut/
+      # opendut-admin-api must be requested at login so CARL's scope enforcement allows LEA's gRPC calls.
+      - OPENDUT_CARL_NETWORK_OIDC_LEA_SCOPES=openid,profile,email,opendut-admin-api
       - OPENDUT_CARL_NETWORK_OIDC_CLIENT_ISSUER_URL=https://${OPENDUT_DOMAIN_AUTH}/realms/opendut/
       - OPENDUT_CARL_NETWORK_OIDC_CLIENT_ISSUER_REMOTE_URL=https://${OPENDUT_DOMAIN_AUTH}/realms/opendut/
       - OPENDUT_CARL_NETWORK_OIDC_CLIENT_ISSUER_ADMIN_URL=https://${OPENDUT_DOMAIN_AUTH}/admin/realms/opendut/
@@ -492,7 +494,7 @@ services:
       - OPENDUT_CLEO_NETWORK_OIDC_CLIENT_ID=opendut-cleo-client
       - OPENDUT_CLEO_NETWORK_OIDC_CLIENT_SECRET
       - OPENDUT_CLEO_NETWORK_OIDC_CLIENT_ISSUER_URL=https://${OPENDUT_DOMAIN_AUTH}/realms/opendut/
-      - OPENDUT_CLEO_NETWORK_OIDC_CLIENT_SCOPES=
+      - OPENDUT_CLEO_NETWORK_OIDC_CLIENT_SCOPES=opendut-admin-api
       - OPENDUT_CLEO_NETWORK_TLS_CA=${OPENDUT_CERT_CA_PATH}
       - SSL_CERT_FILE=${OPENDUT_CERT_CA_PATH}
     volumes:

--- a/opendut-auth/src/confidential/config.rs
+++ b/opendut-auth/src/confidential/config.rs
@@ -126,8 +126,11 @@ impl OidcConfidentialClientConfig {
         let raw_scopes_no_quotations = raw_scopes.replace('\"', "");
         let scopes = raw_scopes_no_quotations.split(',').collect::<Vec<_>>();
         for scope in scopes.clone() {
-            if !scope.chars().all(|c| c.is_ascii_alphabetic() || c.is_ascii_digit()) {
-                panic!("Failed to parse comma-separated OIDC scopes for client_id='{client_id}'. Scopes must only contain ASCII alphabetic characters or digits. Found: {raw_scopes:?}. Parsed as: {scopes:?}");
+            // Hyphens are valid in OAuth scope strings (RFC 6749).
+            // Reject spaces, punctuation, and other characters that would indicate
+            // a malformed config (e.g. accidentally space-separated instead of comma-separated).
+            if !scope.chars().all(|c| c.is_ascii_alphabetic() || c.is_ascii_digit() || c == '-') {
+                panic!("Failed to parse comma-separated OIDC scopes for client_id='{client_id}'. Scopes must only contain ASCII alphabetic characters, digits, or hyphens. Found: {raw_scopes:?}. Parsed as: {scopes:?}");
             }
         }
         scopes.into_iter().filter(|scope| !scope.is_empty()).map(|scope| OAuthScope::new(scope.to_string())).collect()
@@ -236,5 +239,17 @@ mod tests {
         assert_eq!(scopes[0].as_str(), "scope1");
         assert_eq!(scopes[1].as_str(), "scope2");
         assert_eq!(scopes[2].as_str(), "scope3");
+    }
+
+    #[test]
+    fn test_parse_scopes_with_hyphens() {
+        // Scope names like opendut-admin-api and opendut-edge-api contain hyphens,
+        // which are valid per RFC 6749 and must not be rejected.
+        let client_id = "test_client_id";
+        let raw_scopes = "opendut-admin-api,opendut-edge-api";
+        let scopes = OidcConfidentialClientConfig::parse_scopes(client_id, raw_scopes.to_string());
+        assert_eq!(scopes.len(), 2);
+        assert_eq!(scopes[0].as_str(), "opendut-admin-api");
+        assert_eq!(scopes[1].as_str(), "opendut-edge-api");
     }
 }

--- a/opendut-auth/src/registration/client.rs
+++ b/opendut-auth/src/registration/client.rs
@@ -317,8 +317,8 @@ impl Clients {
 #[derive(Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Client {
-    pub id: String,           // Keycloak's internal UUID — used in admin API paths
-    pub client_id: String,    // OAuth client ID (e.g. "opendut-edgar-client")
+    pub id: String,
+    pub client_id: String,
     base_url: Option<String>,
 }
 

--- a/opendut-auth/src/registration/client.rs
+++ b/opendut-auth/src/registration/client.rs
@@ -203,6 +203,73 @@ impl RegistrationClient {
             .map_err(|error| RegistrationClientError::RequestError { error: error.to_string(), cause: error.into() })
     }
 
+    pub async fn assign_scope_to_client(&self, keycloak_client_uuid: &str, scope_name: &str) -> Result<(), RegistrationClientError> {
+        let scopes = self.list_client_scopes().await?;
+
+        let scope_id = scopes.iter()
+            .find(|s| s.name == scope_name)
+            .map(|s| s.id.clone())
+            .ok_or_else(|| RegistrationClientError::InvalidConfiguration {
+                error: format!("Client scope '{scope_name}' not found in Keycloak")
+            })?;
+
+        let assign_uri = format!("clients/{keycloak_client_uuid}/default-client-scopes/{scope_id}");
+        let assign_url = self.config.issuer_admin_url.value().join(&assign_uri)
+            .map_err(|cause| RegistrationClientError::InvalidConfiguration {
+                error: format!("Invalid admin api endpoint for scope assignment. {cause}")
+            })?;
+
+        let request = self.create_http_request_with_auth_token(&assign_url, http::Method::PUT).await?;
+        let response = async_http_client(&self.inner.reqwest_client, request).await
+            .map_err(|error| RegistrationClientError::RequestError {
+                error: format!("Failed to assign scope '{scope_name}' to client '{keycloak_client_uuid}'"),
+                cause: Box::new(error)
+            })?;
+
+        if response.status().is_success() {
+            Ok(())
+        } else {
+            Err(RegistrationClientError::RequestError {
+                error: format!("Failed to assign scope '{scope_name}' to client '{keycloak_client_uuid}': HTTP {}", response.status()),
+                cause: format!("HTTP {}", response.status()).into()
+            })
+        }
+    }
+
+    pub async fn list_client_scopes(&self) -> Result<Vec<KeycloakClientScope>, RegistrationClientError> {
+        let scopes_url = self.config.issuer_admin_url.value().join("client-scopes/")
+            .map_err(|cause| RegistrationClientError::InvalidConfiguration {
+                error: format!("Invalid admin api endpoint for client scopes. {cause}")
+            })?;
+
+        let request = self.create_http_request_with_auth_token(&scopes_url, http::Method::GET).await?;
+        let response = async_http_client(&self.inner.reqwest_client, request).await
+            .map_err(|error| RegistrationClientError::RequestError {
+                error: "Failed to list client scopes".to_string(),
+                cause: Box::new(error)
+            })?;
+
+        let scopes: Vec<KeycloakClientScope> = serde_json::from_slice(response.body())
+            .map_err(|cause| {
+                error!("Could not deserialize client scopes from keycloak: {:?}\nBody:\n{}", cause, String::from_utf8_lossy(response.body()));
+                RegistrationClientError::InvalidConfiguration {
+                    error: format!("Could not deserialize client scopes response. {cause}")
+                }
+            })?;
+
+        Ok(scopes)
+    }
+
+    /// Find the Keycloak internal UUID for use in admin API paths, by its OAuth client_id
+    pub async fn find_client_uuid(&self, oauth_client_id: &str) -> Result<String, RegistrationClientError> {
+        let clients = self.list_clients().await?;
+        clients.value()
+            .into_iter()
+            .find(|c| c.client_id == oauth_client_id)
+            .map(|c| c.id)
+            .ok_or(RegistrationClientError::ClientNotFound)
+    }
+
     async fn create_http_request_with_auth_token(&self, issuer_remote_url: &Url, http_method: http::Method) -> Result<HttpRequest, RegistrationClientError> {
         let access_token = self.inner.get_token().await
             .map_err(|error| RegistrationClientError::RequestError { error: error.to_string(), cause: error.into() })?;
@@ -250,6 +317,13 @@ impl Clients {
 #[derive(Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Client {
-    pub client_id: String,
+    pub id: String,           // Keycloak's internal UUID — used in admin API paths
+    pub client_id: String,    // OAuth client ID (e.g. "opendut-edgar-client")
     base_url: Option<String>,
+}
+
+#[derive(Deserialize, Debug, Clone)]
+pub struct KeycloakClientScope {
+    pub id: String,
+    pub name: String,
 }

--- a/opendut-auth/src/registration/client.rs
+++ b/opendut-auth/src/registration/client.rs
@@ -148,7 +148,10 @@ impl RegistrationClient {
     }
     
     pub async fn list_clients(&self) -> Result<Clients, RegistrationClientError> {
-        let enumerate_clients_uri = self.config.issuer_admin_url.value().join("clients/")
+        // Append max=2147483647 to fetch all registered clients in one request.
+        // Keycloak's default cap is 100, which would silently truncate results in
+        // deployments with many peers, causing delete and UUID-lookup operations to miss clients.
+        let enumerate_clients_uri = self.config.issuer_admin_url.value().join("clients/?max=2147483647")
             .map_err(|cause| RegistrationClientError::InvalidConfiguration { error: format!("Invalid admin api endpoint for issuer. {cause}") })?;
         let request = self.create_http_request_with_auth_token(&enumerate_clients_uri, http::Method::GET).await?;
 
@@ -260,11 +263,36 @@ impl RegistrationClient {
         Ok(scopes)
     }
 
-    /// Find the Keycloak internal UUID for use in admin API paths, by its OAuth client_id
+    /// Find the Keycloak internal UUID for use in admin API paths, by its OAuth client_id.
+    ///
+    /// Uses the `?clientId=` query parameter so Keycloak returns only the matching client,
+    /// avoiding a full paginated scan regardless of deployment size.
     pub async fn find_client_uuid(&self, oauth_client_id: &str) -> Result<String, RegistrationClientError> {
-        let clients = self.list_clients().await?;
-        clients.value()
-            .into_iter()
+        // Keycloak admin API: GET /clients/?clientId=<exact_id>
+        // Returns a JSON array of matching clients (typically 0 or 1 elements).
+        let uri = format!("clients/?clientId={oauth_client_id}");
+        let url = self.config.issuer_admin_url.value().join(&uri)
+            .map_err(|cause| RegistrationClientError::InvalidConfiguration {
+                error: format!("Invalid admin api endpoint for client lookup. {cause}")
+            })?;
+
+        let request = self.create_http_request_with_auth_token(&url, http::Method::GET).await?;
+        let response = async_http_client(&self.inner.reqwest_client, request).await
+            .map_err(|error| RegistrationClientError::RequestError {
+                error: format!("Failed to look up client '{oauth_client_id}'"),
+                cause: Box::new(error)
+            })?;
+
+        let clients: Vec<Client> = serde_json::from_slice(response.body())
+            .map_err(|cause| {
+                error!("Could not deserialize client lookup from keycloak: {:?}\nBody:\n{}", cause, String::from_utf8_lossy(response.body()));
+                RegistrationClientError::InvalidConfiguration {
+                    error: format!("Could not deserialize client lookup response. {cause}")
+                }
+            })?;
+
+        // Keycloak's ?clientId= is a prefix/substring search, so verify exact match.
+        clients.into_iter()
             .find(|c| c.client_id == oauth_client_id)
             .map(|c| c.id)
             .ok_or(RegistrationClientError::ClientNotFound)

--- a/opendut-auth/src/types.rs
+++ b/opendut-auth/src/types.rs
@@ -51,7 +51,7 @@ pub struct MyAdditionalClaims {
     pub groups: Vec<String>,
     /// OAuth scopes (space-separated string in the JWT)
     #[serde(default)]
-    pub scope: String,
+    pub scopes: String,
 }
 
 impl MyAdditionalClaims {
@@ -63,7 +63,7 @@ impl MyAdditionalClaims {
         self.roles.contains(&role.to_string())
     }
     pub fn has_scope(&self, required_scope: &str) -> bool {
-        self.scope.split_whitespace().any(|s| s == required_scope)
+        self.scopes.split_whitespace().any(|s| s == required_scope)
     }
 }
 

--- a/opendut-auth/src/types.rs
+++ b/opendut-auth/src/types.rs
@@ -49,8 +49,8 @@ pub struct MyAdditionalClaims {
     /// Groups of the user (custom claim) may be omitted by identity provider, so we need a default value
     #[serde(default = "MyAdditionalClaims::empty_vector")]
     pub groups: Vec<String>,
-    /// OAuth scopes (space-separated string in the JWT)
-    #[serde(default)]
+    /// OAuth scopes (space-separated list transmitted as "scope" claim in JWT)
+    #[serde(default, rename = "scope")]
     pub scopes: String,
 }
 

--- a/opendut-auth/src/types.rs
+++ b/opendut-auth/src/types.rs
@@ -2,6 +2,11 @@ use std::fmt::Debug;
 use cfg_if::cfg_if;
 use serde::{Deserialize, Serialize};
 
+/// OAuth scope required to access the management API (ClusterManager, PeerManager, etc.)
+pub const SCOPE_ADMIN_API: &str = "opendut-admin-api";
+/// OAuth scope required to access the edge API (PeerMessagingBroker)
+pub const SCOPE_EDGE_API: &str = "opendut-edge-api";
+
 #[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(untagged)]
 pub enum Audience {
@@ -44,6 +49,9 @@ pub struct MyAdditionalClaims {
     /// Groups of the user (custom claim) may be omitted by identity provider, so we need a default value
     #[serde(default = "MyAdditionalClaims::empty_vector")]
     pub groups: Vec<String>,
+    /// OAuth scopes (space-separated string in the JWT)
+    #[serde(default)]
+    pub scope: String,
 }
 
 impl MyAdditionalClaims {
@@ -53,6 +61,9 @@ impl MyAdditionalClaims {
     }
     pub fn has_role(&self, role: &str) -> bool {
         self.roles.contains(&role.to_string())
+    }
+    pub fn has_scope(&self, required_scope: &str) -> bool {
+        self.scope.split_whitespace().any(|s| s == required_scope)
     }
 }
 

--- a/opendut-carl/carl.toml
+++ b/opendut-carl/carl.toml
@@ -46,7 +46,9 @@ key = ""
 [network.oidc.lea]
 client.id = "opendut-lea-client"
 issuer.url = "https://auth.opendut.local/realms/opendut/"
-scopes = "openid,profile,email"
+# opendut-admin-api must be included so CARL's scope enforcement allows LEA's gRPC calls.
+# parse_scopes accepts hyphens, so this is safe to pass as a comma-separated list.
+scopes = "openid,profile,email,opendut-admin-api"
 
 [persistence]
 enabled = false

--- a/opendut-carl/src/auth/grpc_auth_layer.rs
+++ b/opendut-carl/src/auth/grpc_auth_layer.rs
@@ -19,7 +19,11 @@ pub enum GrpcAuthenticationLayer {
 }
 
 impl GrpcAuthenticationLayer {
-    pub async fn auth_interceptor(self, mut request: tonic::Request<()>, reqwest_client: reqwest::Client) -> anyhow::Result<tonic::Request<()>, Status> {
+    /// Authenticate and authorize a gRPC request, enforcing the given `required_scope`.
+    ///
+    /// Each router group (edge vs admin) calls this with the scope it requires,
+    /// so no runtime path detection is needed.
+    pub async fn auth_interceptor(self, mut request: tonic::Request<()>, reqwest_client: reqwest::Client, required_scope: &'static str) -> anyhow::Result<tonic::Request<()>, Status> {
 
         match self {
             GrpcAuthenticationLayer::AuthDisabled => {
@@ -38,6 +42,13 @@ impl GrpcAuthenticationLayer {
 
                 match authorize_current_user(auth_header, issuer_url, issuer_remote_url, cache, reqwest_client).await {
                     Ok(user) => {
+                        if !user.claims.additional_claims().has_scope(required_scope) {
+                            debug!("Blocking request: missing required scope '{required_scope}'");
+                            return Err(Status::permission_denied(
+                                format!("CARL says, missing required scope: {required_scope}")
+                            ));
+                        }
+
                         request.extensions_mut().insert(user);
                         Ok(request)
                     }

--- a/opendut-carl/src/auth/grpc_auth_layer.rs
+++ b/opendut-carl/src/auth/grpc_auth_layer.rs
@@ -19,10 +19,6 @@ pub enum GrpcAuthenticationLayer {
 }
 
 impl GrpcAuthenticationLayer {
-    /// Authenticate and authorize a gRPC request, enforcing the given `required_scope`.
-    ///
-    /// Each router group (edge vs admin) calls this with the scope it requires,
-    /// so no runtime path detection is needed.
     pub async fn auth_interceptor(self, mut request: tonic::Request<()>, reqwest_client: reqwest::Client, required_scope: &'static str) -> anyhow::Result<tonic::Request<()>, Status> {
 
         match self {

--- a/opendut-carl/src/auth/grpc_auth_layer.rs
+++ b/opendut-carl/src/auth/grpc_auth_layer.rs
@@ -19,7 +19,7 @@ pub enum GrpcAuthenticationLayer {
 }
 
 impl GrpcAuthenticationLayer {
-    pub async fn auth_interceptor(self, mut request: tonic::Request<()>, reqwest_client: reqwest::Client, required_scope: &'static str) -> anyhow::Result<tonic::Request<()>, Status> {
+    pub async fn auth_interceptor(self, mut request: tonic::Request<()>, reqwest_client: reqwest::Client, accepted_scopes: &'static [&'static str]) -> anyhow::Result<tonic::Request<()>, Status> {
 
         match self {
             GrpcAuthenticationLayer::AuthDisabled => {
@@ -38,10 +38,14 @@ impl GrpcAuthenticationLayer {
 
                 match authorize_current_user(auth_header, issuer_url, issuer_remote_url, cache, reqwest_client).await {
                     Ok(user) => {
-                        if !user.claims.additional_claims().has_scope(required_scope) {
-                            debug!("Blocking request: missing required scope '{required_scope}'");
+                        let has_required_scope = accepted_scopes
+                            .iter()
+                            .any(|scope| user.claims.additional_claims().has_scope(scope));
+
+                        if !has_required_scope {
+                            debug!("Blocking request: none of the required scopes {accepted_scopes:?} were present");
                             return Err(Status::permission_denied(
-                                format!("CARL says, missing required scope: {required_scope}")
+                                format!("CARL says, missing one of the required scopes: {}", accepted_scopes.join(", "))
                             ));
                         }
 

--- a/opendut-carl/src/lib.rs
+++ b/opendut-carl/src/lib.rs
@@ -150,24 +150,40 @@ async fn run(settings: LoadedConfig, get_resource_manager_ref: bool) -> anyhow::
             }
         };
 
-        let mut routes_builder = Routes::builder();
+        let reqwest_client = reqwest_client::oidc::create_from_config(&settings)?;
 
+        // All services in one Routes builder — scope is enforced inside the interceptor
+        // by inspecting the gRPC path prefix to determine edge vs admin API.
+        let mut routes_builder = Routes::builder();
         routes_builder
+            .add_service(grpc_facades.peer_messaging_broker_facade.into_grpc_service())
             .add_service(grpc_facades.cluster_manager_facade.into_grpc_service())
             .add_service(grpc_facades.metadata_provider_facade.into_grpc_service())
             .add_service(grpc_facades.peer_manager_facade.into_grpc_service())
-            .add_service(grpc_facades.peer_messaging_broker_facade.into_grpc_service())
             .add_service(grpc_facades.observer_messaging_broker_facade.into_grpc_service());
 
         #[cfg(feature = "viper")]
         routes_builder.add_service(grpc_facades.viper_manager_facade.into_grpc_service());
 
-        let reqwest_client = reqwest_client::oidc::create_from_config(&settings)?;
         routes_builder
             .routes()
             .into_axum_router()
-            .layer(async_interceptor(move |request| {
-                Clone::clone(&grpc_auth_layer).auth_interceptor(request, reqwest_client.clone())
+            .layer(async_interceptor(move |request: tonic::Request<()>| {
+                // Determine required scope from the gRPC path pseudo-header:
+                //   /opendut.PeerMessagingBroker/... → edge API
+                //   everything else                  → admin API
+                let is_edge = request
+                    .metadata()
+                    .get(":path")
+                    .and_then(|v| v.to_str().ok())
+                    .map(|p| p.starts_with("/opendut.carl.services.peer_messaging_broker.PeerMessagingBroker"))
+                    .unwrap_or(false);
+                let required_scope = if is_edge {
+                    opendut_auth::types::SCOPE_EDGE_API
+                } else {
+                    opendut_auth::types::SCOPE_ADMIN_API
+                };
+                Clone::clone(&grpc_auth_layer).auth_interceptor(request, reqwest_client.clone(), required_scope)
             }))
     };
 

--- a/opendut-carl/src/lib.rs
+++ b/opendut-carl/src/lib.rs
@@ -171,16 +171,32 @@ async fn run(settings: LoadedConfig, get_resource_manager_ref: bool) -> anyhow::
                     .get::<axum::extract::OriginalUri>()
                     .map(|u| {
                         let path = u.path();
-                        path.starts_with("/opendut.carl.services.peer_messaging_broker.") || 
+                        path.starts_with("/opendut.carl.services.peer_messaging_broker.") ||
                         path.contains("/opendut.carl.services.peer_messaging_broker.")
                     })
                     .unwrap_or(false);
-                let required_scope = if is_edge {
-                    opendut_auth::types::SCOPE_EDGE_API
+
+                // metadata_provider serves a single Version() endpoint used by all clients
+                // (EDGAR, CLEO, LEA) on startup. EDGAR only holds opendut-edge-api while
+                // CLEO/LEA only hold opendut-admin-api, so both scopes must be accepted.
+                let is_metadata_provider = request
+                    .extensions()
+                    .get::<axum::extract::OriginalUri>()
+                    .map(|u| {
+                        let path = u.path();
+                        path.starts_with("/opendut.carl.services.metadata_provider.") ||
+                        path.contains("/opendut.carl.services.metadata_provider.")
+                    })
+                    .unwrap_or(false);
+
+                let accepted_scopes: &'static [&'static str] = if is_metadata_provider {
+                    &[opendut_auth::types::SCOPE_EDGE_API, opendut_auth::types::SCOPE_ADMIN_API]
+                } else if is_edge {
+                    &[opendut_auth::types::SCOPE_EDGE_API]
                 } else {
-                    opendut_auth::types::SCOPE_ADMIN_API
+                    &[opendut_auth::types::SCOPE_ADMIN_API]
                 };
-                Clone::clone(&grpc_auth_layer).auth_interceptor(request, reqwest_client.clone(), required_scope)
+                Clone::clone(&grpc_auth_layer).auth_interceptor(request, reqwest_client.clone(), accepted_scopes)
             }))
     };
 

--- a/opendut-carl/src/lib.rs
+++ b/opendut-carl/src/lib.rs
@@ -150,8 +150,6 @@ async fn run(settings: LoadedConfig, get_resource_manager_ref: bool) -> anyhow::
             }
         };
 
-        let reqwest_client = reqwest_client::oidc::create_from_config(&settings)?;
-
         let mut routes_builder = Routes::builder();
         routes_builder
             .add_service(grpc_facades.cluster_manager_facade.into_grpc_service())
@@ -171,7 +169,11 @@ async fn run(settings: LoadedConfig, get_resource_manager_ref: bool) -> anyhow::
                 let is_edge = request
                     .extensions()
                     .get::<axum::extract::OriginalUri>()
-                    .map(|u| u.path().contains("PeerMessagingBroker"))
+                    .map(|u| {
+                        let path = u.path();
+                        path.starts_with("/opendut.services.peer_messaging_broker.") || 
+                        path.contains("/opendut.services.peer_messaging_broker.")
+                    })
                     .unwrap_or(false);
                 let required_scope = if is_edge {
                     opendut_auth::types::SCOPE_EDGE_API

--- a/opendut-carl/src/lib.rs
+++ b/opendut-carl/src/lib.rs
@@ -171,8 +171,8 @@ async fn run(settings: LoadedConfig, get_resource_manager_ref: bool) -> anyhow::
                     .get::<axum::extract::OriginalUri>()
                     .map(|u| {
                         let path = u.path();
-                        path.starts_with("/opendut.services.peer_messaging_broker.") || 
-                        path.contains("/opendut.services.peer_messaging_broker.")
+                        path.starts_with("/opendut.carl.services.peer_messaging_broker.") || 
+                        path.contains("/opendut.carl.services.peer_messaging_broker.")
                     })
                     .unwrap_or(false);
                 let required_scope = if is_edge {

--- a/opendut-carl/src/lib.rs
+++ b/opendut-carl/src/lib.rs
@@ -152,31 +152,26 @@ async fn run(settings: LoadedConfig, get_resource_manager_ref: bool) -> anyhow::
 
         let reqwest_client = reqwest_client::oidc::create_from_config(&settings)?;
 
-        // All services in one Routes builder — scope is enforced inside the interceptor
-        // by inspecting the gRPC path prefix to determine edge vs admin API.
         let mut routes_builder = Routes::builder();
         routes_builder
-            .add_service(grpc_facades.peer_messaging_broker_facade.into_grpc_service())
             .add_service(grpc_facades.cluster_manager_facade.into_grpc_service())
             .add_service(grpc_facades.metadata_provider_facade.into_grpc_service())
             .add_service(grpc_facades.peer_manager_facade.into_grpc_service())
+            .add_service(grpc_facades.peer_messaging_broker_facade.into_grpc_service())
             .add_service(grpc_facades.observer_messaging_broker_facade.into_grpc_service());
 
         #[cfg(feature = "viper")]
         routes_builder.add_service(grpc_facades.viper_manager_facade.into_grpc_service());
 
+        let reqwest_client = reqwest_client::oidc::create_from_config(&settings)?;
         routes_builder
             .routes()
             .into_axum_router()
             .layer(async_interceptor(move |request: tonic::Request<()>| {
-                // Determine required scope from the gRPC path pseudo-header:
-                //   /opendut.PeerMessagingBroker/... → edge API
-                //   everything else                  → admin API
                 let is_edge = request
-                    .metadata()
-                    .get(":path")
-                    .and_then(|v| v.to_str().ok())
-                    .map(|p| p.starts_with("/opendut.carl.services.peer_messaging_broker.PeerMessagingBroker"))
+                    .extensions()
+                    .get::<axum::extract::OriginalUri>()
+                    .map(|u| u.path().contains("PeerMessagingBroker"))
                     .unwrap_or(false);
                 let required_scope = if is_edge {
                     opendut_auth::types::SCOPE_EDGE_API

--- a/opendut-carl/src/lib.rs
+++ b/opendut-carl/src/lib.rs
@@ -117,6 +117,15 @@ async fn run(settings: LoadedConfig, get_resource_manager_ref: bool) -> anyhow::
         &settings
     ).await?;
 
+    // A newtype wrapper so we can store the gRPC path in the request extensions
+    // and retrieve it from inside the tonic async interceptor.
+    // tonic::Request does not expose the URI, and OriginalUri is an Axum HTTP
+    // concept that is not forwarded to tonic::Request extensions. This wrapper
+    // is injected at the Steer map_request level (before dispatch) so the path
+    // is available when the interceptor closure fires.
+    #[derive(Clone)]
+    struct GrpcPath(String);
+
     let http = {
         let carl_installation_directory = CarlInstallDirectory::determine()
             .expect("Could not determine installation directory.");
@@ -162,38 +171,33 @@ async fn run(settings: LoadedConfig, get_resource_manager_ref: bool) -> anyhow::
         routes_builder.add_service(grpc_facades.viper_manager_facade.into_grpc_service());
 
         let reqwest_client = reqwest_client::oidc::create_from_config(&settings)?;
+
         routes_builder
             .routes()
             .into_axum_router()
             .layer(async_interceptor(move |request: tonic::Request<()>| {
-                let is_edge = request
+                // Retrieve the path injected into extensions by map_request on the Steer below.
+                let path = request
                     .extensions()
-                    .get::<axum::extract::OriginalUri>()
-                    .map(|u| {
-                        let path = u.path();
-                        path.starts_with("/opendut.carl.services.peer_messaging_broker.") ||
-                        path.contains("/opendut.carl.services.peer_messaging_broker.")
-                    })
-                    .unwrap_or(false);
+                    .get::<GrpcPath>()
+                    .map(|p| p.0.as_str().to_owned())
+                    .unwrap_or_default();
 
-                // metadata_provider serves a single Version() endpoint used by all clients
-                // (EDGAR, CLEO, LEA) on startup. EDGAR only holds opendut-edge-api while
-                // CLEO/LEA only hold opendut-admin-api, so both scopes must be accepted.
-                let is_metadata_provider = request
-                    .extensions()
-                    .get::<axum::extract::OriginalUri>()
-                    .map(|u| {
-                        let path = u.path();
-                        path.starts_with("/opendut.carl.services.metadata_provider.") ||
-                        path.contains("/opendut.carl.services.metadata_provider.")
-                    })
-                    .unwrap_or(false);
+                let is_edge = path.starts_with("/opendut.carl.services.peer_messaging_broker.");
+
+                // MetadataProvider (Version RPC) is called by all clients on startup.
+                // Accept either scope so EDGAR (edge) and CLEO/LEA (admin) can both reach it.
+                let is_metadata_provider = path.starts_with("/opendut.carl.services.metadata_provider.");
 
                 let accepted_scopes: &'static [&'static str] = if is_metadata_provider {
                     &[opendut_auth::types::SCOPE_EDGE_API, opendut_auth::types::SCOPE_ADMIN_API]
                 } else if is_edge {
+                    // PeerMessagingBroker is the EDGAR-only edge API.
                     &[opendut_auth::types::SCOPE_EDGE_API]
                 } else {
+                    // All remaining services (ClusterManager, PeerManager,
+                    // ObserverMessagingBroker, ViperManager) are management APIs
+                    // accessible only to CLEO and LEA.
                     &[opendut_auth::types::SCOPE_ADMIN_API]
                 };
                 Clone::clone(&grpc_auth_layer).auth_interceptor(request, reqwest_client.clone(), accepted_scopes)
@@ -213,7 +217,13 @@ async fn run(settings: LoadedConfig, get_resource_manager_ref: bool) -> anyhow::
         usize::from(is_grpc)
     })
     .map_request(|request: ::http::Request<hyper::body::Incoming>| -> ::http::Request<axum::body::Body> {
-        request.map(axum::body::Body::new)
+        let (mut parts, body) = request.into_parts();
+        // Inject the URI path as GrpcPath before the request is dispatched into either
+        // the HTTP or gRPC branch. This lets the tonic async interceptor read the path
+        // from extensions, since tonic::Request does not preserve the URI.
+        let path = parts.uri.path().to_owned();
+        parts.extensions.insert(GrpcPath(path));
+        ::http::Request::from_parts(parts, axum::body::Body::new(body))
     });
 
 

--- a/opendut-carl/src/manager/peer_manager/generate_cleo_setup.rs
+++ b/opendut-carl/src/manager/peer_manager/generate_cleo_setup.rs
@@ -1,5 +1,6 @@
 use opendut_auth::registration::client::RegistrationClientRef;
 use opendut_auth::registration::resources::UserId;
+use opendut_auth::types::SCOPE_ADMIN_API;
 use opendut_model::cleo::{CleoId, CleoSetup};
 use opendut_model::util::net::{AuthConfig, Certificate};
 use tracing::debug;
@@ -32,6 +33,16 @@ pub async fn generate_cleo_setup(params: GenerateCleoSetupParams) -> Result<Cleo
                 .await
                 .map_err(|cause| GenerateCleoSetupError::Internal { cause: cause.to_string() })?;
             debug!("Successfully generated CLEO setup with id <{cleo_id}>. OIDC client_id='{}'.", client_credentials.client_id.clone().value());
+
+            // Assign admin API scope to the CLEO client
+            let keycloak_client_uuid = registration_client.find_client_uuid(&client_credentials.client_id.clone().value())
+                .await
+                .map_err(|cause| GenerateCleoSetupError::Internal { cause: cause.to_string() })?;
+            registration_client.assign_scope_to_client(&keycloak_client_uuid, SCOPE_ADMIN_API)
+                .await
+                .map_err(|cause| GenerateCleoSetupError::Internal { cause: cause.to_string() })?;
+            debug!("Assigned scope '{SCOPE_ADMIN_API}' to CLEO client <{cleo_id}>.");
+
             AuthConfig::from_credentials(issuer_url, client_credentials)
         }
     };

--- a/opendut-carl/src/manager/peer_manager/generate_cleo_setup.rs
+++ b/opendut-carl/src/manager/peer_manager/generate_cleo_setup.rs
@@ -2,7 +2,7 @@ use opendut_auth::registration::client::RegistrationClientRef;
 use opendut_auth::registration::resources::UserId;
 use opendut_auth::types::SCOPE_ADMIN_API;
 use opendut_model::cleo::{CleoId, CleoSetup};
-use opendut_model::util::net::{AuthConfig, Certificate};
+use opendut_model::util::net::{AuthConfig, Certificate, OAuthScope};
 use tracing::debug;
 use url::Url;
 use opendut_util::pem::Pem;
@@ -43,7 +43,7 @@ pub async fn generate_cleo_setup(params: GenerateCleoSetupParams) -> Result<Cleo
                 .map_err(|cause| GenerateCleoSetupError::Internal { cause: cause.to_string() })?;
             debug!("Assigned scope '{SCOPE_ADMIN_API}' to CLEO client <{cleo_id}>.");
 
-            AuthConfig::from_credentials(issuer_url, client_credentials)
+            AuthConfig::from_credentials(issuer_url, client_credentials, vec![OAuthScope(SCOPE_ADMIN_API.to_string())])
         }
     };
 

--- a/opendut-carl/src/manager/peer_manager/generate_cleo_setup.rs
+++ b/opendut-carl/src/manager/peer_manager/generate_cleo_setup.rs
@@ -34,14 +34,21 @@ pub async fn generate_cleo_setup(params: GenerateCleoSetupParams) -> Result<Cleo
                 .map_err(|cause| GenerateCleoSetupError::Internal { cause: cause.to_string() })?;
             debug!("Successfully generated CLEO setup with id <{cleo_id}>. OIDC client_id='{}'.", client_credentials.client_id.clone().value());
 
-            // Assign admin API scope to the CLEO client
-            let keycloak_client_uuid = registration_client.find_client_uuid(&client_credentials.client_id.clone().value())
-                .await
-                .map_err(|cause| GenerateCleoSetupError::Internal { cause: cause.to_string() })?;
-            registration_client.assign_scope_to_client(&keycloak_client_uuid, SCOPE_ADMIN_API)
-                .await
-                .map_err(|cause| GenerateCleoSetupError::Internal { cause: cause.to_string() })?;
-            debug!("Assigned scope '{SCOPE_ADMIN_API}' to CLEO client <{cleo_id}>.");
+            // Only assign the scope when CARL dynamically registered a fresh client.
+            // When peer_credentials is set (static shared credentials, e.g. local dev),
+            // the client already has its scopes assigned by provision.sh, so skipping
+            // the Keycloak round-trip avoids a redundant admin API call and prevents
+            // find_client_uuid from failing if the static client_id is not discoverable
+            // via the dynamic registration listing.
+            if registration_client.config.peer_credentials.is_none() {
+                let keycloak_client_uuid = registration_client.find_client_uuid(&client_credentials.client_id.clone().value())
+                    .await
+                    .map_err(|cause| GenerateCleoSetupError::Internal { cause: cause.to_string() })?;
+                registration_client.assign_scope_to_client(&keycloak_client_uuid, SCOPE_ADMIN_API)
+                    .await
+                    .map_err(|cause| GenerateCleoSetupError::Internal { cause: cause.to_string() })?;
+                debug!("Assigned scope '{SCOPE_ADMIN_API}' to CLEO client <{cleo_id}>.");
+            }
 
             AuthConfig::from_credentials(issuer_url, client_credentials, vec![OAuthScope(SCOPE_ADMIN_API.to_string())])
         }

--- a/opendut-carl/src/manager/peer_manager/generate_peer_setup.rs
+++ b/opendut-carl/src/manager/peer_manager/generate_peer_setup.rs
@@ -2,6 +2,7 @@ use crate::resource::manager::error::PersistenceError;
 use crate::settings::vpn::Vpn;
 use opendut_auth::registration::client::RegistrationClientRef;
 use opendut_auth::registration::resources::UserId;
+use opendut_auth::types::SCOPE_EDGE_API;
 use opendut_model::peer::{PeerDescriptor, PeerId, PeerName, PeerSetup};
 use opendut_model::util::net::{AuthConfig, Certificate};
 use opendut_model::vpn::VpnPeerConfiguration;
@@ -57,6 +58,16 @@ impl Resources<'_> {
                     .await
                     .map_err(|cause| GeneratePeerSetupError::Internal { peer_id, peer_name: Clone::clone(&peer_name), cause: cause.to_string() })?;
                 debug!("Successfully generated peer setup for peer '{peer_name}' <{peer_id}>. OIDC client_id='{}'.", client_credentials.client_id.clone().value());
+
+                // Assign edge API scope to the EDGAR client
+                let keycloak_client_uuid = registration_client.find_client_uuid(&client_credentials.client_id.clone().value())
+                    .await
+                    .map_err(|cause| GeneratePeerSetupError::Internal { peer_id, peer_name: Clone::clone(&peer_name), cause: cause.to_string() })?;
+                registration_client.assign_scope_to_client(&keycloak_client_uuid, SCOPE_EDGE_API)
+                    .await
+                    .map_err(|cause| GeneratePeerSetupError::Internal { peer_id, peer_name: Clone::clone(&peer_name), cause: cause.to_string() })?;
+                debug!("Assigned scope '{SCOPE_EDGE_API}' to EDGAR client for peer '{peer_name}' <{peer_id}>.");
+
                 AuthConfig::from_credentials(issuer_url, client_credentials)
             }
         };

--- a/opendut-carl/src/manager/peer_manager/generate_peer_setup.rs
+++ b/opendut-carl/src/manager/peer_manager/generate_peer_setup.rs
@@ -4,7 +4,7 @@ use opendut_auth::registration::client::RegistrationClientRef;
 use opendut_auth::registration::resources::UserId;
 use opendut_auth::types::SCOPE_EDGE_API;
 use opendut_model::peer::{PeerDescriptor, PeerId, PeerName, PeerSetup};
-use opendut_model::util::net::{AuthConfig, Certificate};
+use opendut_model::util::net::{AuthConfig, Certificate, OAuthScope};
 use opendut_model::vpn::VpnPeerConfiguration;
 use tracing::{debug, info, warn};
 use url::Url;
@@ -68,7 +68,7 @@ impl Resources<'_> {
                     .map_err(|cause| GeneratePeerSetupError::Internal { peer_id, peer_name: Clone::clone(&peer_name), cause: cause.to_string() })?;
                 debug!("Assigned scope '{SCOPE_EDGE_API}' to EDGAR client for peer '{peer_name}' <{peer_id}>.");
 
-                AuthConfig::from_credentials(issuer_url, client_credentials)
+                AuthConfig::from_credentials(issuer_url, client_credentials, vec![OAuthScope(SCOPE_EDGE_API.to_string())])
             }
         };
 

--- a/opendut-carl/src/manager/peer_manager/generate_peer_setup.rs
+++ b/opendut-carl/src/manager/peer_manager/generate_peer_setup.rs
@@ -59,14 +59,21 @@ impl Resources<'_> {
                     .map_err(|cause| GeneratePeerSetupError::Internal { peer_id, peer_name: Clone::clone(&peer_name), cause: cause.to_string() })?;
                 debug!("Successfully generated peer setup for peer '{peer_name}' <{peer_id}>. OIDC client_id='{}'.", client_credentials.client_id.clone().value());
 
-                // Assign edge API scope to the EDGAR client
-                let keycloak_client_uuid = registration_client.find_client_uuid(&client_credentials.client_id.clone().value())
-                    .await
-                    .map_err(|cause| GeneratePeerSetupError::Internal { peer_id, peer_name: Clone::clone(&peer_name), cause: cause.to_string() })?;
-                registration_client.assign_scope_to_client(&keycloak_client_uuid, SCOPE_EDGE_API)
-                    .await
-                    .map_err(|cause| GeneratePeerSetupError::Internal { peer_id, peer_name: Clone::clone(&peer_name), cause: cause.to_string() })?;
-                debug!("Assigned scope '{SCOPE_EDGE_API}' to EDGAR client for peer '{peer_name}' <{peer_id}>.");
+                // Only assign the scope when CARL dynamically registered a fresh client.
+                // When peer_credentials is set (static shared credentials, e.g. local dev),
+                // the client already has its scopes assigned by provision.sh, so skipping
+                // the Keycloak round-trip avoids a redundant admin API call and prevents
+                // find_client_uuid from failing if the static client_id is not discoverable
+                // via the dynamic registration listing.
+                if registration_client.config.peer_credentials.is_none() {
+                    let keycloak_client_uuid = registration_client.find_client_uuid(&client_credentials.client_id.clone().value())
+                        .await
+                        .map_err(|cause| GeneratePeerSetupError::Internal { peer_id, peer_name: Clone::clone(&peer_name), cause: cause.to_string() })?;
+                    registration_client.assign_scope_to_client(&keycloak_client_uuid, SCOPE_EDGE_API)
+                        .await
+                        .map_err(|cause| GeneratePeerSetupError::Internal { peer_id, peer_name: Clone::clone(&peer_name), cause: cause.to_string() })?;
+                    debug!("Assigned scope '{SCOPE_EDGE_API}' to EDGAR client for peer '{peer_name}' <{peer_id}>.");
+                }
 
                 AuthConfig::from_credentials(issuer_url, client_credentials, vec![OAuthScope(SCOPE_EDGE_API.to_string())])
             }

--- a/opendut-cleo/src/commands/setup.rs
+++ b/opendut-cleo/src/commands/setup.rs
@@ -63,15 +63,16 @@ impl SetupCli {
                             OPENDUT_CLEO_NETWORK_OIDC_ENABLED=false
                         ").as_str());
                     }
-                    AuthConfig::Enabled { issuer_url, client_id, client_secret, .. } => {
+                    AuthConfig::Enabled { issuer_url, client_id, client_secret, scopes } => {
                         let id = client_id.value();
                         let secret = client_secret.value();
+                        let scopes_str = scopes.into_iter().map(|s| s.0).collect::<Vec<_>>().join(",");
                         environment_variables.push_str(formatdoc!("
                             OPENDUT_CLEO_NETWORK_OIDC_ENABLED=true
                             OPENDUT_CLEO_NETWORK_OIDC_CLIENT_ISSUER_URL={issuer_url}
                             OPENDUT_CLEO_NETWORK_OIDC_CLIENT_ID={id}
                             OPENDUT_CLEO_NETWORK_OIDC_CLIENT_SECRET={secret}
-                            OPENDUT_CLEO_NETWORK_OIDC_CLIENT_SCOPES=\"\"
+                            OPENDUT_CLEO_NETWORK_OIDC_CLIENT_SCOPES=\"{scopes_str}\"
                         ").as_str());
                     }
                 }

--- a/opendut-model/src/util/net.rs
+++ b/opendut-model/src/util/net.rs
@@ -429,13 +429,12 @@ pub enum AuthConfig {
 }
 
 impl AuthConfig {
-     pub fn from_credentials(issuer_url: Url, client_credentials: ClientCredentials) -> Self {
-
+    pub fn from_credentials(issuer_url: Url, client_credentials: ClientCredentials, scopes: Vec<OAuthScope>) -> Self {
         Self::Enabled {
             issuer_url,
             client_id: client_credentials.client_id,
             client_secret: client_credentials.client_secret,
-            scopes: vec![],
+            scopes,
         }
     }
 }
@@ -455,7 +454,7 @@ mod tests {
         let client_credentials = ClientCredentials { client_id: client_id.clone(), client_secret: client_secret.clone() };
         let expected_scopes: Vec<OAuthScope> = vec![];
         let issuer_url = Url::parse("https://some-address-idk.com").unwrap();
-        let auth_config = AuthConfig::from_credentials(issuer_url.clone(), client_credentials);
+        let auth_config = AuthConfig::from_credentials(issuer_url.clone(), client_credentials, vec![]);
 
         assert_that!(auth_config, eq(&AuthConfig::Enabled {
             issuer_url,


### PR DESCRIPTION
Restrict EDGAR API access via OAuth scopes (#394)
Implements scope-based authorization so EDGAR clients can only access the edge API (PeerMessagingBroker) and are blocked from all management API endpoints.

Tasks completed:
Create client scopes in Keycloak during provisioning (opendut-admin-api, opendut-edge-api)
Assign scopes to clients after registration, add OAuth scope to default scopes to indicate which API it is allowed to use:
- EDGAR client: opendut-edge-api
- CLEO client: opendut-admin-api
- LEA client: opendut-admin-api

Peer messaging broker (Edge API) checks required scope opendut-edge-api
Administrative API checks required scope opendut-admin-api
I have tested my changes manually.
