### PR TITLE
LEA: Show tooltip why peer, cluster, test or source can't be saved

### DIFF
--- a/opendut-lea/opendut-lea-components/src/tabs.rs
+++ b/opendut-lea/opendut-lea-components/src/tabs.rs
@@ -55,7 +55,7 @@ pub fn Tabs(
                                 <a href=tab.href>
                                     <div class="icon-text">
                                         <span class="icon has-text-danger" class=("is-hidden", move || !is_error().unwrap_or_default())>
-                                            <i class=FontAwesomeIcon::CircleExclamation.as_class()></i>
+                                            <i class=FontAwesomeIcon::CircleExclamation.as_class() />
                                         </span>
                                         <span>{ tab.title }</span>
                                     </div>

--- a/opendut-lea/src/clusters/configurator/components/cluster_name_input.rs
+++ b/opendut-lea/src/clusters/configurator/components/cluster_name_input.rs
@@ -6,9 +6,9 @@ use crate::components::{UserInput, UserInputValue};
 use crate::clusters::configurator::types::UserClusterDescriptor;
 
 #[component]
-pub fn ClusterNameInput(cluster_descriptor: RwSignal<UserClusterDescriptor>) -> impl IntoView {
+pub fn ClusterNameInput(user_cluster_descriptor: RwSignal<UserClusterDescriptor>) -> impl IntoView {
 
-    let (getter, setter) = create_slice(cluster_descriptor,
+    let (getter, setter) = create_slice(user_cluster_descriptor,
         |config| {
             Clone::clone(&config.name)
         },

--- a/opendut-lea/src/clusters/configurator/components/controls.rs
+++ b/opendut-lea/src/clusters/configurator/components/controls.rs
@@ -160,7 +160,7 @@ fn SaveClusterButton(
             view! {
                 Cluster can not be updated while it is deployed.
             }.into_any()
-        } else { view! {}.into_any() }
+        } else { ().into_any() }
     });
 
     view! {

--- a/opendut-lea/src/clusters/configurator/components/controls.rs
+++ b/opendut-lea/src/clusters/configurator/components/controls.rs
@@ -16,7 +16,7 @@ use crate::routing::{navigate_to, WellKnownRoutes};
 
 #[component]
 pub fn Controls<OnDeploymentChanged>(
-    cluster_descriptor: RwSignal<UserClusterDescriptor>,
+    user_cluster_descriptor: RwSignal<UserClusterDescriptor>,
     deployed_signal: Signal<IsDeployed>,
     cluster_state: Signal<ClusterState>,
     on_deployment_changed: OnDeploymentChanged,
@@ -25,13 +25,16 @@ where
     OnDeploymentChanged: Fn() + Clone + Send + 'static,
 {
 
-    let cluster_id = Signal::derive(move || {
-        cluster_descriptor.get().id
-    });
-    let is_new_cluster = Signal::derive(move || {
-        cluster_descriptor.get().is_new
-    });
+    let cluster_id = create_read_slice(
+        user_cluster_descriptor,
+        |descriptor| descriptor.id,
+    );
 
+    let is_new_cluster = create_read_slice(
+        user_cluster_descriptor,
+        |descriptor| descriptor.is_new,
+    );
+    
     let use_navigate = use_navigate();
     let on_delete = { move || {
             navigate_to(WellKnownRoutes::ClustersOverview, use_navigate.clone());
@@ -55,7 +58,7 @@ where
             <ClusterHealth state=cluster_state tooltip_direction />
             <div class="px-2" />
             <SaveClusterButton
-                cluster_descriptor
+                user_cluster_descriptor
                 deployed_signal
             />
             <div class="px-1" />
@@ -71,7 +74,7 @@ where
 
 #[component]
 fn SaveClusterButton(
-    cluster_descriptor: RwSignal<UserClusterDescriptor>,
+    user_cluster_descriptor: RwSignal<UserClusterDescriptor>,
     deployed_signal: Signal<IsDeployed>
 ) -> impl IntoView {
 
@@ -79,35 +82,32 @@ fn SaveClusterButton(
     let toaster = use_toaster();
 
     let set_is_new = create_write_slice(
-        cluster_descriptor,
-        |config, is_new| {
-            config.is_new = is_new;
+        user_cluster_descriptor,
+        |descriptor, is_new| {
+            descriptor.is_new = is_new;
         },
     );
 
-    let pending = RwSignal::new(false);
+    let all_tabs_valid = Memo::new(move |_| {
+        user_cluster_descriptor.with(|descriptor| descriptor.is_valid())
+    });
 
+    let pending = RwSignal::new(false);
+    
     let button_state = Signal::derive(move || {
-        if deployed_signal.get().0 {
+        if deployed_signal.get().0 || !all_tabs_valid.get() {
             ButtonState::Disabled
         } else if pending.get() {
             ButtonState::Loading
         }
         else {
-            cluster_descriptor.with(|configuration| {
-                if configuration.is_valid() {
-                    ButtonState::Enabled
-                }
-                else {
-                    ButtonState::Disabled
-                }
-            })
+            ButtonState::Enabled
         }
     });
 
     let on_action = move || {
         let toaster = Arc::clone(&toaster);
-        let configuration = ClusterDescriptor::try_from(cluster_descriptor.get_untracked());
+        let configuration = ClusterDescriptor::try_from(user_cluster_descriptor.get_untracked());
         let mut carl = globals.client.clone();
 
         leptos::task::spawn_local(async move {
@@ -144,13 +144,23 @@ fn SaveClusterButton(
     };
 
     let hide_tooltip = Signal::derive(move || {
-        !deployed_signal.get().0
+        all_tabs_valid.get() || !deployed_signal.get().0
     });
 
     let tooltip_content = Box::new(move || {
-        view! {
-            Cluster can not be updated while it is deployed.
-        }.into_any()
+        if !all_tabs_valid.get() {
+            view! {
+                Cluster cannot be saved while configuration errors " "
+                <span class="icon has-text-danger">
+                    <i class=FontAwesomeIcon::CircleExclamation.as_class() />
+                </span>
+                " " remain.
+            }.into_any()
+        } else if deployed_signal.get().0 {
+            view! {
+                Cluster can not be updated while it is deployed.
+            }.into_any()
+        } else { view! {}.into_any() }
     });
 
     view! {

--- a/opendut-lea/src/clusters/configurator/components/controls.rs
+++ b/opendut-lea/src/clusters/configurator/components/controls.rs
@@ -34,7 +34,7 @@ where
         user_cluster_descriptor,
         |descriptor| descriptor.is_new,
     );
-    
+
     let use_navigate = use_navigate();
     let on_delete = { move || {
             navigate_to(WellKnownRoutes::ClustersOverview, use_navigate.clone());
@@ -93,7 +93,7 @@ fn SaveClusterButton(
     });
 
     let pending = RwSignal::new(false);
-    
+
     let button_state = Signal::derive(move || {
         if deployed_signal.get().0 || !all_tabs_valid.get() {
             ButtonState::Disabled
@@ -144,7 +144,7 @@ fn SaveClusterButton(
     };
 
     let hide_tooltip = Signal::derive(move || {
-        all_tabs_valid.get() || !deployed_signal.get().0
+        all_tabs_valid.get() && !deployed_signal.get().0
     });
 
     let tooltip_content = Box::new(move || {

--- a/opendut-lea/src/clusters/configurator/components/controls.rs
+++ b/opendut-lea/src/clusters/configurator/components/controls.rs
@@ -150,11 +150,11 @@ fn SaveClusterButton(
     let tooltip_content = Box::new(move || {
         if !all_tabs_valid.get() {
             view! {
-                Cluster cannot be saved while configuration errors " "
+                "Cluster cannot be saved while configuration errors "
                 <span class="icon has-text-danger">
                     <i class=FontAwesomeIcon::CircleExclamation.as_class() />
                 </span>
-                " " remain.
+                " remain."
             }.into_any()
         } else if deployed_signal.get().0 {
             view! {

--- a/opendut-lea/src/clusters/configurator/components/device_selector.rs
+++ b/opendut-lea/src/clusters/configurator/components/device_selector.rs
@@ -12,13 +12,13 @@ pub type DeviceSelection = Ior<DeviceSelectionError, HashSet<DeviceId>>;
 
 #[component]
 pub fn DeviceSelector(
-    cluster_descriptor: RwSignal<UserClusterDescriptor>,
+    user_cluster_descriptor: RwSignal<UserClusterDescriptor>,
     peers: ReadSignal<Vec<PeerDescriptor>>,
     is_disabled: Signal<bool>,
 ) -> impl IntoView {
 
     let (getter, setter) = create_slice(
-        cluster_descriptor,
+        user_cluster_descriptor,
         |config| Clone::clone(&config.devices),
         |config, input| {
             config.devices = input;

--- a/opendut-lea/src/clusters/configurator/components/leader_selector.rs
+++ b/opendut-lea/src/clusters/configurator/components/leader_selector.rs
@@ -14,17 +14,17 @@ pub type LeaderSelection = Ior<LeaderSelectionError, PeerId>;
 
 #[component]
 pub fn LeaderSelector(
-    cluster_descriptor: RwSignal<UserClusterDescriptor>,
+    user_cluster_descriptor: RwSignal<UserClusterDescriptor>,
     peers: ReadSignal<Vec<PeerDescriptor>>,
     is_disabled: Signal<bool>,
 ) -> impl IntoView {
 
-    let getter_selected_devices = create_read_slice(cluster_descriptor, |config| {
+    let getter_selected_devices = create_read_slice(user_cluster_descriptor, |config| {
         Clone::clone(&config.devices)
     });
 
     let (getter, setter) = create_slice(
-        cluster_descriptor,
+        user_cluster_descriptor,
         |config| Clone::clone(&config.leader),
         |config, input| {
             config.leader = input;

--- a/opendut-lea/src/clusters/configurator/mod.rs
+++ b/opendut-lea/src/clusters/configurator/mod.rs
@@ -28,7 +28,7 @@ pub fn ClusterConfigurator() -> impl IntoView {
             .and_then(|id| ClusterId::try_from(id.as_str()).ok())
     }).unwrap_or_else(ClusterId::random));
 
-    let cluster_descriptor = RwSignal::new(
+    let user_cluster_descriptor = RwSignal::new(
         UserClusterDescriptor {
             id: cluster_id.get_untracked(),
             name: UserInputValue::Left(String::from("Enter a valid cluster name.")),
@@ -47,7 +47,7 @@ pub fn ClusterConfigurator() -> impl IntoView {
 
             async move {
                 if let Ok(configuration) = carl.cluster.get_cluster_descriptor(cluster_id).await {
-                    cluster_descriptor.set(
+                    user_cluster_descriptor.set(
                         UserClusterDescriptor {
                             id: cluster_id,
                             name: UserInputValue::Right(configuration.name.value().to_owned()),
@@ -73,7 +73,7 @@ pub fn ClusterConfigurator() -> impl IntoView {
             let peers = RwSignal::new(peer_descriptors.await).read_only();
 
             view! {
-                <LoadedClusterConfigurator cluster_descriptor peers />
+                <LoadedClusterConfigurator user_cluster_descriptor peers />
             }
         })}
         </Transition>
@@ -82,14 +82,14 @@ pub fn ClusterConfigurator() -> impl IntoView {
 
 #[component]
 fn LoadedClusterConfigurator(
-    cluster_descriptor: RwSignal<UserClusterDescriptor>,
+    user_cluster_descriptor: RwSignal<UserClusterDescriptor>,
     peers: ReadSignal<Vec<PeerDescriptor>>,
 ) -> impl IntoView {
     let globals = use_app_globals();
     let cluster_state = RwSignal::new(ClusterState::default());
     let active_tab = use_active_tab::<TabIdentifier>();
     
-    let cluster_id = Signal::derive(move || cluster_descriptor.get().id);
+    let cluster_id = Signal::derive(move || user_cluster_descriptor.get().id);
 
     let breadcrumbs = Signal::derive(move || {
         let cluster_id = cluster_id.get().uuid.to_string();
@@ -129,7 +129,7 @@ fn LoadedClusterConfigurator(
     ));
 
     let subtitle = Signal::derive(move || {
-        if let UserInputValue::Right(name) = cluster_descriptor.get().name {
+        if let UserInputValue::Right(name) = user_cluster_descriptor.get().name {
             name
         } else {
             String::new()
@@ -141,17 +141,17 @@ fn LoadedClusterConfigurator(
             Tab::from_title_and_href(
                 String::from("General"), 
                 TabIdentifier::General.as_str().to_owned()
-            ).with_is_error(Signal::derive(move || !cluster_descriptor.read().valid_general_tab())),
-            
+            ).with_is_error(Signal::derive(move || !user_cluster_descriptor.read().valid_general_tab())),
+
             Tab::from_title_and_href(
                 String::from("Devices"),
                 TabIdentifier::Devices.as_str().to_owned()
-            ).with_is_error(Signal::derive(move || !cluster_descriptor.read().valid_devices_tab())),
-            
+            ).with_is_error(Signal::derive(move || !user_cluster_descriptor.read().valid_devices_tab())),
+
             Tab::from_title_and_href(
                 String::from("Leader"),
                 TabIdentifier::Leader.as_str().to_owned()
-            ).with_is_error(Signal::derive(move || !cluster_descriptor.read().valid_leader_tab())),
+            ).with_is_error(Signal::derive(move || !user_cluster_descriptor.read().valid_leader_tab())),
         ]
     });
     
@@ -163,7 +163,7 @@ fn LoadedClusterConfigurator(
             controls=move || {
                 view! {
                     <Controls
-                        cluster_descriptor
+                        user_cluster_descriptor
                         deployed_signal
                         cluster_state=cluster_state.into()
                         on_deployment_changed=move || refetch_cluster_deployments.notify()
@@ -175,19 +175,19 @@ fn LoadedClusterConfigurator(
                 <fieldset prop:disabled=move || { deployed_signal.get().0 }>
                     { move || match active_tab.get() {
                         TabIdentifier::General => view! {
-                            <GeneralTab cluster_descriptor />
+                            <GeneralTab user_cluster_descriptor />
                         }.into_any(),
 
                         TabIdentifier::Devices => view! {
                             <DevicesTab
-                                cluster_descriptor
+                                user_cluster_descriptor
                                 peers is_disabled=Signal::derive(move || deployed_signal.get().0)
                             />
                         }.into_any(),
                         
                         TabIdentifier::Leader => view! {
                             <LeaderTab
-                                cluster_descriptor
+                                user_cluster_descriptor
                                 peers
                                 is_disabled=Signal::derive(move || deployed_signal.get().0)
                             />

--- a/opendut-lea/src/clusters/configurator/tabs/devices.rs
+++ b/opendut-lea/src/clusters/configurator/tabs/devices.rs
@@ -6,14 +6,14 @@ use crate::clusters::configurator::types::UserClusterDescriptor;
 
 #[component]
 pub fn DevicesTab(
-    cluster_descriptor: RwSignal<UserClusterDescriptor>,
+    user_cluster_descriptor: RwSignal<UserClusterDescriptor>,
     peers: ReadSignal<Vec<PeerDescriptor>>,
     is_disabled: Signal<bool>,
 ) -> impl IntoView {
 
     view! {
         <div>
-            <DeviceSelector cluster_descriptor peers is_disabled />
+            <DeviceSelector user_cluster_descriptor peers is_disabled />
         </div>
     }
 }

--- a/opendut-lea/src/clusters/configurator/tabs/general.rs
+++ b/opendut-lea/src/clusters/configurator/tabs/general.rs
@@ -5,9 +5,9 @@ use crate::clusters::configurator::types::UserClusterDescriptor;
 use crate::components::ReadOnlyInput;
 
 #[component]
-pub fn GeneralTab(cluster_descriptor: RwSignal<UserClusterDescriptor>) -> impl IntoView {
+pub fn GeneralTab(user_cluster_descriptor: RwSignal<UserClusterDescriptor>) -> impl IntoView {
 
-    let cluster_id = Signal::derive(move || cluster_descriptor.get().id.to_string());
+    let cluster_id = Signal::derive(move || user_cluster_descriptor.get().id.to_string());
 
     view! {
         <div>
@@ -16,7 +16,7 @@ pub fn GeneralTab(cluster_descriptor: RwSignal<UserClusterDescriptor>) -> impl I
                 value=cluster_id
             />
             <ClusterNameInput
-                cluster_descriptor=cluster_descriptor
+                user_cluster_descriptor
             />
         </div>
     }

--- a/opendut-lea/src/clusters/configurator/tabs/leader.rs
+++ b/opendut-lea/src/clusters/configurator/tabs/leader.rs
@@ -6,14 +6,14 @@ use crate::clusters::configurator::types::UserClusterDescriptor;
 
 #[component]
 pub fn LeaderTab(
-    cluster_descriptor: RwSignal<UserClusterDescriptor>,
+    user_cluster_descriptor: RwSignal<UserClusterDescriptor>,
     peers: ReadSignal<Vec<PeerDescriptor>>,
     is_disabled: Signal<bool>,
 ) -> impl IntoView {
 
     view! {
         <div>
-            <LeaderSelector cluster_descriptor peers is_disabled />
+            <LeaderSelector user_cluster_descriptor peers is_disabled />
         </div>
     }
 }

--- a/opendut-lea/src/peers/configurator/components/controls.rs
+++ b/opendut-lea/src/peers/configurator/components/controls.rs
@@ -136,11 +136,11 @@ fn SavePeerButton(
     let tooltip_content = Box::new(move || {
         if !all_tabs_valid.get() {
             view! {
-                Peer cannot be saved while configuration errors " "
+                "Peer cannot be saved while configuration errors "
                 <span class="icon has-text-danger">
                     <i class=FontAwesomeIcon::CircleExclamation.as_class() />
                 </span>
-                " " remain.
+                " remain."
             }.into_any()
         } else { ().into_any() }
     });

--- a/opendut-lea/src/peers/configurator/components/controls.rs
+++ b/opendut-lea/src/peers/configurator/components/controls.rs
@@ -5,6 +5,7 @@ use std::sync::Arc;
 use leptos::prelude::*;
 use leptos_router::hooks::use_navigate;
 use tracing::{debug, error};
+use opendut_lea_components::tooltip::{Tooltip, TooltipDirection};
 use opendut_model::cluster::ClusterId;
 use opendut_model::peer::PeerDescriptor;
 use opendut_model::peer::state::PeerState;
@@ -18,18 +19,17 @@ use crate::peers::components::PeerHealth;
 
 #[component]
 pub fn Controls(
-    configuration: RwSignal<UserPeerDescriptor>,
-    is_valid_peer_configuration: Signal<bool>,
+    user_peer_descriptor: RwSignal<UserPeerDescriptor>,
     peer_state: Signal<PeerState>
 ) -> impl IntoView {
 
     let peer_id = Signal::derive(move || {
-        configuration.get().id
+        user_peer_descriptor.get().id
     });
 
     let used_clusters_length = Signal::derive(move || {
         let mut used_clusters: HashSet<ClusterId> = HashSet::new();
-        let _ = configuration.get().devices
+        let _ = user_peer_descriptor.get().devices
             .into_iter()
             .filter(|device| device.get().contained_in_clusters.is_empty().not())
             .map(|device| for cluster_descriptor in device.get().contained_in_clusters {
@@ -49,10 +49,7 @@ pub fn Controls(
         <div class="is-flex is-align-items-center">
             <PeerHealth state=peer_state />
             <div class="px-2" />
-            <SavePeerButton
-                configuration
-                is_valid_peer_configuration
-            />
+            <SavePeerButton user_peer_descriptor />
             <div class="px-1" />
             <DeletePeerButton
                 peer_id
@@ -66,26 +63,29 @@ pub fn Controls(
 
 #[component]
 fn SavePeerButton(
-    configuration: RwSignal<UserPeerDescriptor>,
-    is_valid_peer_configuration: Signal<bool>,
+    user_peer_descriptor: RwSignal<UserPeerDescriptor>,
 ) -> impl IntoView {
 
     let globals = use_app_globals();
     let toaster = use_toaster();
 
     let setter = create_write_slice(
-        configuration,
-        |config, input| {
-            config.is_new = input;
+        user_peer_descriptor,
+        |descriptor, input| {
+            descriptor.is_new = input;
         },
     );
+
+    let all_tabs_valid = Memo::new(move |_| {
+        user_peer_descriptor.with(|descriptor| descriptor.is_valid())
+    });
 
     let pending = RwSignal::new(false);
 
     let button_state = Signal::derive(move || {
         if pending.get() {
             ButtonState::Loading
-        } else if is_valid_peer_configuration.get() {
+        } else if all_tabs_valid.get() {
             ButtonState::Enabled
         } else {
             ButtonState::Disabled
@@ -99,7 +99,7 @@ fn SavePeerButton(
         leptos::task::spawn_local(async move {
             pending.set(true);
 
-            let peer_descriptor = PeerDescriptor::try_from(configuration.get_untracked());
+            let peer_descriptor = PeerDescriptor::try_from(user_peer_descriptor.get_untracked());
             match peer_descriptor {
                 Ok(peer_descriptor) => {
                     let peer_id = peer_descriptor.id;
@@ -129,14 +129,36 @@ fn SavePeerButton(
         })
     };
 
+    let hide_tooltip = Signal::derive(move || {
+        all_tabs_valid.get()
+    });
+
+    let tooltip_content = Box::new(move || {
+        if !all_tabs_valid.get() {
+            view! {
+                Peer cannot be saved while configuration errors " "
+                <span class="icon has-text-danger">
+                    <i class=FontAwesomeIcon::CircleExclamation.as_class() />
+                </span>
+                " " remain.
+            }.into_any()
+        } else { view! {}.into_any() }
+    });
+
     view! {
-        <IconButton
-            icon=FontAwesomeIcon::Save
-            color=ButtonColor::Info
-            size=ButtonSize::Normal
-            state=button_state
-            label="Save Peer"
-            on_action
-        />
+        <Tooltip
+            text=tooltip_content
+            direction=TooltipDirection::Right
+            is_hidden=hide_tooltip
+        >
+            <IconButton
+                icon=FontAwesomeIcon::Save
+                color=ButtonColor::Info
+                size=ButtonSize::Normal
+                state=button_state
+                label="Save Peer"
+                on_action
+            />
+        </Tooltip>
     }
 }

--- a/opendut-lea/src/peers/configurator/components/controls.rs
+++ b/opendut-lea/src/peers/configurator/components/controls.rs
@@ -142,7 +142,7 @@ fn SavePeerButton(
                 </span>
                 " " remain.
             }.into_any()
-        } else { view! {}.into_any() }
+        } else { ().into_any() }
     });
 
     view! {

--- a/opendut-lea/src/peers/configurator/mod.rs
+++ b/opendut-lea/src/peers/configurator/mod.rs
@@ -180,12 +180,6 @@ pub fn PeerConfigurator() -> impl IntoView {
         }
     });
 
-    let is_valid_peer_configuration = Memo::new(move |_| {
-        user_peer_descriptor.with(|peer_configuration| {
-            peer_configuration.is_valid()
-        })
-    });
-
     let peer_id_string = create_read_slice(user_peer_descriptor, |config| config.id.to_string());
     let setup_disabled = create_read_slice(user_peer_descriptor, |config| config.is_new);
 
@@ -283,7 +277,7 @@ pub fn PeerConfigurator() -> impl IntoView {
             title="Configure Peer"
             subtitle=subtitle
             breadcrumbs=breadcrumbs
-            controls=view! { <Controls configuration=user_peer_descriptor is_valid_peer_configuration=is_valid_peer_configuration.into() peer_state=peer_state.into() /> }
+            controls=view! { <Controls user_peer_descriptor peer_state=peer_state.into() /> }
         >
         <div> {cluster_column} </div>
             <Suspense

--- a/opendut-lea/src/viper_sources/configurator/components/controls.rs
+++ b/opendut-lea/src/viper_sources/configurator/components/controls.rs
@@ -118,7 +118,7 @@ fn SaveViperSourceButton(
                 </span>
                 " " remain.
             }.into_any()
-        } else { view! {}.into_any() }
+        } else { ().into_any() }
     });
 
     view! {

--- a/opendut-lea/src/viper_sources/configurator/components/controls.rs
+++ b/opendut-lea/src/viper_sources/configurator/components/controls.rs
@@ -3,6 +3,7 @@ use leptos::prelude::*;
 use leptos_router::hooks::use_navigate;
 use tracing::{debug, error};
 use opendut_lea_components::{use_toaster, ButtonColor, ButtonSize, ButtonState, FontAwesomeIcon, IconButton, Toast};
+use opendut_lea_components::tooltip::{Tooltip, TooltipDirection};
 use opendut_model::viper::ViperSourceDescriptor;
 use crate::app::use_app_globals;
 use crate::routing::{navigate_to, WellKnownRoutes};
@@ -11,12 +12,11 @@ use crate::viper_sources::configurator::types::UserViperSourceConfiguration;
 
 #[component]
 pub fn Controls(
-    configuration: RwSignal<UserViperSourceConfiguration>,
-    #[prop(into)] is_valid_configuration: Signal<bool>,
+    user_source_descriptor: RwSignal<UserViperSourceConfiguration>,
 ) -> impl IntoView {
 
     let viper_source_id = Signal::derive(move || {
-        configuration.get().id
+        user_source_descriptor.get().id
     });
 
     let use_navigate = use_navigate();
@@ -26,10 +26,7 @@ pub fn Controls(
 
     view! {
         <div class="is-flex">
-            <SaveViperSourceButton
-                configuration
-                is_valid_configuration
-            />
+            <SaveViperSourceButton user_source_descriptor />
             <div class="px-1" />
             <DeleteViperSourceButton
                 viper_source_id
@@ -42,26 +39,29 @@ pub fn Controls(
 
 #[component]
 fn SaveViperSourceButton(
-    configuration: RwSignal<UserViperSourceConfiguration>,
-    is_valid_configuration: Signal<bool>,
+    user_source_descriptor: RwSignal<UserViperSourceConfiguration>,
 ) -> impl IntoView {
 
     let globals = use_app_globals();
     let toaster = use_toaster();
 
     let setter = create_write_slice(
-        configuration,
-        |config, input| {
-            config.is_new = input;
+        user_source_descriptor,
+        |descriptor, input| {
+            descriptor.is_new = input;
         },
     );
+
+    let all_tabs_valid = Memo::new(move |_| {
+        user_source_descriptor.with(|descriptor| descriptor.is_valid())
+    });
 
     let pending = RwSignal::new(false);
 
     let button_state = Signal::derive(move || {
         if pending.get() {
             ButtonState::Loading
-        } else if is_valid_configuration.get() {
+        } else if all_tabs_valid.get() {
             ButtonState::Enabled
         } else {
             ButtonState::Disabled
@@ -75,7 +75,7 @@ fn SaveViperSourceButton(
         leptos::task::spawn_local(async move {
             pending.set(true);
 
-            let viper_source_descriptor = ViperSourceDescriptor::try_from(configuration.get_untracked());
+            let viper_source_descriptor = ViperSourceDescriptor::try_from(user_source_descriptor.get_untracked());
             match viper_source_descriptor {
                 Ok(viper_source_descriptor) => {
                     let viper_source_id = viper_source_descriptor.id;
@@ -105,14 +105,36 @@ fn SaveViperSourceButton(
         })
     };
 
+    let hide_tooltip = Signal::derive(move || {
+        all_tabs_valid.get()
+    });
+
+    let tooltip_content = Box::new(move || {
+        if !all_tabs_valid.get() {
+            view! {
+                VIPER Source cannot be saved while configuration errors " "
+                <span class="icon has-text-danger">
+                    <i class=FontAwesomeIcon::CircleExclamation.as_class() />
+                </span>
+                " " remain.
+            }.into_any()
+        } else { view! {}.into_any() }
+    });
+
     view! {
-        <IconButton
-            icon=FontAwesomeIcon::Save
-            color=ButtonColor::Info
-            size=ButtonSize::Normal
-            state=button_state
-            label="Save Viper Source"
-            on_action
-        />
+        <Tooltip
+            text=tooltip_content
+            direction=TooltipDirection::Right
+            is_hidden=hide_tooltip
+        >
+            <IconButton
+                icon=FontAwesomeIcon::Save
+                color=ButtonColor::Info
+                size=ButtonSize::Normal
+                state=button_state
+                label="Save Viper Source"
+                on_action
+            />
+        </Tooltip>
     }
 }

--- a/opendut-lea/src/viper_sources/configurator/components/controls.rs
+++ b/opendut-lea/src/viper_sources/configurator/components/controls.rs
@@ -112,11 +112,11 @@ fn SaveViperSourceButton(
     let tooltip_content = Box::new(move || {
         if !all_tabs_valid.get() {
             view! {
-                VIPER Source cannot be saved while configuration errors " "
+                "VIPER Source cannot be saved while configuration errors "
                 <span class="icon has-text-danger">
                     <i class=FontAwesomeIcon::CircleExclamation.as_class() />
                 </span>
-                " " remain.
+                " remain."
             }.into_any()
         } else { ().into_any() }
     });

--- a/opendut-lea/src/viper_sources/configurator/components/viper_source_kind_select.rs
+++ b/opendut-lea/src/viper_sources/configurator/components/viper_source_kind_select.rs
@@ -6,10 +6,10 @@ use crate::viper_sources::configurator::types::UserViperSourceConfiguration;
 pub fn ViperSourceKindSelect(user_source_descriptor: RwSignal<UserViperSourceConfiguration>) -> impl IntoView {
 
     let (getter, setter) = create_slice(user_source_descriptor,
-                                        |config| {
+        |config| {
             Clone::clone(&config.kind)
         },
-                                        |config, input| {
+        |config, input| {
             config.kind = input;
         }
     );

--- a/opendut-lea/src/viper_sources/configurator/components/viper_source_kind_select.rs
+++ b/opendut-lea/src/viper_sources/configurator/components/viper_source_kind_select.rs
@@ -3,13 +3,13 @@ use opendut_lea_components::{SelectionOption, UserSelect};
 use crate::viper_sources::configurator::types::UserViperSourceConfiguration;
 
 #[component]
-pub fn ViperSourceKindSelect(viper_source_configuration: RwSignal<UserViperSourceConfiguration>) -> impl IntoView {
+pub fn ViperSourceKindSelect(user_source_descriptor: RwSignal<UserViperSourceConfiguration>) -> impl IntoView {
 
-    let (getter, setter) = create_slice(viper_source_configuration,
-        |config| {
+    let (getter, setter) = create_slice(user_source_descriptor,
+                                        |config| {
             Clone::clone(&config.kind)
         },
-        |config, input| {
+                                        |config, input| {
             config.kind = input;
         }
     );

--- a/opendut-lea/src/viper_sources/configurator/mod.rs
+++ b/opendut-lea/src/viper_sources/configurator/mod.rs
@@ -20,65 +20,53 @@ pub fn ViperSourceConfigurator() -> impl IntoView {
     let params = use_params_map();
     let active_tab = use_active_tab::<TabIdentifier>();
     
-    let (viper_source_configuration, viper_source_configuration_resource, is_valid_configuration) = {
-        let viper_source_id = {
-            let viper_source_id = params.with_untracked(|params| {
-                params.get("id").and_then(|id| ViperSourceId::try_from(id.as_str()).ok())
-            });
-            match viper_source_id {
-                None => {
-                    let use_navigate = use_navigate();
-                    navigate_to(WellKnownRoutes::ErrorPage {
-                        title: String::from("Invalid ViperSourceId"),
-                        text: String::from("Could not parse the provided value as ViperSourceId!"),
-                        details: None,
-                    }, use_navigate);
-                    ViperSourceId::random()
-                }
-                Some(viper_source_id) => {
-                    viper_source_id
-                }
-            }
-        };
-
-        let viper_source_configuration = RwSignal::new(
-            UserViperSourceConfiguration {
-                id: viper_source_id,
-                name: UserInputValue::Left(UserInputError::from("Enter a valid VIPER source name.")),
-                url: UserInputValue::Left(UserInputError::from("Enter a valid VIPER source url.")),
-                kind: UserInputValue::Left(UserInputError::from("Select source kind")),
-                is_new: true,
-            }
-        );
-
-        let viper_source_configuration_resource = LocalResource::new(move || {
-            let mut carl = globals.client.clone();
-            async move {
-                if let Ok(configuration) = carl.viper.get_viper_source_descriptor(viper_source_id).await {
-                    viper_source_configuration.update(|user_configuration| {
-                        user_configuration.name = UserInputValue::Right(configuration.name.to_string());
-                        user_configuration.url = UserInputValue::Right(configuration.url.to_string());
-                        user_configuration.kind = UserInputValue::Right(match configuration.kind {
-                            opendut_model::viper::ViperSourceKind::Git => String::from("Git"),
-                            opendut_model::viper::ViperSourceKind::Http => String::from("HTTP"),
-                        });
-                    })
-                }
-            }
+    let viper_source_id = {
+        let viper_source_id = params.with_untracked(|params| {
+            params.get("id").and_then(|id| ViperSourceId::try_from(id.as_str()).ok())
         });
-
-        let is_valid_configuration = Memo::new(move |_| {
-            viper_source_configuration.with(|source_configuration| {
-                source_configuration.name.is_right()
-                && source_configuration.url.is_right()
-                && source_configuration.kind.is_right()
-            })
-        });
-
-        (viper_source_configuration, viper_source_configuration_resource, is_valid_configuration)
+        match viper_source_id {
+            None => {
+                let use_navigate = use_navigate();
+                navigate_to(WellKnownRoutes::ErrorPage {
+                    title: String::from("Invalid ViperSourceId"),
+                    text: String::from("Could not parse the provided value as ViperSourceId!"),
+                    details: None,
+                }, use_navigate);
+                ViperSourceId::random()
+            }
+            Some(viper_source_id) => {
+                viper_source_id
+            }
+        }
     };
 
-    let viper_source_id_string = create_read_slice(viper_source_configuration, |config| config.id.to_string());
+    let user_source_descriptor = RwSignal::new(
+        UserViperSourceConfiguration {
+            id: viper_source_id,
+            name: UserInputValue::Left(UserInputError::from("Enter a valid VIPER source name.")),
+            url: UserInputValue::Left(UserInputError::from("Enter a valid VIPER source url.")),
+            kind: UserInputValue::Left(UserInputError::from("Select source kind")),
+            is_new: true,
+        }
+    );
+
+    let viper_source_descriptor_resource = LocalResource::new(move || {
+        let mut carl = globals.client.clone();
+        async move {
+            if let Ok(configuration) = carl.viper.get_viper_source_descriptor(viper_source_id).await {
+                user_source_descriptor.update(|user_configuration| {
+                    user_configuration.name = UserInputValue::Right(configuration.name.to_string());
+                    user_configuration.url = UserInputValue::Right(configuration.url.to_string());
+                    user_configuration.kind = UserInputValue::Right(match configuration.kind {
+                        opendut_model::viper::ViperSourceKind::Git => String::from("Git"),
+                        opendut_model::viper::ViperSourceKind::Http => String::from("HTTP"),
+                    });
+                })
+            }
+        }
+    });
+
+    let viper_source_id_string = create_read_slice(user_source_descriptor, |config| config.id.to_string());
 
     let breadcrumbs = Signal::derive(move || {
         let viper_source_id = viper_source_id_string.get();
@@ -91,7 +79,7 @@ pub fn ViperSourceConfigurator() -> impl IntoView {
     });
 
     let subtitle = Signal::derive(move || {
-        if let UserInputValue::Right(name) = viper_source_configuration.get().name {
+        if let UserInputValue::Right(name) = user_source_descriptor.get().name {
             name
         } else {
             String::new()
@@ -103,7 +91,7 @@ pub fn ViperSourceConfigurator() -> impl IntoView {
             Tab::from_title_and_href(
                 String::from("General"),
                 TabIdentifier::General.as_str().to_owned()
-            ).with_is_error(Signal::derive(move || !viper_source_configuration.read().is_valid())),
+            ).with_is_error(Signal::derive(move || !user_source_descriptor.read().is_valid())),
         ]
     });
     
@@ -112,19 +100,19 @@ pub fn ViperSourceConfigurator() -> impl IntoView {
             title="Configure VIPER Source"
             subtitle=subtitle
             breadcrumbs=breadcrumbs
-            controls=view! { <Controls configuration=viper_source_configuration is_valid_configuration /> }
+            controls=view! { <Controls user_source_descriptor /> }
         >
             <Suspense
                 fallback=move || view! { <LoadingSpinner /> }
             >
                 {
                     move || Suspend::new(async move {
-                        viper_source_configuration_resource.await;
+                        viper_source_descriptor_resource.await;
 
                         view! {
                             <Tabs tabs active_tab=Signal::derive(move || active_tab.get().as_str())>
                                 { move || match active_tab.get() {
-                                    TabIdentifier::General => view! { <GeneralTab viper_source_configuration /> }
+                                    TabIdentifier::General => view! { <GeneralTab user_source_descriptor /> }
                                 }}
                             </Tabs>
                         }

--- a/opendut-lea/src/viper_sources/configurator/tabs/general/mod.rs
+++ b/opendut-lea/src/viper_sources/configurator/tabs/general/mod.rs
@@ -9,9 +9,9 @@ pub mod name_input;
 pub mod url_input;
 
 #[component]
-pub fn GeneralTab(viper_source_configuration: RwSignal<UserViperSourceConfiguration>) -> impl IntoView {
+pub fn GeneralTab(user_source_descriptor: RwSignal<UserViperSourceConfiguration>) -> impl IntoView {
 
-    let source_id = Signal::derive(move || viper_source_configuration.get().id.to_string());
+    let source_id = Signal::derive(move || user_source_descriptor.get().id.to_string());
 
     view! {
         <div>
@@ -20,13 +20,13 @@ pub fn GeneralTab(viper_source_configuration: RwSignal<UserViperSourceConfigurat
                 value=source_id
             />
             <ViperSourceNameInput
-                viper_source_configuration
+                user_source_descriptor
             />
             <ViperSourceUrlInput
-                viper_source_configuration
+                user_source_descriptor
             />
             <ViperSourceKindSelect
-                viper_source_configuration
+                user_source_descriptor
             />
         </div>
     }

--- a/opendut-lea/src/viper_sources/configurator/tabs/general/name_input.rs
+++ b/opendut-lea/src/viper_sources/configurator/tabs/general/name_input.rs
@@ -7,10 +7,10 @@ use crate::viper_sources::configurator::types::UserViperSourceConfiguration;
 pub fn ViperSourceNameInput(user_source_descriptor: RwSignal<UserViperSourceConfiguration>) -> impl IntoView {
 
     let (getter, setter) = create_slice(user_source_descriptor,
-                                        |config| {
+        |config| {
             Clone::clone(&config.name)
         },
-                                        |config, input| {
+        |config, input| {
             config.name = input;
         }
     );

--- a/opendut-lea/src/viper_sources/configurator/tabs/general/name_input.rs
+++ b/opendut-lea/src/viper_sources/configurator/tabs/general/name_input.rs
@@ -4,13 +4,13 @@ use crate::components::{UserInput, UserInputValue};
 use crate::viper_sources::configurator::types::UserViperSourceConfiguration;
 
 #[component]
-pub fn ViperSourceNameInput(viper_source_configuration: RwSignal<UserViperSourceConfiguration>) -> impl IntoView {
+pub fn ViperSourceNameInput(user_source_descriptor: RwSignal<UserViperSourceConfiguration>) -> impl IntoView {
 
-    let (getter, setter) = create_slice(viper_source_configuration,
-        |config| {
+    let (getter, setter) = create_slice(user_source_descriptor,
+                                        |config| {
             Clone::clone(&config.name)
         },
-        |config, input| {
+                                        |config, input| {
             config.name = input;
         }
     );

--- a/opendut-lea/src/viper_sources/configurator/tabs/general/url_input.rs
+++ b/opendut-lea/src/viper_sources/configurator/tabs/general/url_input.rs
@@ -4,9 +4,9 @@ use crate::components::{UserInput, UserInputValue};
 use crate::viper_sources::configurator::types::UserViperSourceConfiguration;
 
 #[component]
-pub fn ViperSourceUrlInput(viper_source_configuration: RwSignal<UserViperSourceConfiguration>) -> impl IntoView {
+pub fn ViperSourceUrlInput(user_source_descriptor: RwSignal<UserViperSourceConfiguration>) -> impl IntoView {
 
-    let (getter, setter) = create_slice(viper_source_configuration,
+    let (getter, setter) = create_slice(user_source_descriptor,
         |config| {
             Clone::clone(&config.url)
         },

--- a/opendut-lea/src/viper_tests/configurator/components/controls.rs
+++ b/opendut-lea/src/viper_tests/configurator/components/controls.rs
@@ -112,11 +112,11 @@ fn SaveViperTestButton(
     let tooltip_content = Box::new(move || {
         if !all_tabs_valid.get() {
             view! {
-                VIPER Test cannot be saved while configuration errors " "
+                "VIPER Test cannot be saved while configuration errors "
                 <span class="icon has-text-danger">
                     <i class=FontAwesomeIcon::CircleExclamation.as_class() />
                 </span>
-                " " remain.
+                " remain."
             }.into_any()
         } else { ().into_any() }
     });

--- a/opendut-lea/src/viper_tests/configurator/components/controls.rs
+++ b/opendut-lea/src/viper_tests/configurator/components/controls.rs
@@ -118,7 +118,7 @@ fn SaveViperTestButton(
                 </span>
                 " " remain.
             }.into_any()
-        } else { view! {}.into_any() }
+        } else { ().into_any() }
     });
 
     view! {

--- a/opendut-lea/src/viper_tests/configurator/components/controls.rs
+++ b/opendut-lea/src/viper_tests/configurator/components/controls.rs
@@ -3,6 +3,7 @@ use leptos::prelude::*;
 use leptos_router::hooks::use_navigate;
 use tracing::{debug, error};
 use opendut_lea_components::{use_toaster, ButtonColor, ButtonSize, ButtonState, FontAwesomeIcon, IconButton, Toast};
+use opendut_lea_components::tooltip::{Tooltip, TooltipDirection};
 use opendut_model::viper::ViperTestRunDescriptor;
 use crate::app::use_app_globals;
 use crate::routing::{navigate_to, WellKnownRoutes};
@@ -11,12 +12,11 @@ use crate::viper_tests::configurator::types::UserViperTestRunDescriptor;
 
 #[component]
 pub fn Controls(
-    configuration: RwSignal<UserViperTestRunDescriptor>,
-    #[prop(into)] is_valid_configuration: Signal<bool>,
+    user_test_run_descriptor: RwSignal<UserViperTestRunDescriptor>,
 ) -> impl IntoView {
 
     let viper_test_id = Signal::derive(move || {
-        configuration.get().id
+        user_test_run_descriptor.get().id
     });
 
     let use_navigate = use_navigate();
@@ -26,10 +26,7 @@ pub fn Controls(
 
     view! {
         <div class="is-flex">
-            <SaveViperTestButton
-                configuration
-                is_valid_configuration
-            />
+            <SaveViperTestButton user_test_run_descriptor />
             <div class="px-1" />
             <DeleteViperTestButton
                 viper_test_id
@@ -42,26 +39,29 @@ pub fn Controls(
 
 #[component]
 fn SaveViperTestButton(
-    configuration: RwSignal<UserViperTestRunDescriptor>,
-    is_valid_configuration: Signal<bool>,
+    user_test_run_descriptor: RwSignal<UserViperTestRunDescriptor>,
 ) -> impl IntoView {
 
     let globals = use_app_globals();
     let toaster = use_toaster();
 
     let setter = create_write_slice(
-        configuration,
-        |config, input| {
-            config.is_new = input;
+        user_test_run_descriptor,
+        |descriptor, input| {
+            descriptor.is_new = input;
         },
     );
+
+    let all_tabs_valid = Memo::new(move |_| {
+        user_test_run_descriptor.with(|descriptor| descriptor.is_valid())
+    });
 
     let pending = RwSignal::new(false);
 
     let button_state = Signal::derive(move || {
         if pending.get() {
             ButtonState::Loading
-        } else if is_valid_configuration.get() {
+        } else if all_tabs_valid.get() {
             ButtonState::Enabled
         } else {
             ButtonState::Disabled
@@ -75,7 +75,7 @@ fn SaveViperTestButton(
         leptos::task::spawn_local(async move {
             pending.set(true);
 
-            let viper_test_run_descriptor = ViperTestRunDescriptor::try_from(configuration.get_untracked());
+            let viper_test_run_descriptor = ViperTestRunDescriptor::try_from(user_test_run_descriptor.get_untracked());
             match viper_test_run_descriptor {
                 Ok(viper_test_run_descriptor) => {
                     let viper_test_id = viper_test_run_descriptor.id;
@@ -105,14 +105,36 @@ fn SaveViperTestButton(
         })
     };
 
+    let hide_tooltip = Signal::derive(move || {
+        all_tabs_valid.get()
+    });
+
+    let tooltip_content = Box::new(move || {
+        if !all_tabs_valid.get() {
+            view! {
+                VIPER Test cannot be saved while configuration errors " "
+                <span class="icon has-text-danger">
+                    <i class=FontAwesomeIcon::CircleExclamation.as_class() />
+                </span>
+                " " remain.
+            }.into_any()
+        } else { view! {}.into_any() }
+    });
+
     view! {
-        <IconButton
-            icon=FontAwesomeIcon::Save
-            color=ButtonColor::Info
-            size=ButtonSize::Normal
-            state=button_state
-            label="Save Viper Test"
-            on_action
-        />
+        <Tooltip
+            text=tooltip_content
+            direction=TooltipDirection::Right
+            is_hidden=hide_tooltip
+        >
+            <IconButton
+                icon=FontAwesomeIcon::Save
+                color=ButtonColor::Info
+                size=ButtonSize::Normal
+                state=button_state
+                label="Save Viper Test"
+                on_action
+            />
+        </Tooltip>
     }
 }

--- a/opendut-lea/src/viper_tests/configurator/mod.rs
+++ b/opendut-lea/src/viper_tests/configurator/mod.rs
@@ -44,7 +44,7 @@ pub fn ViperTestConfigurator() -> impl IntoView {
         }
     };
 
-    let viper_test_run_descriptor = RwSignal::new(
+    let user_test_run_descriptor = RwSignal::new(
         UserViperTestRunDescriptor {
             id: viper_test_id,
             name: UserInputValue::Left(UserInputError::from("Enter a valid VIPER test name.")),
@@ -61,7 +61,7 @@ pub fn ViperTestConfigurator() -> impl IntoView {
             let mut carl = carl.clone();
             async move {
                 if let Ok(descriptor) = carl.viper.get_viper_test_run_descriptor(viper_test_id).await {
-                    viper_test_run_descriptor.update(|user_configuration| {
+                    user_test_run_descriptor.update(|user_configuration| {
                         let ViperTestRunDescriptor { id: _, name, source: viper_source, peer, parameters } = descriptor;
 
                         user_configuration.name = UserInputValue::Right(name.value().to_owned());
@@ -85,7 +85,7 @@ pub fn ViperTestConfigurator() -> impl IntoView {
     };
 
     let viper_source = create_read_slice(
-        viper_test_run_descriptor,
+        user_test_run_descriptor,
         |descriptor| Clone::clone(&descriptor.viper_source),
     );
 
@@ -107,7 +107,7 @@ pub fn ViperTestConfigurator() -> impl IntoView {
 
                     match result {
                         Ok(test_suite_descriptor) => {
-                            viper_test_run_descriptor.update(|user_configuration| {
+                            user_test_run_descriptor.update(|user_configuration| {
                                 let mut new_parameters: HashMap<ViperParameterName, ViperBindingValueInput> = HashMap::new();
 
                                 for parameter in test_suite_descriptor.parameters.iter() {
@@ -155,11 +155,7 @@ pub fn ViperTestConfigurator() -> impl IntoView {
         })
     };
 
-    let is_valid_configuration = Memo::new(move |_| {
-        viper_test_run_descriptor.with(|config| config.is_valid())
-    });
-
-    let viper_test_id_string = create_read_slice(viper_test_run_descriptor, |config| config.id.to_string());
+    let viper_test_id_string = create_read_slice(user_test_run_descriptor, |config| config.id.to_string());
 
     let breadcrumbs = Signal::derive(move || {
         let viper_test_id = viper_test_id_string.get();
@@ -172,7 +168,7 @@ pub fn ViperTestConfigurator() -> impl IntoView {
     });
 
     let subtitle = Signal::derive(move || {
-        if let UserInputValue::Right(name) = viper_test_run_descriptor.get().name {
+        if let UserInputValue::Right(name) = user_test_run_descriptor.get().name {
             name
         } else {
             String::new()
@@ -184,22 +180,22 @@ pub fn ViperTestConfigurator() -> impl IntoView {
             Tab::from_title_and_href(
                 String::from("General"),
                 TabIdentifier::General.as_str().to_owned()
-            ).with_is_error(Signal::derive(move || !viper_test_run_descriptor.read().valid_general_tab())),
+            ).with_is_error(Signal::derive(move || !user_test_run_descriptor.read().valid_general_tab())),
 
             Tab::from_title_and_href(
                 String::from("VIPER Source"),
                 TabIdentifier::ViperSource.as_str().to_owned()
-            ).with_is_error(Signal::derive(move || !viper_test_run_descriptor.read().valid_viper_source_tab())),
+            ).with_is_error(Signal::derive(move || !user_test_run_descriptor.read().valid_viper_source_tab())),
 
             Tab::from_title_and_href(
                 String::from("Parameters"),
                 TabIdentifier::Parameters.as_str().to_owned()
-            ).with_is_error(Signal::derive(move || !viper_test_run_descriptor.read().valid_parameters_tab())),
+            ).with_is_error(Signal::derive(move || !user_test_run_descriptor.read().valid_parameters_tab())),
 
             Tab::from_title_and_href(
                 String::from("Peer"),
                 TabIdentifier::Peer.as_str().to_owned()
-            ).with_is_error(Signal::derive(move || !viper_test_run_descriptor.read().valid_peer_tab())),
+            ).with_is_error(Signal::derive(move || !user_test_run_descriptor.read().valid_peer_tab())),
         ]
     });
     
@@ -208,7 +204,7 @@ pub fn ViperTestConfigurator() -> impl IntoView {
             title="Configure VIPER Test"
             subtitle
             breadcrumbs
-            controls=view! { <Controls configuration=viper_test_run_descriptor is_valid_configuration /> }
+            controls=view! { <Controls user_test_run_descriptor /> }
         >
             <Suspense
                 fallback=move || view! { <LoadingSpinner /> }
@@ -220,10 +216,10 @@ pub fn ViperTestConfigurator() -> impl IntoView {
                         view! {
                             <Tabs tabs active_tab=Signal::derive(move || active_tab.get().as_str())>
                                 { move || match active_tab.get() {
-                                    TabIdentifier::General => view! { <GeneralTab viper_test_run_descriptor /> }.into_any(),
-                                    TabIdentifier::ViperSource => view! { <SourceTab viper_test_run_descriptor /> }.into_any(),
-                                    TabIdentifier::Parameters => view! { <ParametersTab viper_test_run_descriptor parameter_result=parameter_result.clone() /> }.into_any(),
-                                    TabIdentifier::Peer => view! { <PeerTab viper_test_run_descriptor /> }.into_any()
+                                    TabIdentifier::General => view! { <GeneralTab user_test_run_descriptor /> }.into_any(),
+                                    TabIdentifier::ViperSource => view! { <SourceTab user_test_run_descriptor /> }.into_any(),
+                                    TabIdentifier::Parameters => view! { <ParametersTab user_test_run_descriptor parameter_result=parameter_result.clone() /> }.into_any(),
+                                    TabIdentifier::Peer => view! { <PeerTab user_test_run_descriptor /> }.into_any()
                                 }}
                             </Tabs>
                         }

--- a/opendut-lea/src/viper_tests/configurator/tabs/general/mod.rs
+++ b/opendut-lea/src/viper_tests/configurator/tabs/general/mod.rs
@@ -6,9 +6,9 @@ use crate::viper_tests::configurator::types::UserViperTestRunDescriptor;
 pub mod name_input;
 
 #[component]
-pub fn GeneralTab(viper_test_run_descriptor: RwSignal<UserViperTestRunDescriptor>) -> impl IntoView {
+pub fn GeneralTab(user_test_run_descriptor: RwSignal<UserViperTestRunDescriptor>) -> impl IntoView {
 
-    let test_id = Signal::derive(move || viper_test_run_descriptor.get().id.to_string());
+    let test_id = Signal::derive(move || user_test_run_descriptor.get().id.to_string());
 
     view! {
         <div>
@@ -17,7 +17,7 @@ pub fn GeneralTab(viper_test_run_descriptor: RwSignal<UserViperTestRunDescriptor
                 value=test_id
             />
             <ViperTestNameInput
-                viper_test_run_descriptor
+                user_test_run_descriptor
             />
         </div>
     }

--- a/opendut-lea/src/viper_tests/configurator/tabs/general/name_input.rs
+++ b/opendut-lea/src/viper_tests/configurator/tabs/general/name_input.rs
@@ -5,10 +5,10 @@ use crate::components::{UserInput, UserInputValue};
 use crate::viper_tests::configurator::types::UserViperTestRunDescriptor;
 
 #[component]
-pub fn ViperTestNameInput(viper_test_run_descriptor: RwSignal<UserViperTestRunDescriptor>) -> impl IntoView {
+pub fn ViperTestNameInput(user_test_run_descriptor: RwSignal<UserViperTestRunDescriptor>) -> impl IntoView {
 
     let (getter, setter) = create_slice(
-        viper_test_run_descriptor,
+        user_test_run_descriptor,
         |config| {
             Clone::clone(&config.name)
         },

--- a/opendut-lea/src/viper_tests/configurator/tabs/parameters/mod.rs
+++ b/opendut-lea/src/viper_tests/configurator/tabs/parameters/mod.rs
@@ -13,7 +13,7 @@ use crate::viper_tests::configurator::types::{UserViperTestRunDescriptor, ViperB
 
 #[component]
 pub fn ParametersTab(
-    viper_test_run_descriptor: RwSignal<UserViperTestRunDescriptor>,
+    user_test_run_descriptor: RwSignal<UserViperTestRunDescriptor>,
     parameter_result: Result<ViperParameterDescriptors, SourceFetchError>,
 ) -> impl IntoView {
 
@@ -25,7 +25,7 @@ pub fn ParametersTab(
                     key=|parameter_descriptor| Clone::clone(parameter_descriptor.name())
                     children=move |parameter_descriptor| {
 
-                        let (test_run_getter, test_run_setter) = viper_test_run_descriptor.split();
+                        let (test_run_getter, test_run_setter) = user_test_run_descriptor.split();
 
                         let test_run_getter = {
                             let parameter_descriptor = Clone::clone(&parameter_descriptor);

--- a/opendut-lea/src/viper_tests/configurator/tabs/peer/mod.rs
+++ b/opendut-lea/src/viper_tests/configurator/tabs/peer/mod.rs
@@ -5,9 +5,9 @@ use crate::viper_tests::configurator::tabs::peer::peer_selector::PeerSelector;
 use crate::viper_tests::configurator::types::UserViperTestRunDescriptor;
 
 #[component]
-pub fn PeerTab(viper_test_run_descriptor: RwSignal<UserViperTestRunDescriptor>) -> impl IntoView {
+pub fn PeerTab(user_test_run_descriptor: RwSignal<UserViperTestRunDescriptor>) -> impl IntoView {
 
     view! {
-        <PeerSelector viper_test_run_descriptor />
+        <PeerSelector user_test_run_descriptor />
     }
 }

--- a/opendut-lea/src/viper_tests/configurator/tabs/peer/peer_selector.rs
+++ b/opendut-lea/src/viper_tests/configurator/tabs/peer/peer_selector.rs
@@ -6,7 +6,7 @@ use crate::util;
 use crate::viper_tests::configurator::types::{PeerSelection, UserViperTestRunDescriptor};
 
 #[component]
-pub fn PeerSelector(viper_test_run_descriptor: RwSignal<UserViperTestRunDescriptor>) -> impl IntoView {
+pub fn PeerSelector(user_test_run_descriptor: RwSignal<UserViperTestRunDescriptor>) -> impl IntoView {
 
     let globals = use_app_globals();
 
@@ -26,11 +26,11 @@ pub fn PeerSelector(viper_test_run_descriptor: RwSignal<UserViperTestRunDescript
         })
     };
 
-    let (getter, setter) = create_slice(viper_test_run_descriptor,
-        |config| {
+    let (getter, setter) = create_slice(user_test_run_descriptor,
+                                        |config| {
             Clone::clone(&config.peer)
         },
-        |config, input| {
+                                        |config, input| {
             config.peer = input;
         }
     );

--- a/opendut-lea/src/viper_tests/configurator/tabs/peer/peer_selector.rs
+++ b/opendut-lea/src/viper_tests/configurator/tabs/peer/peer_selector.rs
@@ -27,10 +27,10 @@ pub fn PeerSelector(user_test_run_descriptor: RwSignal<UserViperTestRunDescripto
     };
 
     let (getter, setter) = create_slice(user_test_run_descriptor,
-                                        |config| {
+        |config| {
             Clone::clone(&config.peer)
         },
-                                        |config, input| {
+        |config, input| {
             config.peer = input;
         }
     );

--- a/opendut-lea/src/viper_tests/configurator/tabs/source/mod.rs
+++ b/opendut-lea/src/viper_tests/configurator/tabs/source/mod.rs
@@ -5,9 +5,9 @@ use crate::viper_tests::configurator::types::UserViperTestRunDescriptor;
 pub mod source_selector;
 
 #[component]
-pub fn SourceTab(viper_test_run_descriptor: RwSignal<UserViperTestRunDescriptor>) -> impl IntoView {
+pub fn SourceTab(user_test_run_descriptor: RwSignal<UserViperTestRunDescriptor>) -> impl IntoView {
 
     view! {
-        <ViperTestSourceSelector viper_test_run_descriptor />
+        <ViperTestSourceSelector user_test_run_descriptor />
     }
 }

--- a/opendut-lea/src/viper_tests/configurator/tabs/source/source_selector.rs
+++ b/opendut-lea/src/viper_tests/configurator/tabs/source/source_selector.rs
@@ -5,7 +5,7 @@ use crate::app::use_app_globals;
 use crate::viper_tests::configurator::types::{SourceSelection, UserViperTestRunDescriptor};
 
 #[component]
-pub fn ViperTestSourceSelector(viper_test_run_descriptor: RwSignal<UserViperTestRunDescriptor>) -> impl IntoView {
+pub fn ViperTestSourceSelector(user_test_run_descriptor: RwSignal<UserViperTestRunDescriptor>) -> impl IntoView {
 
     let globals = use_app_globals();
 
@@ -21,7 +21,7 @@ pub fn ViperTestSourceSelector(viper_test_run_descriptor: RwSignal<UserViperTest
         })
     };
 
-    let (getter, setter) = create_slice(viper_test_run_descriptor,
+    let (getter, setter) = create_slice(user_test_run_descriptor,
         |config| {
             Clone::clone(&config.viper_source)
         },


### PR DESCRIPTION
Addressing issue #505

## Note 
Please merge the PR #567 first, as this one builds on it.

## Changes 

- Added a `Tooltip` for all configurator views (`Clusterconfigurator`, `PeerConfigurator`, `ViperTestConfigurator` and `ViperSourceConfigurator`)
- Renamed each `..._descriptor` / `..._configurator` to `user_..._descriptor` (e. g. `user_peer_descriptor`) to match variable names across all configurators

## UI
<img width="1385" height="461" alt="image" src="https://github.com/user-attachments/assets/e28675cb-40fa-4262-b44a-5cadc33faf50" />


## Checklist

- [ ] I have added or updated automated tests.
- [x] I have tested my changes manually.
- [ ] I have added or updated documentation.
