### PR TITLE
Rename error `cause` fields to `source`

### DIFF
--- a/.ci/cargo-ci/src/tasks/coverage.rs
+++ b/.ci/cargo-ci/src/tasks/coverage.rs
@@ -38,7 +38,7 @@ pub fn coverage() -> anyhow::Result<()> {
     let files = fs::read_dir(&out_dir)?
         .filter_map(|entry| {
             entry
-                .inspect_err(|cause| warn!("Ignoring coverage file which could not be read: {cause}"))
+                .inspect_err(|source| warn!("Ignoring coverage file which could not be read: {source}"))
                 .ok()
         })
         .filter(|entry| entry.path().is_file());

--- a/.ci/deploy/opendut-theo/src/commands/vagrant.rs
+++ b/.ci/deploy/opendut-theo/src/commands/vagrant.rs
@@ -126,7 +126,7 @@ impl VagrantCli {
 pub fn running_in_opendut_vm() -> bool {
     let hostname = Command::new("hostname")
         .output()
-        .unwrap_or_else(|cause| panic!("Failed to execute hostname. {cause}"));
+        .unwrap_or_else(|source| panic!("Failed to execute hostname. {source}"));
     let hostname = String::from_utf8(hostname.stdout).expect("Could not determine hostname!");
     hostname.trim().contains(OPENDUT_VM_NAME)
 }

--- a/.ci/deploy/opendut-theo/src/core/docker/command.rs
+++ b/.ci/deploy/opendut-theo/src/core/docker/command.rs
@@ -160,7 +160,7 @@ impl DockerCommand {
         let command_status = self
             .command
             .status()
-            .map_err(|cause| TheoError::DockerCommandFailed(format!("{error_message}. Cause: {cause}")))?;
+            .map_err(|source| TheoError::DockerCommandFailed(format!("{error_message}. Cause: {source}")))?;
 
         if command_status.success() {
             Ok(command_status.code().unwrap_or(1))

--- a/opendut-auth/src/confidential/client.rs
+++ b/opendut-auth/src/confidential/client.rs
@@ -77,13 +77,13 @@ pub type ConfidentialClientRef = Arc<ConfidentialClient>;
 impl ConfidentialClient {
     pub async fn from_settings(settings: &Config) -> Result<Option<ConfidentialClientRef>, ConfidentialClientError> {
         let config_enabled = OidcConfigEnabled::from_settings(settings)
-            .map_err(|cause| ConfidentialClientError::Configuration { message: String::from("Failed to load OIDC configuration"), cause: cause.into() })?;
+            .map_err(|source| ConfidentialClientError::Configuration { message: String::from("Failed to load OIDC configuration"), source: source.into() })?;
 
         match config_enabled {
             OidcConfigEnabled::Yes(config) => {
                 trace!("OIDC configuration loaded: client_id='{}', issuer_url='{}'", config.get_client_id().as_str(), config.get_issuer().value().as_str());
                 let reqwest_client = reqwest_client::oidc::create_from_config(settings)
-                    .map_err(|cause| ConfidentialClientError::Configuration { message: String::from("Failed to create reqwest client."), cause: cause.into() })?;
+                    .map_err(|source| ConfidentialClientError::Configuration { message: String::from("Failed to create reqwest client."), source: source.into() })?;
 
                 let client = ConfidentialClient::from_client_config(*config.clone(), reqwest_client)?;
                 match client.check_connection().await {
@@ -116,7 +116,7 @@ impl ConfidentialClient {
     async fn check_connection(&self) -> Result<(), ConfidentialClientError> {
 
         let token_endpoint = self.issuer_url.value().join("protocol/openid-connect/token")
-            .map_err(|error| ConfidentialClientError::UrlParse { message: String::from("Failed to derive token url from issuer url: "), cause: error })?;
+            .map_err(|error| ConfidentialClientError::UrlParse { message: String::from("Failed to derive token url from issuer url: "), source: error })?;
 
         let operation = move || {
             let client = self.reqwest_client.clone();
@@ -148,7 +148,7 @@ impl ConfidentialClient {
         match backoff_result {
             Ok(_) => Ok(()),
             Err(error) => {
-                Err(ConfidentialClientError::KeycloakConnection { message: String::from("Could not connect to Keycloak"), cause: error })
+                Err(ConfidentialClientError::KeycloakConnection { message: String::from("Could not connect to Keycloak"), source: error })
             }
         }
     }
@@ -277,18 +277,18 @@ pub async fn async_http_client(
         request_builder = request_builder.header(name.as_str(), value.as_bytes());
     }
     let request = request_builder.build()
-        .map_err(|cause| {
-            OidcClientError::AuthReqwest { message: cause.to_string(), status: cause.status().unwrap_or_default().to_string(), inner: cause }
+        .map_err(|source| {
+            OidcClientError::AuthReqwest { message: source.to_string(), status: source.status().unwrap_or_default().to_string(), inner: source }
         })?;
     let response = client.execute(request).await
-        .map_err(|cause: reqwest::Error| {
-            OidcClientError::AuthReqwest { message: cause.to_string(), status: cause.status().unwrap_or_default().to_string(), inner: cause }
+        .map_err(|source: reqwest::Error| {
+            OidcClientError::AuthReqwest { message: source.to_string(), status: source.status().unwrap_or_default().to_string(), inner: source }
         })?;
     let status_code = response.status();
     let headers = response.headers().to_owned();
     let data = response.bytes().await
-        .map_err(|cause| {
-            OidcClientError::AuthReqwest { message: cause.to_string(), status: cause.status().unwrap_or_default().to_string(), inner: cause }
+        .map_err(|source| {
+            OidcClientError::AuthReqwest { message: source.to_string(), status: source.status().unwrap_or_default().to_string(), inner: source }
         })?;
 
     let returned_response = {
@@ -299,8 +299,8 @@ pub async fn async_http_client(
         }
         returned_response
             .body(data.to_vec())
-            .map_err(|cause| {
-                OidcClientError::Other(format!("Failed to build response body: {cause}"))
+            .map_err(|source| {
+                OidcClientError::Other(format!("Failed to build response body: {source}"))
             })?
     };
 

--- a/opendut-auth/src/confidential/config.rs
+++ b/opendut-auth/src/confidential/config.rs
@@ -74,7 +74,7 @@ pub enum OidcConfigEnabled {
 impl OidcConfigEnabled {
     pub fn from_settings(settings: &Config) -> Result<Self, ConfidentialClientError> {
         let oidc_enabled = settings.get_bool(CONFIG_KEY_OIDC_ENABLED)
-            .map_err(|cause| ConfidentialClientError::Configuration { message: format!("No configuration found for {CONFIG_KEY_OIDC_ENABLED}."), cause: cause.into() })?;
+            .map_err(|source| ConfidentialClientError::Configuration { message: format!("No configuration found for {CONFIG_KEY_OIDC_ENABLED}."), source: source.into() })?;
         if oidc_enabled {
             Ok(Self::Yes(Box::new(OidcClientConfig::Confidential(OidcConfidentialClientConfig::from_settings(settings)?))))
         } else {
@@ -143,9 +143,9 @@ impl OidcConfidentialClientConfig {
 
     pub fn get_client(&self) -> Result<ConfiguredClient, ConfidentialClientError> {
         let auth_endpoint = self.issuer_url.value().join("protocol/openid-connect/auth")
-            .map_err(|cause| ConfidentialClientError::Configuration { message: String::from("Failed to derive authorization url from issuer url."), cause: cause.into() })?;
+            .map_err(|source| ConfidentialClientError::Configuration { message: String::from("Failed to derive authorization url from issuer url."), source: source.into() })?;
         let token_endpoint = self.issuer_url.value().join("protocol/openid-connect/token")
-            .map_err(|cause| ConfidentialClientError::Configuration { message: String::from("Failed to derive token url from issuer url."), cause: cause.into() })?;
+            .map_err(|source| ConfidentialClientError::Configuration { message: String::from("Failed to derive token url from issuer url."), source: source.into() })?;
 
         let client = BasicClient::new(self.client_id.clone())
             .set_client_secret(self.client_secret.clone())
@@ -159,16 +159,16 @@ impl OidcConfidentialClientConfig {
 impl OidcConfidentialClientConfig {
     pub fn from_settings(settings: &Config) -> Result<Self, ConfidentialClientError> {
         let client_id = settings.get_string(OidcConfidentialClientConfig::CLIENT_ID)
-            .map_err(|error| ConfidentialClientError::Configuration { message: format!("Failed to find configuration for `{}`.", OidcConfidentialClientConfig::CLIENT_ID), cause: error.into() })?;
+            .map_err(|error| ConfidentialClientError::Configuration { message: format!("Failed to find configuration for `{}`.", OidcConfidentialClientConfig::CLIENT_ID), source: error.into() })?;
         let client_secret = settings.get_string(OidcConfidentialClientConfig::CLIENT_SECRET)
-            .map_err(|error| ConfidentialClientError::Configuration { message: format!("Failed to find configuration for `{}`.", OidcConfidentialClientConfig::CLIENT_SECRET), cause: error.into() })?;
+            .map_err(|error| ConfidentialClientError::Configuration { message: format!("Failed to find configuration for `{}`.", OidcConfidentialClientConfig::CLIENT_SECRET), source: error.into() })?;
         let issuer = settings.get_string(OidcConfidentialClientConfig::ISSUER_URL)
-            .map_err(|error| ConfidentialClientError::Configuration { message: format!("Failed to find configuration for `{}`.", OidcConfidentialClientConfig::ISSUER_URL), cause: error.into() })?;
+            .map_err(|error| ConfidentialClientError::Configuration { message: format!("Failed to find configuration for `{}`.", OidcConfidentialClientConfig::ISSUER_URL), source: error.into() })?;
 
         let issuer_url = IssuerUrl::try_from(&issuer)
-            .map_err(|error| ConfidentialClientError::Configuration { message: format!("Failed to parse issuer URL: `{issuer}`."), cause: error.into() })?;
+            .map_err(|error| ConfidentialClientError::Configuration { message: format!("Failed to parse issuer URL: `{issuer}`."), source: error.into() })?;
         let raw_scopes = settings.get_string(OidcConfidentialClientConfig::SCOPES)
-            .map_err(|error| ConfidentialClientError::Configuration { message: format!("Failed to find configuration for `{}`.", OidcConfidentialClientConfig::SCOPES), cause: error.into() })?;
+            .map_err(|error| ConfidentialClientError::Configuration { message: format!("Failed to find configuration for `{}`.", OidcConfidentialClientConfig::SCOPES), source: error.into() })?;
         let scopes = OidcConfidentialClientConfig::parse_scopes(&client_id, raw_scopes);
 
         Ok(Self {

--- a/opendut-auth/src/confidential/error.rs
+++ b/opendut-auth/src/confidential/error.rs
@@ -21,12 +21,12 @@ pub enum OidcClientError {
 
 #[derive(thiserror::Error, Debug)]
 pub enum ConfidentialClientError {
-    #[error("Failed to load OIDC configuration: '{message}'. Cause: '{cause}'")]
-    Configuration { message: String, cause: Box<dyn std::error::Error + Send + Sync> },
-    #[error("{message}\n  {cause}")]
-    KeycloakConnection { message: String, cause: reqwest::Error },
-    #[error("{message}\n  {cause}")]
-    UrlParse { message: String, cause: url::ParseError },
+    #[error("Failed to load OIDC configuration: '{message}'. Cause: '{source}'")]
+    Configuration { message: String, source: Box<dyn std::error::Error + Send + Sync> },
+    #[error("{message}\n  {source}")]
+    KeycloakConnection { message: String, source: reqwest::Error },
+    #[error("{message}\n  {source}")]
+    UrlParse { message: String, source: url::ParseError },
     #[error("OIDC configuration error: '{message}'.")]
     Other { message: String },
 }

--- a/opendut-auth/src/registration/client.rs
+++ b/opendut-auth/src/registration/client.rs
@@ -37,16 +37,16 @@ pub enum RegistrationClientError {
     #[error("Failed request: {error}")]
     RequestError {
         error: String,
-        #[source] cause: Box<dyn std::error::Error + Send + Sync>,
+        source: Box<dyn std::error::Error + Send + Sync>,
     },
     #[error("Failed to register new client: {message}")]
     ClientParameter {
         message: String,
-        #[source] cause: Box<dyn std::error::Error + Send + Sync>,
+        source: Box<dyn std::error::Error + Send + Sync>,
     },
     #[error("Failed to register new client")]
     Registration {
-        #[source] cause: WrappedClientRegistrationError,
+        source: WrappedClientRegistrationError,
     },
     #[error("Client could not be found")]
     ClientNotFound,
@@ -88,7 +88,7 @@ impl RegistrationClient {
             }
             None => {
                 let access_token = self.inner.get_token().await
-                    .map_err(|error| RegistrationClientError::RequestError { error: error.to_string(), cause: Box::new(error) })?;
+                    .map_err(|error| RegistrationClientError::RequestError { error: error.to_string(), source: Box::new(error) })?;
                 let additional_metadata = EmptyAdditionalClientMetadata {};
                 let redirect_uris = vec![self.config.device_redirect_url.clone()];
                 let grant_types = vec![CoreGrantType::ClientCredentials];
@@ -104,12 +104,12 @@ impl RegistrationClient {
                 let resource_uri = self.config.client_home_base_url.resource_url(resource_id, user_id)
                     .map_err(|error| RegistrationClientError::ClientParameter {
                         message: format!("Failed to create resource url for client: {error:?}"),
-                        cause: Box::new(error),
+                        source: Box::new(error),
                     })?;
                 let client_home_uri = ClientUrl::new(String::from(resource_uri))
                     .map_err(|error| RegistrationClientError::ClientParameter {
                         message: format!("Failed to create client home url: {error:?}"),
-                        cause: Box::new(error),
+                        source: Box::new(error),
                     })?;
                 let response = ExplicitSendFutureWrapper::from(
                     request
@@ -140,7 +140,7 @@ impl RegistrationClient {
                         })
                     }
                     Err(error) => {
-                        Err(RegistrationClientError::Registration { cause: WrappedClientRegistrationError(error) })
+                        Err(RegistrationClientError::Registration { source: WrappedClientRegistrationError(error) })
                     }
                 }
             }
@@ -149,21 +149,21 @@ impl RegistrationClient {
     
     pub async fn list_clients(&self) -> Result<Clients, RegistrationClientError> {
         let enumerate_clients_uri = self.config.issuer_admin_url.value().join("clients/")
-            .map_err(|cause| RegistrationClientError::InvalidConfiguration { error: format!("Invalid admin api endpoint for issuer. {cause}") })?;
+            .map_err(|source| RegistrationClientError::InvalidConfiguration { error: format!("Invalid admin api endpoint for issuer. {source}") })?;
         let request = self.create_http_request_with_auth_token(&enumerate_clients_uri, http::Method::GET).await?;
 
         let response = async_http_client(&self.inner.reqwest_client, request).await;
         match response {
             Ok(response) => {
                  let clients: Clients = serde_json::from_slice(response.body())
-                     .map_err(|cause| {
-                         error!("Could not deserialize client list from keycloak: {:?}\nBody:\n{}", cause, String::from_utf8_lossy(response.body()));
-                         RegistrationClientError::InvalidConfiguration { error: format!("Could not deserialize response body. {cause}") }
+                     .map_err(|source| {
+                         error!("Could not deserialize client list from keycloak: {:?}\nBody:\n{}", source, String::from_utf8_lossy(response.body()));
+                         RegistrationClientError::InvalidConfiguration { error: format!("Could not deserialize response body. {source}") }
                      })?;
                  Ok(clients)
             }
             Err(error) => {
-                 Err(RegistrationClientError::RequestError { error: "OIDC client list request failed!".to_string(), cause: Box::new(error) })
+                 Err(RegistrationClientError::RequestError { error: "OIDC client list request failed!".to_string(), source: Box::new(error) })
             }
         }
     }
@@ -195,17 +195,17 @@ impl RegistrationClient {
     pub async fn delete_client(&self, client_id: &String) -> Result<HttpResponse, RegistrationClientError> {
         let client_uri = format!("clients/{client_id}");
         let delete_client_url = self.config.issuer_admin_url.value().join(&client_uri)
-            .map_err(|cause| RegistrationClientError::InvalidConfiguration { error: format!("Invalid admin api endpoint for issuer. {cause}") })?;
+            .map_err(|source| RegistrationClientError::InvalidConfiguration { error: format!("Invalid admin api endpoint for issuer. {source}") })?;
 
         let request = self.create_http_request_with_auth_token(&delete_client_url, http::Method::DELETE).await?;
 
         async_http_client(&self.inner.reqwest_client, request).await
-            .map_err(|error| RegistrationClientError::RequestError { error: error.to_string(), cause: error.into() })
+            .map_err(|error| RegistrationClientError::RequestError { error: error.to_string(), source: error.into() })
     }
 
     async fn create_http_request_with_auth_token(&self, issuer_remote_url: &Url, http_method: http::Method) -> Result<HttpRequest, RegistrationClientError> {
         let access_token = self.inner.get_token().await
-            .map_err(|error| RegistrationClientError::RequestError { error: error.to_string(), cause: error.into() })?;
+            .map_err(|error| RegistrationClientError::RequestError { error: error.to_string(), source: error.into() })?;
         let bearer_header = format!("Bearer {access_token}");
         let access_token_value = HeaderValue::from_str(&bearer_header)
             .map_err(|error| RegistrationClientError::InvalidConfiguration { error: error.to_string() })?;
@@ -218,7 +218,7 @@ impl RegistrationClient {
             .uri(issuer_remote_url)
             .header(http::header::AUTHORIZATION, access_token_value)
             .body(vec![])
-            .map_err(|error| RegistrationClientError::RequestError { error: error.to_string(), cause: error.into() })?;
+            .map_err(|error| RegistrationClientError::RequestError { error: error.to_string(), source: error.into() })?;
 
         Ok(request)
     }

--- a/opendut-carl/opendut-carl-api/src/carl/broker.rs
+++ b/opendut-carl/opendut-carl-api/src/carl/broker.rs
@@ -141,13 +141,13 @@ mod client {
                     self.inner.open(request)
                 )
                     .await
-                    .map_err(|cause| error::OpenStream { message: format!("Error while opening stream: {cause}") })?
+                    .map_err(|source| error::OpenStream { message: format!("Error while opening stream: {source}") })?
             };
 
             let inbound = response.into_inner()
                 .map(|result| result.and_then(|message| {
                     DownstreamMessage::try_from(message)
-                        .map_err(|cause| tonic::Status::invalid_argument(format!("Error while converting stream message in open_stream: {cause}")))
+                        .map_err(|source| tonic::Status::invalid_argument(format!("Error while converting stream message in open_stream: {source}")))
                 }));
 
             Ok((GrpcDownstream::from(inbound), GrpcUpstream::from(tx)))

--- a/opendut-carl/opendut-carl-api/src/carl/client/mod.rs
+++ b/opendut-carl/opendut-carl-api/src/carl/client/mod.rs
@@ -46,25 +46,25 @@ impl <A> From<ConversionError> for ClientError<A>
 where
     A: Display
 {
-    fn from(cause: ConversionError) -> Self {
-        Self::InvalidResponse(cause.to_string())
+    fn from(source: ConversionError) -> Self {
+        Self::InvalidResponse(source.to_string())
     }
 }
 
 #[derive(thiserror::Error, Debug)]
 pub enum InitializationError {
-    #[error("Invalid URI '{uri}': {cause}")]
-    InvalidUri { uri: String, cause: InvalidUri },
+    #[error("Invalid URI '{uri}': {source}")]
+    InvalidUri { uri: String, source: InvalidUri },
     #[error("Expected https scheme. Given scheme: '{given_scheme}'")]
     ExpectedHttpsScheme { given_scheme: String },
-    #[error("{message}: {cause}")]
-    OidcConfiguration { message: String, cause: Box<dyn std::error::Error + Send + Sync> },
-    #[error("{message}: {cause}")]
-    TlsConfiguration { message: String, cause: Box<dyn std::error::Error + Send + Sync> },
+    #[error("{message}: {source}")]
+    OidcConfiguration { message: String, source: Box<dyn std::error::Error + Send + Sync> },
+    #[error("{message}: {source}")]
+    TlsConfiguration { message: String, source: Box<dyn std::error::Error + Send + Sync> },
     #[error("{message}")]
     TlsClientConfiguration { message: String },
-    #[error("Error while connecting to CARL at '{address}': {cause}")]
-    ConnectError { address: String, cause: Box<dyn std::error::Error + Send + Sync> },
+    #[error("Error while connecting to CARL at '{address}': {source}")]
+    ConnectError { address: String, source: Box<dyn std::error::Error + Send + Sync> },
 }
 
 pub trait ExtractOrClientError<A, B, E>
@@ -87,7 +87,7 @@ where
             .ok_or_else(|| ClientError::InvalidResponse(format!("Field '{}' not set", Clone::clone(&field).into())))
             .and_then(|value| {
                 B::try_from(value)
-                    .map_err(|cause| ClientError::InvalidResponse(format!("Field '{}' is not valid: {}", field.into(), cause)))
+                    .map_err(|source| ClientError::InvalidResponse(format!("Field '{}' is not valid: {}", field.into(), source)))
             })
     }
 }

--- a/opendut-carl/opendut-carl-api/src/carl/client/native.rs
+++ b/opendut-carl/opendut-carl-api/src/carl/client/native.rs
@@ -74,21 +74,21 @@ impl CarlClient {
         };
 
         let endpoint = tonic::transport::Channel::from_shared(address.clone())
-            .map_err(|cause| InitializationError::InvalidUri { uri: address.clone(), cause })?
+            .map_err(|source| InitializationError::InvalidUri { uri: address.clone(), source })?
             .tls_config(tls_config)
-            .map_err(|cause| InitializationError::TlsConfiguration { message: String::from("Failed to initialize secure channel with specified TLS configuration"), cause: cause.into() })?;
+            .map_err(|source| InitializationError::TlsConfiguration { message: String::from("Failed to initialize secure channel with specified TLS configuration"), source: source.into() })?;
 
         let oidc_client = ConfidentialClient::from_settings(settings).await
-            .map_err(|cause| InitializationError::OidcConfiguration { message: String::from("Failed to initialize OIDC authentication manager"), cause: cause.into() })?;
+            .map_err(|source| InitializationError::OidcConfiguration { message: String::from("Failed to initialize OIDC authentication manager"), source: source.into() })?;
 
         if let Some(oidc_client) = &oidc_client {
             oidc_client.check_login().await
-                .map_err(|cause| InitializationError::ConnectError { address: address.clone(), cause: cause.into() })?;
+                .map_err(|source| InitializationError::ConnectError { address: address.clone(), source: source.into() })?;
         }
         debug!("Set up endpoint for connection to CARL at '{address}'.");
 
         let channel = endpoint.connect().await
-            .map_err(|cause| InitializationError::ConnectError { address: address.clone(), cause: cause.into() })?;
+            .map_err(|source| InitializationError::ConnectError { address: address.clone(), source: source.into() })?;
         info!("Connected to CARL at '{address}'.");
 
         let auth_service = ServiceBuilder::new()

--- a/opendut-carl/opendut-carl-api/src/carl/cluster.rs
+++ b/opendut-carl/opendut-carl-api/src/carl/cluster.rs
@@ -9,11 +9,11 @@ use opendut_model::ShortName;
 
 #[derive(thiserror::Error, Debug)]
 pub enum CreateClusterDescriptorError {
-    #[error("ClusterConfigration '{cluster_name}' <{cluster_id}> could not be created, due to internal errors:\n  {cause}")]
+    #[error("ClusterConfigration '{cluster_name}' <{cluster_id}> could not be created, due to internal errors:\n  {message}")]
     Internal {
         cluster_id: ClusterId,
         cluster_name: ClusterName,
-        cause: String
+        message: String
     }
 }
 
@@ -44,11 +44,11 @@ pub enum DeleteClusterDescriptorError {
         actual_state: ClusterState,
         required_states: Vec<ClusterState>,
     },
-    #[error("ClusterDescriptor {cluster} deleted with internal errors:\n  {cause}", cluster=ClusterDisplay::new(cluster_name, cluster_id))]
+    #[error("ClusterDescriptor {cluster} deleted with internal errors:\n  {message}", cluster=ClusterDisplay::new(cluster_name, cluster_id))]
     Internal {
         cluster_id: ClusterId,
         cluster_name: Option<ClusterName>,
-        cause: String
+        message: String
     }
 }
 
@@ -73,11 +73,11 @@ pub enum StoreClusterDeploymentError {
         cluster_name: Option<ClusterName>,
         invalid_peers: Vec<PeerId>,
     },
-    #[error("ClusterDeployment for cluster {cluster} could not be changed, due to internal errors:\n  {cause}", cluster=ClusterDisplay::new(cluster_name, cluster_id))]
+    #[error("ClusterDeployment for cluster {cluster} could not be changed, due to internal errors:\n  {message}", cluster=ClusterDisplay::new(cluster_name, cluster_id))]
     Internal {
         cluster_id: ClusterId,
         cluster_name: Option<ClusterName>,
-        cause: String
+        message: String
     }
 }
 
@@ -98,18 +98,18 @@ pub enum DeleteClusterDeploymentError {
         actual_state: ClusterState,
         required_states: Vec<ClusterState>,
     },
-    #[error("ClusterDeployment for cluster {cluster} deleted with internal errors:\n  {cause}", cluster=ClusterDisplay::new(cluster_name, cluster_id))]
+    #[error("ClusterDeployment for cluster {cluster} deleted with internal errors:\n  {message}", cluster=ClusterDisplay::new(cluster_name, cluster_id))]
     Internal {
         cluster_id: ClusterId,
         cluster_name: Option<ClusterName>,
-        cause: String
+        message: String
     },
 }
 
 #[derive(thiserror::Error, Debug)]
 pub enum GetClusterDeploymentError {
-    #[error("ClusterDeployment for cluster <{cluster_id}> could not be retrieved, due to internal errors:\n  {cause}")]
-    Internal { cluster_id: ClusterId, cause: String },
+    #[error("ClusterDeployment for cluster <{cluster_id}> could not be retrieved, due to internal errors:\n  {message}")]
+    Internal { cluster_id: ClusterId, message: String },
 }
 
 #[derive(thiserror::Error, Debug)]
@@ -326,21 +326,21 @@ mod client {
             match self.inner.get_cluster_deployment(request).await {
                 Ok(response) => {
                     let result = response.into_inner().result
-                        .ok_or(GetClusterDeploymentError::Internal { cluster_id, cause: String::from("Response contains no result!") })?;
+                        .ok_or(GetClusterDeploymentError::Internal { cluster_id, message: String::from("Response contains no result!") })?;
                     match result {
                         cluster_manager::get_cluster_deployment_response::Result::Failure(_) => {
-                            Err(GetClusterDeploymentError::Internal { cluster_id, cause: String::from("Failed to get cluster deployment!") })
+                            Err(GetClusterDeploymentError::Internal { cluster_id, message: String::from("Failed to get cluster deployment!") })
                         }
                         cluster_manager::get_cluster_deployment_response::Result::Success(cluster_manager::GetClusterDeploymentSuccess { deployment }) => {
                             let deployment = deployment
-                                .ok_or(GetClusterDeploymentError::Internal { cluster_id, cause: String::from("Response contains no cluster deployment!") })?;
+                                .ok_or(GetClusterDeploymentError::Internal { cluster_id, message: String::from("Response contains no cluster deployment!") })?;
                             ClusterDeployment::try_from(deployment)
-                                .map_err(|_| GetClusterDeploymentError::Internal { cluster_id, cause: String::from("Conversion failed for cluster deployment!") })
+                                .map_err(|_| GetClusterDeploymentError::Internal { cluster_id, message: String::from("Conversion failed for cluster deployment!") })
                         }
                     }
                 },
                 Err(status) => {
-                    Err(GetClusterDeploymentError::Internal { cluster_id, cause: format!("gRPC failure: {status}") })
+                    Err(GetClusterDeploymentError::Internal { cluster_id, message: format!("gRPC failure: {status}") })
                 }
             }
         }

--- a/opendut-carl/opendut-carl-api/src/carl/observer.rs
+++ b/opendut-carl/opendut-carl-api/src/carl/observer.rs
@@ -118,12 +118,12 @@ mod client {
             let response = self.inner
                 .wait_for_peers_online(proto_request)
                 .await
-                .map_err(|cause| error::OpenStream { message: format!("Error while opening stream: {cause}") })?;
+                .map_err(|source| error::OpenStream { message: format!("Error while opening stream: {source}") })?;
 
             let inbound = response.into_inner()
                 .map(|result| result.and_then(|element| {
                     WaitForPeersOnlineResponse::try_from(element)
-                        .map_err(|cause| tonic::Status::invalid_argument(format!("Error while converting stream message in wait_peers_online: {cause}")))
+                        .map_err(|source| tonic::Status::invalid_argument(format!("Error while converting stream message in wait_peers_online: {source}")))
                 }));
 
             Ok(GrpcDownstream::from(inbound))

--- a/opendut-carl/opendut-carl-api/src/carl/peer.rs
+++ b/opendut-carl/opendut-carl-api/src/carl/peer.rs
@@ -22,11 +22,11 @@ pub enum StorePeerDescriptorError {
         peer_name: PeerName,
         error: IllegalDevicesError
     },
-    #[error("Peer '{peer_name}' <{peer_id}> could not be created, due to internal errors:\n  {cause}")]
+    #[error("Peer '{peer_name}' <{peer_id}> could not be created, due to internal errors:\n  {message}")]
     Internal {
         peer_id: PeerId,
         peer_name: PeerName,
-        cause: String
+        message: String
     }
 }
 
@@ -52,11 +52,11 @@ pub enum DeletePeerDescriptorError {
         actual_state: PeerState,
         required_states: Vec<PeerState>,
     },
-    #[error("Peer {peer} deleted with internal errors:\n  {cause}", peer=format_id_with_optional_name(peer_id, peer_name))]
+    #[error("Peer {peer} deleted with internal errors:\n  {message}", peer=format_id_with_optional_name(peer_id, peer_name))]
     Internal {
         peer_id: PeerId,
         peer_name: Option<PeerName>,
-        cause: String,
+        message: String,
     }
 }
 
@@ -66,18 +66,18 @@ pub enum GetPeerDescriptorError {
     PeerNotFound {
         peer_id: PeerId
     },
-    #[error("An internal error occurred searching for a peer with id <{peer_id}>:\n  {cause}")]
+    #[error("An internal error occurred searching for a peer with id <{peer_id}>:\n  {message}")]
     Internal {
         peer_id: PeerId,
-        cause: String
+        message: String
     }
 }
 
 #[derive(thiserror::Error, Debug)]
 pub enum ListPeerDescriptorsError {
-    #[error("An internal error occurred computing the list of peers:\n  {cause}")]
+    #[error("An internal error occurred computing the list of peers:\n  {message}")]
     Internal {
-        cause: String
+        message: String
     }
 }
 
@@ -87,26 +87,26 @@ pub enum GetPeerStateError {
     PeerNotFound {
         peer_id: PeerId
     },
-    #[error("An internal error occurred searching for the state of a peer with id <{peer_id}>:\n  {cause}")]
+    #[error("An internal error occurred searching for the state of a peer with id <{peer_id}>:\n  {message}")]
     Internal {
         peer_id: PeerId,
-        cause: String
+        message: String
     }
 }
 
 #[derive(thiserror::Error, Debug, PartialEq, Eq)]
 pub enum ListPeerStatesError {
-    #[error("An internal error occurred while listing peer states:\n  {cause}")]
+    #[error("An internal error occurred while listing peer states:\n  {message}")]
     Internal {
-        cause: String
+        message: String
     }
 }
 
 #[derive(thiserror::Error, Debug)]
 pub enum ListDevicesError {
-    #[error("An internal error occurred computing the list of devices:\n  {cause}")]
+    #[error("An internal error occurred computing the list of devices:\n  {message}")]
     Internal {
-        cause: String
+        message: String
     }
 }
 
@@ -327,7 +327,7 @@ mod client {
                             setup
                                 .ok_or(CreateSetupError { message: format!("Failed to create setup-string for peer <{peer_id}>! Got no PeerSetup!") })
                                 .and_then(|setup| PeerSetup::try_from(setup)
-                                    .map_err(|cause| CreateSetupError { message: cause.to_string() })
+                                    .map_err(|source| CreateSetupError { message: source.to_string() })
                                 )
                         }
                         _ => {
@@ -357,7 +357,7 @@ mod client {
                             setup
                                 .ok_or(CreateSetupError { message: "Failed to create setup-string for CLEO! Got no CleoSetup!".to_owned() })
                                 .and_then(|setup| CleoSetup::try_from(setup)
-                                    .map_err(|cause| CreateSetupError { message: cause.to_string() })
+                                    .map_err(|source| CreateSetupError { message: source.to_string() })
                                 )
                         }
                         _ => {
@@ -382,10 +382,10 @@ mod client {
                         .into_iter()
                         .map(DeviceDescriptor::try_from)
                         .collect::<Result<_, _>>()
-                        .map_err(|cause| ListDevicesError::Internal { cause: cause.to_string() })
+                        .map_err(|source| ListDevicesError::Internal { message: source.to_string() })
                 },
                 Err(status) => {
-                    Err(ListDevicesError::Internal { cause: format!("gRPC failure: {status}") })
+                    Err(ListDevicesError::Internal { message: format!("gRPC failure: {status}") })
                 },
             }
         }

--- a/opendut-carl/opendut-carl-api/src/carl/viper.rs
+++ b/opendut-carl/opendut-carl-api/src/carl/viper.rs
@@ -11,11 +11,11 @@ use opendut_model::format::{format_id_with_name, format_id_with_optional_name};
 
 #[derive(thiserror::Error, Debug)]
 pub enum StoreViperSourceDescriptorError {
-    #[error("VIPER source {source} could not be created, due to internal errors:\n  {cause}", source=format_id_with_name(source_id, source_name))]
+    #[error("VIPER source {source} could not be created, due to internal errors:\n  {message}", source=format_id_with_name(source_id, source_name))]
     Internal {
         source_id: ViperSourceId,
         source_name: ViperTestSuiteIdentifier,
-        cause: String
+        message: String
     }
 }
 
@@ -30,11 +30,11 @@ pub enum DeleteViperSourceDescriptorError {
         source_id: ViperSourceId,
         test_id: ViperTestId,
     },
-    #[error("VIPER source {source} deleted with internal errors:\n  {cause}", source=format_id_with_optional_name(source_id, source_name))]
+    #[error("VIPER source {source} deleted with internal errors:\n  {message}", source=format_id_with_optional_name(source_id, source_name))]
     Internal {
         source_id: ViperSourceId,
         source_name: Option<ViperTestSuiteIdentifier>,
-        cause: String,
+        message: String,
     }
 }
 
@@ -44,18 +44,18 @@ pub enum GetViperSourceDescriptorError {
     SourceNotFound {
         source_id: ViperSourceId
     },
-    #[error("An internal error occurred searching for a VIPER source with ID <{source_id}>:\n  {cause}")]
+    #[error("An internal error occurred searching for a VIPER source with ID <{source_id}>:\n  {message}")]
     Internal {
         source_id: ViperSourceId,
-        cause: String
+        message: String
     }
 }
 
 #[derive(thiserror::Error, Debug)]
 pub enum ListViperSourceDescriptorsError {
-    #[error("An internal error occurred computing the list of VIPER sources:\n  {cause}")]
+    #[error("An internal error occurred computing the list of VIPER sources:\n  {message}")]
     Internal {
-        cause: String
+        message: String
     }
 }
 
@@ -80,10 +80,10 @@ pub enum GetViperTestSuiteParametersError {
         source_id: ViperSourceId,
         source_name: ViperTestSuiteIdentifier,
     },
-    #[error("An internal error occurred while fetching the VIPER test suite descriptor for source <{source_id}>:\n  {cause}")]
+    #[error("An internal error occurred while fetching the VIPER test suite descriptor for source <{source_id}>:\n  {message}")]
     Internal {
         source_id: ViperSourceId,
-        cause: String,
+        message: String,
     }
 }
 
@@ -94,10 +94,10 @@ pub enum GetViperTestSuiteParametersError {
 
 #[derive(thiserror::Error, Debug)]
 pub enum StoreViperTestRunDescriptorError {
-    #[error("Test <{test_id}> could not be created, due to internal errors:\n  {cause}")]
+    #[error("Test <{test_id}> could not be created, due to internal errors:\n  {message}")]
     Internal {
         test_id: ViperTestId,
-        cause: String
+        message: String
     }
 }
 
@@ -112,10 +112,10 @@ pub enum DeleteViperTestRunDescriptorError {
         test_id: ViperTestId,
         run_id: ViperRunId,
     },
-    #[error("Test <{test_id}> deleted with internal errors:\n  {cause}")]
+    #[error("Test <{test_id}> deleted with internal errors:\n  {message}")]
     Internal {
         test_id: ViperTestId,
-        cause: String,
+        message: String,
     }
 }
 
@@ -125,18 +125,18 @@ pub enum GetViperTestRunDescriptorError {
     TestNotFound {
         test_id: ViperTestId
     },
-    #[error("An internal error occurred searching for a test with ID <{test_id}>:\n  {cause}")]
+    #[error("An internal error occurred searching for a test with ID <{test_id}>:\n  {message}")]
     Internal {
         test_id: ViperTestId,
-        cause: String
+        message: String
     }
 }
 
 #[derive(thiserror::Error, Debug)]
 pub enum ListViperTestRunDescriptorsError {
-    #[error("An internal error occurred computing the list of VIPER test descriptors:\n  {cause}")]
+    #[error("An internal error occurred computing the list of VIPER test descriptors:\n  {message}")]
     Internal {
-        cause: String
+        message: String
     }
 }
 
@@ -147,10 +147,10 @@ pub enum ListViperTestRunDescriptorsError {
 
 #[derive(thiserror::Error, Debug)]
 pub enum StoreViperRunDeploymentError {
-    #[error("VIPER run deployment <{run_id}> could not be created, due to internal errors:\n  {cause}")]
+    #[error("VIPER run deployment <{run_id}> could not be created, due to internal errors:\n  {message}")]
     Internal {
         run_id: ViperRunId,
-        cause: String
+        message: String
     }
 }
 
@@ -160,10 +160,10 @@ pub enum DeleteViperRunDeploymentError {
     RunDeploymentNotFound {
         run_id: ViperRunId,
     },
-    #[error("VIPER run deployment <{run_id}> deleted with internal errors:\n  {cause}")]
+    #[error("VIPER run deployment <{run_id}> deleted with internal errors:\n  {message}")]
     Internal {
         run_id: ViperRunId,
-        cause: String,
+        message: String,
     }
 }
 
@@ -173,18 +173,18 @@ pub enum GetViperRunDeploymentError {
     RunDeploymentNotFound {
         run_id: ViperRunId
     },
-    #[error("An internal error occurred searching for a VIPER run deployment with ID <{run_id}>:\n  {cause}")]
+    #[error("An internal error occurred searching for a VIPER run deployment with ID <{run_id}>:\n  {message}")]
     Internal {
         run_id: ViperRunId,
-        cause: String
+        message: String
     }
 }
 
 #[derive(thiserror::Error, Debug)]
 pub enum ListViperRunDeploymentsError {
-    #[error("An internal error occurred computing the list of VIPER run deployments:\n  {cause}")]
+    #[error("An internal error occurred computing the list of VIPER run deployments:\n  {message}")]
     Internal {
-        cause: String
+        message: String
     }
 }
 

--- a/opendut-carl/opendut-carl-api/src/proto/services/cluster_manager.rs
+++ b/opendut-carl/opendut-carl-api/src/proto/services/cluster_manager.rs
@@ -59,7 +59,7 @@ conversion! {
 impl From<CreateClusterDescriptorError> for CreateClusterDescriptorFailure {
     fn from(error: CreateClusterDescriptorError) -> Self {
         let proto_error = match error {
-            CreateClusterDescriptorError::Internal { cluster_id, cluster_name, cause } => {
+            CreateClusterDescriptorError::Internal { cluster_id, cluster_name, message } => {
                 create_cluster_descriptor_failure::Error::Internal(CreateClusterDescriptorFailureInternal {
                     cluster_id: Some(cluster_id.into()),
                     cluster_name: Some(cluster_name.into()),
@@ -98,7 +98,7 @@ impl TryFrom<CreateClusterDescriptorFailureInternal> for CreateClusterDescriptor
         let cluster_name: ClusterName = failure.cluster_name
             .ok_or_else(|| ErrorBuilder::field_not_set("cluster_name"))?
             .try_into()?;
-        Ok(CreateClusterDescriptorError::Internal { cluster_id, cluster_name, cause: failure.cause })
+        Ok(CreateClusterDescriptorError::Internal { cluster_id, cluster_name, message: failure.cause })
     }
 }
 
@@ -118,7 +118,7 @@ impl From<DeleteClusterDescriptorError> for DeleteClusterDescriptorFailure {
                     required_states: required_states.into_iter().map(Into::into).collect(),
                 })
             }
-            DeleteClusterDescriptorError::Internal { cluster_id, cluster_name, cause } => {
+            DeleteClusterDescriptorError::Internal { cluster_id, cluster_name, message } => {
                 delete_cluster_descriptor_failure::Error::Internal(DeleteClusterDescriptorFailureInternal {
                     cluster_id: Some(cluster_id.into()),
                     cluster_name: cluster_name.map(Into::into),
@@ -247,14 +247,14 @@ impl TryFrom<DeleteClusterDescriptorFailureInternal> for DeleteClusterDescriptor
         let cluster_name: Option<ClusterName> = failure.cluster_name
             .map(TryInto::try_into)
             .transpose()?;
-        Ok(DeleteClusterDescriptorError::Internal { cluster_id, cluster_name, cause: failure.cause })
+        Ok(DeleteClusterDescriptorError::Internal { cluster_id, cluster_name, message: failure.cause })
     }
 }
 
 impl From<StoreClusterDeploymentError> for StoreClusterDeploymentFailure {
     fn from(error: StoreClusterDeploymentError) -> Self {
         let proto_error = match error {
-            StoreClusterDeploymentError::Internal { cluster_id, cluster_name, cause } => {
+            StoreClusterDeploymentError::Internal { cluster_id, cluster_name, message } => {
                 store_cluster_deployment_failure::Error::Internal(StoreClusterDeploymentFailureInternal {
                     cluster_id: Some(cluster_id.into()),
                     cluster_name: cluster_name.map(|name| name.into()),
@@ -303,7 +303,7 @@ impl TryFrom<StoreClusterDeploymentFailureInternal> for StoreClusterDeploymentEr
         let cluster_name: Option<ClusterName> = failure.cluster_name
             .map(TryInto::try_into)
             .transpose()?;
-        Ok(StoreClusterDeploymentError::Internal { cluster_id, cluster_name, cause: failure.cause })
+        Ok(StoreClusterDeploymentError::Internal { cluster_id, cluster_name, message: failure.cause })
     }
 }
 
@@ -340,7 +340,7 @@ impl From<DeleteClusterDeploymentError> for DeleteClusterDeploymentFailure {
                     required_states: required_states.into_iter().map(Into::into).collect(),
                 })
             }
-            DeleteClusterDeploymentError::Internal { cluster_id, cluster_name, cause } => {
+            DeleteClusterDeploymentError::Internal { cluster_id, cluster_name, message } => {
                 delete_cluster_deployment_failure::Error::Internal(DeleteClusterDeploymentFailureInternal {
                     cluster_id: Some(cluster_id.into()),
                     cluster_name: cluster_name.map(Into::into),
@@ -416,6 +416,6 @@ impl TryFrom<DeleteClusterDeploymentFailureInternal> for DeleteClusterDeployment
         let cluster_name: Option<ClusterName> = failure.cluster_name
             .map(TryInto::try_into)
             .transpose()?;
-        Ok(DeleteClusterDeploymentError::Internal { cluster_id, cluster_name, cause: failure.cause })
+        Ok(DeleteClusterDeploymentError::Internal { cluster_id, cluster_name, message: failure.cause })
     }
 }

--- a/opendut-carl/opendut-carl-api/src/proto/services/peer_manager.rs
+++ b/opendut-carl/opendut-carl-api/src/proto/services/peer_manager.rs
@@ -25,7 +25,7 @@ impl From<StorePeerDescriptorError> for StorePeerDescriptorFailure {
                     error: Some(error.into()),
                 })
             }
-            StorePeerDescriptorError::Internal { peer_id, peer_name, cause } => {
+            StorePeerDescriptorError::Internal { peer_id, peer_name, message } => {
                 store_peer_descriptor_failure::Error::Internal(StorePeerDescriptorFailureInternal {
                     peer_id: Some(peer_id.into()),
                     peer_name: Some(peer_name.into()),
@@ -107,7 +107,7 @@ impl TryFrom<StorePeerDescriptorFailureInternal> for StorePeerDescriptorError {
         let peer_name: PeerName = failure.peer_name
             .ok_or_else(|| ErrorBuilder::field_not_set("peer_name"))?
             .try_into()?;
-        Ok(StorePeerDescriptorError::Internal { peer_id, peer_name, cause: failure.cause })
+        Ok(StorePeerDescriptorError::Internal { peer_id, peer_name, message: failure.cause })
     }
 }
 
@@ -131,7 +131,7 @@ conversion! {
                     required_states: required_states.into_iter().map(Into::into).collect(),
                 })
             }
-            DeletePeerDescriptorError::Internal { peer_id, peer_name, cause } => {
+            DeletePeerDescriptorError::Internal { peer_id, peer_name, message } => {
                 delete_peer_descriptor_failure::Error::Internal(DeletePeerDescriptorFailureInternal {
                     peer_id: Some(peer_id.into()),
                     peer_name: peer_name.map(Into::into),
@@ -181,7 +181,7 @@ conversion! {
                 Ok(Model::Internal {
                     peer_id,
                     peer_name,
-                    cause,
+                    message,
                 })
             }
             delete_peer_descriptor_failure::Error::DeploymentExists(error) => {
@@ -245,7 +245,7 @@ impl From<GetPeerDescriptorError> for GetPeerDescriptorFailure {
                     peer_id: Some(peer_id.into()),
                 })
             }
-            GetPeerDescriptorError::Internal { peer_id, cause } => {
+            GetPeerDescriptorError::Internal { peer_id, message } => {
                 get_peer_descriptor_failure::Error::Internal(GetPeerDescriptorFailureInternal {
                     peer_id: Some(peer_id.into()),
                     cause
@@ -294,14 +294,14 @@ impl TryFrom<GetPeerDescriptorFailureInternal> for GetPeerDescriptorError {
         let peer_id: PeerId = failure.peer_id
             .ok_or_else(|| ErrorBuilder::field_not_set("peer_id"))?
             .try_into()?;
-        Ok(GetPeerDescriptorError::Internal{ peer_id, cause: failure.cause})
+        Ok(GetPeerDescriptorError::Internal{ peer_id, message: failure.cause})
     }
 }
 
 impl From<ListPeerDescriptorsError> for ListPeerDescriptorsFailure {
     fn from(error: ListPeerDescriptorsError) -> Self {
         let proto_error = match error {
-            ListPeerDescriptorsError::Internal { cause } => {
+            ListPeerDescriptorsError::Internal { message } => {
                 list_peer_descriptors_failure::Error::Internal(ListPeerDescriptorsFailureInternal {
                     cause
                 })
@@ -332,7 +332,7 @@ impl TryFrom<ListPeerDescriptorsFailureInternal> for ListPeerDescriptorsError {
     type Error = ConversionError;
     fn try_from(failure: ListPeerDescriptorsFailureInternal) -> Result<Self, Self::Error> {
         // type ErrorBuilder = ConversionErrorBuilder<ListPeersFailureInternal, ListPeersError>;
-        Ok(ListPeerDescriptorsError::Internal{ cause: failure.cause})
+        Ok(ListPeerDescriptorsError::Internal{ message: failure.cause})
     }
 }
 
@@ -344,7 +344,7 @@ impl From<GetPeerStateError> for GetPeerStateFailure {
                     peer_id: Some(peer_id.into()),
                 })
             }
-            GetPeerStateError::Internal { peer_id, cause } => {
+            GetPeerStateError::Internal { peer_id, message } => {
                 get_peer_state_failure::Error::Internal(GetPeerStateFailureInternal {
                     peer_id: Some(peer_id.into()),
                     cause
@@ -375,7 +375,7 @@ impl TryFrom<GetPeerStateFailureInternal> for GetPeerStateError {
         let peer_id: PeerId = failure.peer_id
             .ok_or_else(|| ErrorBuilder::field_not_set("peer_id"))?
             .try_into()?;
-        Ok(GetPeerStateError::Internal{ peer_id, cause: failure.cause})
+        Ok(GetPeerStateError::Internal{ peer_id, message: failure.cause})
     }
 }
 
@@ -400,7 +400,7 @@ impl TryFrom<GetPeerStateFailure> for GetPeerStateError {
 impl From<ListPeerStatesError> for ListPeerStatesFailure {
     fn from(error: ListPeerStatesError) -> Self {
         let proto_error = match error {
-            ListPeerStatesError::Internal { cause } => {
+            ListPeerStatesError::Internal { message } => {
                 list_peer_states_failure::Error::Internal(ListPeerStatesFailureInternal {
                     cause
                 })
@@ -430,6 +430,6 @@ impl TryFrom<ListPeerStatesFailure> for ListPeerStatesError {
 impl TryFrom<ListPeerStatesFailureInternal> for ListPeerStatesError {
     type Error = ConversionError;
     fn try_from(failure: ListPeerStatesFailureInternal) -> Result<Self, Self::Error> {
-        Ok(ListPeerStatesError::Internal{ cause: failure.cause})
+        Ok(ListPeerStatesError::Internal{ message: failure.cause})
     }
 }

--- a/opendut-carl/src/auth/grpc_auth_layer.rs
+++ b/opendut-carl/src/auth/grpc_auth_layer.rs
@@ -41,8 +41,8 @@ impl GrpcAuthenticationLayer {
                         request.extensions_mut().insert(user);
                         Ok(request)
                     }
-                    Err(cause) => {
-                        debug!("Blocking authentication attempt due to error while validating credentials: {cause}");
+                    Err(source) => {
+                        debug!("Blocking authentication attempt due to error while validating credentials: {source}");
                         Err(Status::unauthenticated("CARL says, invalid credentials!"))
                     }
                 }

--- a/opendut-carl/src/auth/json_web_key.rs
+++ b/opendut-carl/src/auth/json_web_key.rs
@@ -31,7 +31,7 @@ pub struct OidcJsonWebKeySet {
 impl OidcJsonWebKeySet {
     pub fn parse(json_web_key: &str) -> Result<BTreeMap<String, JsonWebKey>, ValidationError> {
         let json_web_key_set = serde_json::from_str::<OidcJsonWebKeySet>(json_web_key)
-            .map_err(|cause| ValidationError::Configuration(format!("Failed to parse json: {cause}")))?;
+            .map_err(|source| ValidationError::Configuration(format!("Failed to parse json: {source}")))?;
         Ok(json_web_key_set.keys.into_iter().map(|jwk| {
             (jwk.key_identifier.clone(), jwk)
         }).collect::<BTreeMap<_, _>>())

--- a/opendut-carl/src/auth/validation.rs
+++ b/opendut-carl/src/auth/validation.rs
@@ -85,7 +85,7 @@ pub async fn authorize_user(issuer_url: Url, issuer_remote_url: Url, access_toke
 
 async fn fetch_and_cache_jwk_from_idp(issuer_url: &Url, key_id: String, jwk_requester: impl JwkRequester, mut cache: CustomInMemoryCache<String, JwkCacheValue>) -> Result<JsonWebKey, ValidationError> {
     let issuer_jwk_url = issuer_url.join(GIVEN_ISSUER_JWK_URL)
-        .map_err(|cause| ValidationError::Configuration(format!("Issuer JWK error: {cause}")))?;
+        .map_err(|source| ValidationError::Configuration(format!("Issuer JWK error: {source}")))?;
 
     let jwk_map = fetch_jwk_custom(issuer_jwk_url, jwk_requester).await?;
 
@@ -142,9 +142,9 @@ impl JwkRequester for Jwk {
         let response = self.0.get(issuer_jwk_url.clone())
             .send()
             .await
-            .map_err(|cause| ValidationError::Configuration(format!("Failed to fetch IDP jwk URL from '{issuer_jwk_url}': {cause}")))?;
+            .map_err(|source| ValidationError::Configuration(format!("Failed to fetch IDP jwk URL from '{issuer_jwk_url}': {source}")))?;
         let result = response.text().await
-            .map_err(|cause| ValidationError::Configuration(format!("Failed to read IDP configuration URL from '{issuer_jwk_url}': {cause}")))?;
+            .map_err(|source| ValidationError::Configuration(format!("Failed to read IDP configuration URL from '{issuer_jwk_url}': {source}")))?;
         Ok(result)
     }
 }

--- a/opendut-carl/src/manager/cluster_manager/mod.rs
+++ b/opendut-carl/src/manager/cluster_manager/mod.rs
@@ -230,7 +230,7 @@ impl ClusterManager {
 
 
         let member_interface_mapping = determine_member_interface_mapping(cluster_config.devices, all_peers, cluster_config.leader)
-            .map_err(|cause| match cause {
+            .map_err(|source| match source {
                 DetermineMemberInterfaceMappingError::PeerForDeviceNotFound { device_id } => RolloutClusterError::PeerForDeviceNotFound { device_id, cluster_id, cluster_name },
             })?;
 
@@ -238,10 +238,10 @@ impl ClusterManager {
 
         if let Vpn::Enabled { vpn_client } = &self.vpn {
             vpn_client.create_cluster(cluster_id, &member_ids).await
-                .map_err(|cause| {
+                .map_err(|source| {
                     let message = format!("Failure while creating cluster <{cluster_id}> in VPN service.");
-                    error!("{}\n  {cause}", message);
-                    RolloutClusterError::Internal { cluster_id, cause: message }
+                    error!("{}\n  {source}", message);
+                    RolloutClusterError::Internal { cluster_id, source: message }
                 })?;
 
             let peers_string = member_ids.iter().map(ToString::to_string).collect::<Vec<_>>().join(",");
@@ -264,16 +264,16 @@ impl ClusterManager {
                                         Ok(remote_host)
                                     }
                                     Some(PeerConnectionState::Offline) => {
-                                        Err(RolloutClusterError::Internal { cluster_id, cause: format!("Peer <{peer_id}> which is used in a cluster, should have a PeerConnectionState of 'Online'.") })
+                                        Err(RolloutClusterError::Internal { cluster_id, source: format!("Peer <{peer_id}> which is used in a cluster, should have a PeerConnectionState of 'Online'.") })
                                     }
                                     None => {
-                                        Err(RolloutClusterError::Internal { cluster_id, cause: format!("Peer <{peer_id}> which is used in a cluster, should have a PeerConnectionState associated.") })
+                                        Err(RolloutClusterError::Internal { cluster_id, source: format!("Peer <{peer_id}> which is used in a cluster, should have a PeerConnectionState associated.") })
                                     }
                                 }
-                                Err(cause) => {
+                                Err(source) => {
                                     let message = format!("Error while accessing persistence to read PeerConnectionState of peer <{peer_id}>");
-                                    error!("{message}:\n  {cause}");
-                                    Err(RolloutClusterError::Internal { cluster_id, cause: message })
+                                    error!("{message}:\n  {source}");
+                                    Err(RolloutClusterError::Internal { cluster_id, source: message })
                                 }
                             };
 
@@ -306,10 +306,10 @@ impl ClusterManager {
                     device_interfaces,
                     options: assign_cluster_options.clone(),
                 }).await
-                .map_err(|cause| {
-                    let message = format!("Failure while assigning cluster <{cluster_id}> to peer <{member_id}>. Cause: {cause}"); // TODO
-                    error!("{}\n  {cause}", message);
-                    RolloutClusterError::Internal { cluster_id, cause: message }
+                .map_err(|source| {
+                    let message = format!("Failure while assigning cluster <{cluster_id}> to peer <{member_id}>. Cause: {source}"); // TODO
+                    error!("{}\n  {source}", message);
+                    RolloutClusterError::Internal { cluster_id, source: message }
                 })?;
             }
             Ok(())
@@ -321,12 +321,12 @@ impl ClusterManager {
 
     fn determine_can_server_ports(&mut self, member_interface_mapping: &[PeerId], cluster_id: ClusterId) -> Result<Vec<Port>, RolloutClusterError> {
         let n_peers = u16::try_from(member_interface_mapping.len())
-            .map_err(|cause| RolloutClusterError::DetermineCanServerPort { cluster_id, cause: cause.to_string() })?;
+            .map_err(|source| RolloutClusterError::DetermineCanServerPort { cluster_id, source: source.to_string() })?;
 
         if self.options.can_server_port_range_start + n_peers >= self.options.can_server_port_range_end {
             return Err(RolloutClusterError::DetermineCanServerPort {
                 cluster_id,
-                cause: format!(
+                source: format!(
                     "Failure while creating cluster <{}>. Port range [{}, {}) specified by 'can_server_port_range_start' \
                     and 'can_server_port_range_start' is too narrow for the configured number of peers ({})",
                     cluster_id,
@@ -338,7 +338,7 @@ impl ClusterManager {
         } else if self.options.can_server_port_range_start + n_peers * 2 >= self.options.can_server_port_range_end {
             warn!(
                 "Port range [{}, {}) specified by 'can_server_port_range_start' \
-                and 'can_server_port_range_start' is very narrow for the configured number of peers ({}). This may cause errors on EDGAR.",
+                and 'can_server_port_range_start' is very narrow for the configured number of peers ({}). This may source errors on EDGAR.",
                 self.options.can_server_port_range_start,
                 self.options.can_server_port_range_end,
                 n_peers
@@ -414,10 +414,10 @@ impl ClusterManagerOptions {
 
         let field = "peer.ethernet.bridge.name.default";
         let bridge_name_default = config.get_string(field)
-            .map_err(|cause| opendut_util::settings::LoadError::ReadField { field, source: cause.into() })?;
+            .map_err(|source| opendut_util::settings::LoadError::ReadField { field, source: source.into() })?;
 
         let bridge_name_default = NetworkInterfaceName::try_from(bridge_name_default.clone())
-            .map_err(|cause| opendut_util::settings::LoadError::ParseValue { field, value: bridge_name_default, source: cause.into() })?;
+            .map_err(|source| opendut_util::settings::LoadError::ParseValue { field, value: bridge_name_default, source: source.into() })?;
 
         Ok(ClusterManagerOptions {
             can_server_port_range_start,
@@ -440,7 +440,7 @@ pub mod error {
     #[error("ClusterDescriptor <{cluster_id}> could not be retrieved")]
     pub struct GetClusterDescriptorError {
         pub cluster_id: ClusterId,
-        #[source] pub source: PersistenceError,
+        pub source: PersistenceError,
     }
 
     #[derive(thiserror::Error, Debug)]
@@ -458,8 +458,8 @@ pub mod error {
             cluster_name: Option<ClusterName>,
             invalid_peers: Vec<PeerId>,
         },
-        ListClusterPeerStates { cluster_id: ClusterId, #[source] source: ListClusterPeerStatesError },
-        Persistence { cluster_id: ClusterId, cluster_name: Option<ClusterName>, #[source] source: PersistenceError },
+        ListClusterPeerStates { cluster_id: ClusterId, source: ListClusterPeerStatesError },
+        Persistence { cluster_id: ClusterId, cluster_name: Option<ClusterName>, source: PersistenceError },
     }
 
     #[derive(thiserror::Error, Debug)]
@@ -467,14 +467,14 @@ pub mod error {
         #[error("Error when accessing persistence while retrieving cluster deployment for cluster <{cluster_id}>")]
         Persistence {
             cluster_id: ClusterId,
-            #[source] source: PersistenceError,
+            source: PersistenceError,
         },
     }
 
     #[derive(thiserror::Error, Debug)]
     #[error("Error while listing cluster deployments")]
     pub struct ListClusterDeploymentsError {
-        #[source] pub source: PersistenceError,
+        pub source: PersistenceError,
     }
 
     #[derive(thiserror::Error, Debug)]
@@ -490,22 +490,22 @@ pub mod error {
         #[error("Error when listing cluster peer states while rolling out cluster <{cluster_id}>")]
         ListClusterPeerStates {
             cluster_id: ClusterId,
-            #[source] source: ListClusterPeerStatesError,
+            source: ListClusterPeerStatesError,
         },
         #[error("Error when accessing persistence while rolling out cluster <{cluster_id}>")]
         Persistence {
             cluster_id: ClusterId,
-            #[source] source: PersistenceError,
+            source: PersistenceError,
         },
         #[error("Error when determining CAN server port while rolling out cluster <{cluster_id}>")]
         DetermineCanServerPort {
             cluster_id: ClusterId,
-            cause: String,
+            message: String,
         },
-        #[error("Internal error while rolling out cluster <{cluster_id}>:\n  {cause}")]
+        #[error("Internal error while rolling out cluster <{cluster_id}>:\n  {message}")]
         Internal {
             cluster_id: ClusterId,
-            cause: String,
+            message: String,
         },
     }
 }

--- a/opendut-carl/src/manager/grpc/cluster_manager.rs
+++ b/opendut-carl/src/manager/grpc/cluster_manager.rs
@@ -113,7 +113,7 @@ impl ClusterManagerService for ClusterManagerFacade {
 
         let configuration = self.cluster_manager.lock().await.get_cluster_descriptor(cluster_id).await
             .log_api_err()
-            .map_err(|cause| Status::internal(cause.to_string()))?;
+            .map_err(|source| Status::internal(source.to_string()))?;
 
         let result = match configuration {
             Some(configuration) => get_cluster_descriptor_response::Result::Success(
@@ -136,7 +136,7 @@ impl ClusterManagerService for ClusterManagerFacade {
 
         let configurations = self.cluster_manager.lock().await.list_cluster_descriptor().await
             .log_api_err()
-            .map_err(|cause| Status::internal(cause.to_string()))?;
+            .map_err(|source| Status::internal(source.to_string()))?;
 
         Ok(Response::new(ListClusterDescriptorsResponse {
             result: Some(list_cluster_descriptors_response::Result::Success(
@@ -156,7 +156,7 @@ impl ClusterManagerService for ClusterManagerFacade {
         trace!("Received request to store cluster deployment: {cluster_deployment:?}");
 
         let result = self.cluster_manager.lock().await.store_cluster_deployment(cluster_deployment).await
-            .inspect_err(|cause| error!("{cause}"))
+            .inspect_err(|source| error!("{source}"))
             .map_err(opendut_carl_api::carl::cluster::StoreClusterDeploymentError::from);
 
         let reply = match result {
@@ -217,7 +217,7 @@ impl ClusterManagerService for ClusterManagerFacade {
 
         let deployment = self.cluster_manager.lock().await.get_cluster_deployment(cluster_id).await
             .log_api_err()
-            .map_err(|cause| Status::internal(cause.to_string()))?;
+            .map_err(|source| Status::internal(source.to_string()))?;
 
         match deployment {
             Some(configuration) => Ok(Response::new(GetClusterDeploymentResponse {
@@ -241,7 +241,7 @@ impl ClusterManagerService for ClusterManagerFacade {
 
         let deployments = self.cluster_manager.lock().await.list_cluster_deployment().await
             .log_api_err()
-            .map_err(|cause| Status::internal(cause.to_string()))?;
+            .map_err(|source| Status::internal(source.to_string()))?;
 
         Ok(Response::new(ListClusterDeploymentsResponse {
             result: Some(list_cluster_deployments_response::Result::Success(
@@ -259,8 +259,8 @@ impl ClusterManagerService for ClusterManagerFacade {
         let result: ClusterPeerStates = self.resource_manager.resources_mut(async |resources| {
             resources.list_cluster_peer_states(cluster_id).await
         }).await
-            .map_err(|cause| Status::internal(cause.to_string()))?
-            .map_err(|cause| Status::internal(cause.to_string()))?;
+            .map_err(|source| Status::internal(source.to_string()))?
+            .map_err(|source| Status::internal(source.to_string()))?;
         
         let peer_states = result.peer_states.iter().map(|(peer_id, peer_state)| (peer_id.uuid.to_string(), peer_state.clone())).collect::<HashMap<_, _>>();
         

--- a/opendut-carl/src/manager/grpc/error.rs
+++ b/opendut-carl/src/manager/grpc/error.rs
@@ -26,7 +26,7 @@ mod cluster_manager {
                     Self::Internal {
                         cluster_id,
                         cluster_name,
-                        cause: String::from("Error when accessing persistence"),
+                        source: String::from("Error when accessing persistence"),
                     }
                 }
             }
@@ -46,7 +46,7 @@ mod cluster_manager {
                     Self::Internal {
                         cluster_id,
                         cluster_name,
-                        cause: String::from("Error when accessing persistence"),
+                        source: String::from("Error when accessing persistence"),
                     }
                 }
                 #[cfg(feature="viper")]
@@ -65,14 +65,14 @@ mod cluster_manager {
                     Self::Internal {
                         cluster_id,
                         cluster_name: None,
-                        cause: String::from("Error when listing cluster peer states"),
+                        source: String::from("Error when listing cluster peer states"),
                     }
                 }
                 cluster_manager::error::StoreClusterDeploymentError::Persistence { cluster_id, cluster_name, source: _ } => {
                     Self::Internal {
                         cluster_id,
                         cluster_name,
-                        cause: String::from("Error when accessing persistence"),
+                        source: String::from("Error when accessing persistence"),
                     }
                 }
             }
@@ -90,14 +90,14 @@ mod cluster_manager {
                     Self::Internal {
                         cluster_id,
                         cluster_name,
-                        cause: String::from("Error when accessing persistence while deleting cluster deployment"),
+                        source: String::from("Error when accessing persistence while deleting cluster deployment"),
                     }
                 }
                 cluster_manager::DeleteClusterDeploymentError::VpnClient { cluster_id, cluster_name, source: _ } =>
                     Self::Internal {
                         cluster_id,
                         cluster_name: Some(cluster_name),
-                        cause: String::from("Error when tearing down VPN while deleting cluster deployment"),
+                        source: String::from("Error when tearing down VPN while deleting cluster deployment"),
                     }
             }
         }
@@ -117,13 +117,13 @@ mod peer_manager {
                     Self::Internal {
                         peer_id,
                         peer_name,
-                        cause: String::from("Error when accessing persistence while storing peer descriptor"),
+                        source: String::from("Error when accessing persistence while storing peer descriptor"),
                     },
                 peer_manager::store_peer_descriptor::StorePeerDescriptorError::VpnClient { peer_id, peer_name, source: _ } =>
                     Self::Internal {
                         peer_id,
                         peer_name,
-                        cause: String::from("Error when creating peer in VPN management while storing peer descriptor"),
+                        source: String::from("Error when creating peer in VPN management while storing peer descriptor"),
                     }
             }
         }
@@ -142,19 +142,19 @@ mod peer_manager {
                     Self::Internal {
                         peer_id,
                         peer_name,
-                        cause: String::from("Error when accessing persistence while deleting peer descriptor"),
+                        source: String::from("Error when accessing persistence while deleting peer descriptor"),
                     },
                 peer_manager::delete_peer_descriptor::DeletePeerDescriptorError::AuthRegistration { peer_id, peer_name, source: _ } =>
                     Self::Internal {
                         peer_id,
                         peer_name: Some(peer_name),
-                        cause: String::from("Error when removing registration while deleting peer descriptor"),
+                        source: String::from("Error when removing registration while deleting peer descriptor"),
                     },
                 peer_manager::delete_peer_descriptor::DeletePeerDescriptorError::VpnClient { peer_id, peer_name, source: _ } =>
                     Self::Internal {
                         peer_id,
                         peer_name: Some(peer_name),
-                        cause: String::from("Error when removing peer in VPN management while deleting peer descriptor"),
+                        source: String::from("Error when removing peer in VPN management while deleting peer descriptor"),
                     },
             }
         }
@@ -168,7 +168,7 @@ mod peer_manager {
                 peer_manager::get_peer_state::GetPeerStateError::Persistence { peer_id, source: _ } =>
                     Self::Internal {
                         peer_id,
-                        cause: String::from("Error when accessing persistence while getting peer state"),
+                        source: String::from("Error when accessing persistence while getting peer state"),
                     }
             }
         }
@@ -179,7 +179,7 @@ mod peer_manager {
             match value {
                 peer_manager::list_peer_states::ListPeerStatesError::Persistence { source: _ } =>
                     Self::Internal {
-                        cause: String::from("Error when accessing persistence while listing peer state"),
+                        source: String::from("Error when accessing persistence while listing peer state"),
                     }
             }
         }
@@ -198,11 +198,11 @@ mod viper_manager {
                     Self::SourceNotFound { source_id },
                 viper_manager::delete_viper_source_descriptor::DeleteViperSourceDescriptorError::TestExists { source_id, test_id } =>
                     Self::TestExists { source_id, test_id },
-                viper_manager::delete_viper_source_descriptor::DeleteViperSourceDescriptorError::Persistence { source_id, source_name, cause: _ } =>
+                viper_manager::delete_viper_source_descriptor::DeleteViperSourceDescriptorError::Persistence { source_id, source_name, source: _ } =>
                     Self::Internal {
                         source_id,
                         source_name,
-                        cause: String::from("Error when accessing persistence while deleting VIPER source descriptor"),
+                        source: String::from("Error when accessing persistence while deleting VIPER source descriptor"),
                     },
             }
         }
@@ -215,10 +215,10 @@ mod viper_manager {
                     Self::TestNotFound { test_id },
                 viper_manager::delete_viper_test_descriptor::DeleteViperTestDescriptorError::ViperRunDeploymentExists { test_id, run_id } =>
                     Self::ViperRunDeploymentExists { test_id, run_id },
-                viper_manager::delete_viper_test_descriptor::DeleteViperTestDescriptorError::Persistence { test_id, cause: _ } =>
+                viper_manager::delete_viper_test_descriptor::DeleteViperTestDescriptorError::Persistence { test_id, source: _ } =>
                     Self::Internal {
                         test_id,
-                        cause: String::from("Error when accessing persistence while deleting VIPER test descriptor"),
+                        source: String::from("Error when accessing persistence while deleting VIPER test descriptor"),
                     }
             }
         }
@@ -230,17 +230,17 @@ mod viper_manager {
             match value {
                 viper_manager::get_viper_test_suite_parameters::GetViperTestSuiteParametersError::Compilation { source_id, source_name } =>
                     Self::Compilation { source_id, source_name },
-                viper_manager::get_viper_test_suite_parameters::GetViperTestSuiteParametersError::TaskJoin { source_id, when, cause: _ } =>
+                viper_manager::get_viper_test_suite_parameters::GetViperTestSuiteParametersError::TaskJoin { source_id, when, source: _ } =>
                     Self::Internal {
                         source_id,
-                        cause: format!("Internal error when {when} to completion while retrieving VIPER test suite descriptor"),
+                        source: format!("Internal error when {when} to completion while retrieving VIPER test suite descriptor"),
                     },
                 viper_manager::get_viper_test_suite_parameters::GetViperTestSuiteParametersError::ViperRuntime { source_id, source_name } =>
                     Self::ViperRuntime { source_id, source_name },
-                viper_manager::get_viper_test_suite_parameters::GetViperTestSuiteParametersError::Persistence { source_id, cause: _ } =>
+                viper_manager::get_viper_test_suite_parameters::GetViperTestSuiteParametersError::Persistence { source_id, source: _ } =>
                     Self::Internal {
                         source_id,
-                        cause: String::from("Error when accessing persistence while getting VIPER test suite descriptor"),
+                        source: String::from("Error when accessing persistence while getting VIPER test suite descriptor"),
                     },
             }
         }

--- a/opendut-carl/src/manager/grpc/mod.rs
+++ b/opendut-carl/src/manager/grpc/mod.rs
@@ -33,8 +33,8 @@ where
         self
             .ok_or_else(|| tonic::Status::invalid_argument(format!("Field '{}' not set", Clone::clone(&field).into())))
             .and_then(|value| {
-                B::try_from(value).map_err(|cause| {
-                    tonic::Status::invalid_argument(format!("Field '{}' is not valid: {}", field.into(), cause))
+                B::try_from(value).map_err(|source| {
+                    tonic::Status::invalid_argument(format!("Field '{}' is not valid: {}", field.into(), source))
                 })
             })
     }

--- a/opendut-carl/src/manager/grpc/observer_messaging_broker.rs
+++ b/opendut-carl/src/manager/grpc/observer_messaging_broker.rs
@@ -64,7 +64,7 @@ impl ObserverMessagingBrokerService for ObserverMessagingBrokerFacade {
 
         trace!("Received request to wait for following peers to be online: {:?}", request.peer_ids);
         let rx_outbound = self.observer_messaging_broker.wait_for_peers_online(request.peer_ids, request.max_observation_duration).await
-            .map_err(|cause| Status::internal(cause.to_string()))?;
+            .map_err(|source| Status::internal(source.to_string()))?;
         let outbound_stream = ReceiverStream::new(rx_outbound)
             .map(Ok);
 

--- a/opendut-carl/src/manager/grpc/peer_manager.rs
+++ b/opendut-carl/src/manager/grpc/peer_manager.rs
@@ -143,7 +143,7 @@ impl PeerManagerService for PeerManagerFacade {
                 .inspect_err(|error| error!("Error while getting peer descriptor from gRPC API: {error}"))
                 .map_err(|_: PersistenceError| opendut_carl_api::carl::peer::GetPeerDescriptorError::Internal {
                     peer_id,
-                    cause: String::from("Error when accessing persistence while getting peer descriptor"),
+                    source: String::from("Error when accessing persistence while getting peer descriptor"),
                 });
 
         let response = match result {
@@ -173,7 +173,7 @@ impl PeerManagerService for PeerManagerFacade {
         let result = self.resource_manager.list::<PeerDescriptor>().await
             .inspect_err(|error| error!("Error while listing peer descriptors from gRPC API: {error}"))
             .map_err(|_: PersistenceError| opendut_carl_api::carl::peer::ListPeerDescriptorsError::Internal {
-                cause: String::from("Error when accessing persistence while listing peer descriptors"),
+                source: String::from("Error when accessing persistence while listing peer descriptors"),
             });
 
         let response = match result {

--- a/opendut-carl/src/manager/grpc/peer_messaging_broker.rs
+++ b/opendut-carl/src/manager/grpc/peer_messaging_broker.rs
@@ -58,13 +58,13 @@ impl opendut_carl_api::proto::services::peer_messaging_broker::peer_messaging_br
 
 
         let (tx_inbound, rx_outbound) = self.peer_messaging_broker.open(peer_id, remote_host, extra_headers).await
-            .map_err(|cause| {
-                error!("Error while opening stream from newly connected peer <{peer_id}>:\n  {cause}");
-                match cause {
-                    OpenError::PeerAlreadyConnected { .. } => Status::aborted(cause.to_string()),
-                    OpenError::SendApplyPeerConfiguration { .. } => Status::unavailable(cause.to_string()),
-                    OpenError::Persistence { .. } => Status::internal(cause.to_string()),
-                    OpenError::PeerNotFound(_) => Status::internal(cause.to_string()),
+            .map_err(|source| {
+                error!("Error while opening stream from newly connected peer <{peer_id}>:\n  {source}");
+                match source {
+                    OpenError::PeerAlreadyConnected { .. } => Status::aborted(source.to_string()),
+                    OpenError::SendApplyPeerConfiguration { .. } => Status::unavailable(source.to_string()),
+                    OpenError::Persistence { .. } => Status::internal(source.to_string()),
+                    OpenError::PeerNotFound(_) => Status::internal(source.to_string()),
                 }
             })?;
 
@@ -74,9 +74,9 @@ impl opendut_carl_api::proto::services::peer_messaging_broker::peer_messaging_br
                 match result {
                     Ok(upstream) => {
                         let upstream_conversion_result = UpstreamMessage::try_from(upstream)
-                            .map_err(|cause| {
-                                error!("Error while converting upstream message from client <{}>: {cause}", peer_id);
-                                Status::invalid_argument(cause.to_string())
+                            .map_err(|source| {
+                                error!("Error while converting upstream message from client <{}>: {source}", peer_id);
+                                Status::invalid_argument(source.to_string())
                             });
                         
                         match upstream_conversion_result {

--- a/opendut-carl/src/manager/grpc/viper_manager.rs
+++ b/opendut-carl/src/manager/grpc/viper_manager.rs
@@ -44,7 +44,7 @@ impl ViperManagerService for ViperManagerFacade {
                 .map_err(|_: PersistenceError| opendut_carl_api::carl::viper::StoreViperSourceDescriptorError::Internal {
                     source_id: source.id,
                     source_name: source.name,
-                    cause: String::from("Error when accessing persistence while storing test suite source descriptor"),
+                    source: String::from("Error when accessing persistence while storing test suite source descriptor"),
                 });
 
         let reply = match result {
@@ -73,10 +73,10 @@ impl ViperManagerService for ViperManagerFacade {
             self.resource_manager.resources_mut(async |resources|
                 resources.delete_viper_source_descriptor(source_id).await
             ).await
-            .map_err_to_inner(|cause| DeleteViperSourceDescriptorError::Persistence {
+            .map_err_to_inner(|source| DeleteViperSourceDescriptorError::Persistence {
                 source_id,
                 source_name: None,
-                cause: cause.context("Persistence error in transaction for deleting VIPER source descriptor"),
+                source: source.context("Persistence error in transaction for deleting VIPER source descriptor"),
             })
             .log_api_err()
             .map_err(opendut_carl_api::carl::viper::DeleteViperSourceDescriptorError::from);
@@ -109,7 +109,7 @@ impl ViperManagerService for ViperManagerFacade {
                 .inspect_err(|error| error!("Error while getting test suite source descriptor from gRPC API: {error}"))
                 .map_err(|_: PersistenceError| opendut_carl_api::carl::viper::GetViperSourceDescriptorError::Internal {
                     source_id,
-                    cause: String::from("Error when accessing persistence while getting test suite source descriptor"),
+                    source: String::from("Error when accessing persistence while getting test suite source descriptor"),
                 });
 
         let response = match result {
@@ -139,7 +139,7 @@ impl ViperManagerService for ViperManagerFacade {
         let result = self.resource_manager.list::<ViperSourceDescriptor>().await
             .inspect_err(|error| error!("Error while listing test suite source descriptors from gRPC API: {error}"))
             .map_err(|_: PersistenceError| opendut_carl_api::carl::viper::ListViperSourceDescriptorsError::Internal {
-                cause: String::from("Error when accessing persistence while listing test suite source descriptors"),
+                source: String::from("Error when accessing persistence while listing test suite source descriptors"),
             });
 
         let response = match result {
@@ -177,9 +177,9 @@ impl ViperManagerService for ViperManagerFacade {
             self.resource_manager.resources_mut(async |resources|
                 resources.get_viper_test_suite_parameters(source_id).await
             ).await
-            .map_err_to_inner(|cause| GetViperTestSuiteParametersError::Persistence {
+            .map_err_to_inner(|source| GetViperTestSuiteParametersError::Persistence {
                 source_id,
-                cause: cause.context("Persistence error in transaction while getting VIPER test suite descriptors"),
+                source: source.context("Persistence error in transaction while getting VIPER test suite descriptors"),
             })
             .log_api_err()
             .map_err(opendut_carl_api::carl::viper::GetViperTestSuiteParametersError::from);
@@ -222,7 +222,7 @@ impl ViperManagerService for ViperManagerFacade {
                 .log_api_err()
                 .map_err(|_: PersistenceError| opendut_carl_api::carl::viper::StoreViperTestRunDescriptorError::Internal {
                     test_id: test.id,
-                    cause: String::from("Error when accessing persistence while storing VIPER test descriptor"),
+                    source: String::from("Error when accessing persistence while storing VIPER test descriptor"),
                 });
 
         let reply = match result {
@@ -252,7 +252,7 @@ impl ViperManagerService for ViperManagerFacade {
                 .log_api_err()
                 .map_err(|_: PersistenceError| opendut_carl_api::carl::viper::DeleteViperTestRunDescriptorError::Internal {
                     test_id,
-                    cause: String::from("Error when accessing persistence while storing VIPER test descriptor"),
+                    source: String::from("Error when accessing persistence while storing VIPER test descriptor"),
                 });
 
         let response = match result {
@@ -282,7 +282,7 @@ impl ViperManagerService for ViperManagerFacade {
                 .inspect_err(|error| error!("Error while getting VIPER test descriptor from gRPC API: {error}"))
                 .map_err(|_: PersistenceError| opendut_carl_api::carl::viper::GetViperTestRunDescriptorError::Internal {
                     test_id,
-                    cause: String::from("Error when accessing persistence while getting VIPER test descriptor"),
+                    source: String::from("Error when accessing persistence while getting VIPER test descriptor"),
                 });
 
         let response = match result {
@@ -312,7 +312,7 @@ impl ViperManagerService for ViperManagerFacade {
         let result = self.resource_manager.list::<ViperTestRunDescriptor>().await
             .inspect_err(|error| error!("Error while listing VIPER test descriptors from gRPC API: {error}"))
             .map_err(|_: PersistenceError| opendut_carl_api::carl::viper::ListViperTestRunDescriptorsError::Internal {
-                cause: String::from("Error when accessing persistence while listing VIPER test descriptors"),
+                source: String::from("Error when accessing persistence while listing VIPER test descriptors"),
             });
 
         let response = match result {
@@ -352,7 +352,7 @@ impl ViperManagerService for ViperManagerFacade {
                 .log_api_err()
                 .map_err(|_: PersistenceError| opendut_carl_api::carl::viper::StoreViperRunDeploymentError::Internal {
                     run_id: run.run_id,
-                    cause: String::from("Error when accessing persistence while storing test suite run deployment"),
+                    source: String::from("Error when accessing persistence while storing test suite run deployment"),
                 });
 
         let reply = match result {
@@ -382,7 +382,7 @@ impl ViperManagerService for ViperManagerFacade {
                 .log_api_err()
                 .map_err(|_: PersistenceError| opendut_carl_api::carl::viper::DeleteViperRunDeploymentError::Internal {
                     run_id,
-                    cause: String::from("Error when accessing persistence while storing test suite run deployment"),
+                    source: String::from("Error when accessing persistence while storing test suite run deployment"),
                 });
 
         let response = match result {
@@ -412,7 +412,7 @@ impl ViperManagerService for ViperManagerFacade {
                 .inspect_err(|error| error!("Error while getting test suite run deployment from gRPC API: {error}"))
                 .map_err(|_: PersistenceError| opendut_carl_api::carl::viper::GetViperRunDeploymentError::Internal {
                     run_id,
-                    cause: String::from("Error when accessing persistence while getting test suite run deployment"),
+                    source: String::from("Error when accessing persistence while getting test suite run deployment"),
                 });
 
         let response = match result {
@@ -442,7 +442,7 @@ impl ViperManagerService for ViperManagerFacade {
         let result = self.resource_manager.list::<ViperRunDeployment>().await
             .inspect_err(|error| error!("Error while listing test suite run deployments from gRPC API: {error}"))
             .map_err(|_: PersistenceError| opendut_carl_api::carl::viper::ListViperRunDeploymentsError::Internal {
-                cause: String::from("Error when accessing persistence while listing test suite run deployments"),
+                source: String::from("Error when accessing persistence while listing test suite run deployments"),
             });
 
         let response = match result {

--- a/opendut-carl/src/manager/observer_messaging_broker/mod.rs
+++ b/opendut-carl/src/manager/observer_messaging_broker/mod.rs
@@ -46,7 +46,7 @@ impl ObserverMessagingBroker {
             if let WaitForPeersOnlineResponseStatus::WaitForPeersOnlineSuccess = response.status {
                 let _ignore = tx_outbound.send(response.into())
                     .await
-                    .inspect_err(|cause| warn!("Failed to send response:\n  {cause}"));
+                    .inspect_err(|source| warn!("Failed to send response:\n  {source}"));
             } else {
                 loop {
                     observed_peer_connection_states.observe().await;
@@ -57,7 +57,7 @@ impl ObserverMessagingBroker {
                     let response = observed_peer_connection_states.determine_response();
                     let _ignore = tx_outbound.send(response.clone().into())
                         .await
-                        .inspect_err(|cause| warn!("Failed to send response:\n  {cause}"));
+                        .inspect_err(|source| warn!("Failed to send response:\n  {source}"));
                     if let WaitForPeersOnlineResponseStatus::WaitForPeersOnlineSuccess = response.status {
                         break;
                     }

--- a/opendut-carl/src/manager/peer_manager/assign_cluster/mod.rs
+++ b/opendut-carl/src/manager/peer_manager/assign_cluster/mod.rs
@@ -29,11 +29,11 @@ pub enum AssignClusterError {
     #[error("Assigning cluster for peer <{0}> failed, because a peer with that ID does not exist!")]
     PeerNotFound(PeerId),
     #[error("Could not assign interface name.")]
-    InterfaceName { #[source] source: NetworkInterfaceNameError },
-    #[error("Sending PeerConfiguration with ClusterAssignment to peer <{peer_id}> failed: {cause}")]
-    SendingToPeerFailed { peer_id: PeerId, cause: String },
+    InterfaceName { source: NetworkInterfaceNameError },
+    #[error("Sending PeerConfiguration with ClusterAssignment to peer <{peer_id}> failed: {message}")]
+    SendingToPeerFailed { peer_id: PeerId, message: String },
     #[error("Error while persisting ClusterAssignment for peer <{peer_id}>.")]
-    Persistence { peer_id: PeerId, #[source] source: PersistenceError },
+    Persistence { peer_id: PeerId, source: PersistenceError },
     #[error("IPv6 not supported for GRE interface configuration.")]
     Ipv6NotSupported,
 }

--- a/opendut-carl/src/manager/peer_manager/generate_cleo_setup.rs
+++ b/opendut-carl/src/manager/peer_manager/generate_cleo_setup.rs
@@ -30,7 +30,7 @@ pub async fn generate_cleo_setup(params: GenerateCleoSetupParams) -> Result<Cleo
             let issuer_url = registration_client.config.issuer_remote_url.value().clone();
             let client_credentials = registration_client.register_new_client_for_user(resource_id, params.user_id)
                 .await
-                .map_err(|cause| GenerateCleoSetupError::Internal { cause: cause.to_string() })?;
+                .map_err(|source| GenerateCleoSetupError::Internal { source: source.to_string() })?;
             debug!("Successfully generated CLEO setup with id <{cleo_id}>. OIDC client_id='{}'.", client_credentials.client_id.clone().value());
             AuthConfig::from_credentials(issuer_url, client_credentials)
         }
@@ -46,9 +46,9 @@ pub async fn generate_cleo_setup(params: GenerateCleoSetupParams) -> Result<Cleo
 
 #[derive(thiserror::Error, Debug)]
 pub enum GenerateCleoSetupError {
-    #[error("An internal error occurred while creating a CleoSetup:\n  {cause}")]
+    #[error("An internal error occurred while creating a CleoSetup:\n  {message}")]
     Internal {
-        cause: String,
+        message: String,
     }
 }
 

--- a/opendut-carl/src/manager/peer_manager/generate_peer_setup.rs
+++ b/opendut-carl/src/manager/peer_manager/generate_peer_setup.rs
@@ -36,7 +36,7 @@ impl Resources<'_> {
         let vpn_config = if let Vpn::Enabled { vpn_client } = &params.vpn {
             debug!("Retrieving VPN configuration for peer <{peer_id}>.");
             let vpn_config = vpn_client.generate_vpn_peer_configuration(params.peer).await
-                .map_err(|cause| GeneratePeerSetupError::Internal { peer_id, peer_name: Clone::clone(&peer_name), cause: cause.to_string() })?;
+                .map_err(|source| GeneratePeerSetupError::Internal { peer_id, peer_name: Clone::clone(&peer_name), source: source.to_string() })?;
             info!("Successfully retrieved vpn configuration for peer <{peer_id}>.");
             vpn_config
         }
@@ -55,7 +55,7 @@ impl Resources<'_> {
                 let issuer_url = registration_client.config.issuer_remote_url.value().clone();
                 let client_credentials = registration_client.register_new_client_for_user(resource_id, params.user_id)
                     .await
-                    .map_err(|cause| GeneratePeerSetupError::Internal { peer_id, peer_name: Clone::clone(&peer_name), cause: cause.to_string() })?;
+                    .map_err(|source| GeneratePeerSetupError::Internal { peer_id, peer_name: Clone::clone(&peer_name), source: source.to_string() })?;
                 debug!("Successfully generated peer setup for peer '{peer_name}' <{peer_id}>. OIDC client_id='{}'.", client_credentials.client_id.clone().value());
                 AuthConfig::from_credentials(issuer_url, client_credentials)
             }
@@ -76,11 +76,11 @@ pub enum GeneratePeerSetupError {
     #[error("A PeerSetup for peer <{0}> could not be created, because a peer with that ID does not exist!")]
     PeerNotFound(PeerId),
     #[error("An error occurred while accessing persistence for creating a PeerSetup for peer <{peer_id}>")]
-    Persistence { peer_id: PeerId, #[source] source: PersistenceError },
-    #[error("An internal error occurred while creating a PeerSetup for peer '{peer_name}' <{peer_id}>:\n  {cause}")]
+    Persistence { peer_id: PeerId, source: PersistenceError },
+    #[error("An internal error occurred while creating a PeerSetup for peer '{peer_name}' <{peer_id}>:\n  {message}")]
     Internal {
         peer_id: PeerId,
         peer_name: PeerName,
-        cause: String
+        message: String
     }
 }

--- a/opendut-carl/src/manager/peer_manager/store_peer_descriptor.rs
+++ b/opendut-carl/src/manager/peer_manager/store_peer_descriptor.rs
@@ -48,7 +48,7 @@ impl Resources<'_> {
                 let result = vpn_client.delete_peer(peer_id).await;
                 match result {
                     Ok(()) => info!("Successfully deleted previously created VPN peer <{peer_id}>."),
-                    Err(cause) => error!("Failed to delete previously created VPN peer <{peer_id}>: {cause}\n  Cannot recover automatically. Please remove the peer from the VPN management server manually."),
+                    Err(source) => error!("Failed to delete previously created VPN peer <{peer_id}>: {source}\n  Cannot recover automatically. Please remove the peer from the VPN management server manually."),
                 }
             }
         }
@@ -76,13 +76,13 @@ pub enum StorePeerDescriptorError {
     Persistence {
         peer_id: PeerId,
         peer_name: PeerName,
-        #[source] source: PersistenceError,
+        source: PersistenceError,
     },
     #[error("Error when creating peer in VPN management while storing peer descriptor for peer '{peer_name}' <{peer_id}>")]
     VpnClient {
         peer_id: PeerId,
         peer_name: PeerName,
-        #[source] source: opendut_vpn::CreatePeerError,
+        source: opendut_vpn::CreatePeerError,
     },
 }
 

--- a/opendut-carl/src/manager/peer_messaging_broker/effects.rs
+++ b/opendut-carl/src/manager/peer_messaging_broker/effects.rs
@@ -67,8 +67,8 @@ async fn remove_absent_peer_configuration_parameters_that_are_absent(resource_ma
                         PersistenceResult::Ok(())
                     }
                 }).await
-                    .inspect_err(|cause| {
-                        error!("Failed to remove absent peer configuration parameters for peer <{id}>: {cause}");
+                    .inspect_err(|source| {
+                        error!("Failed to remove absent peer configuration parameters for peer <{id}>: {source}");
                     });
             }
         }

--- a/opendut-carl/src/manager/peer_messaging_broker/mod.rs
+++ b/opendut-carl/src/manager/peer_messaging_broker/mod.rs
@@ -162,8 +162,8 @@ impl PeerMessagingBroker {
                             info!("Peer <{peer_id}> disconnected! Closing inbound channel.");
                             break;
                         }
-                        Err(cause) => {
-                            error!("No message from peer <{peer_id}> within {} ms:\n  {cause}. Closing connection.", timeout_duration.as_millis());
+                        Err(source) => {
+                            error!("No message from peer <{peer_id}> within {} ms:\n  {source}. Closing connection.", timeout_duration.as_millis());
                             rx_inbound.close();
                         }
                     }
@@ -187,7 +187,7 @@ impl PeerMessagingBroker {
                 }
 
                 Self::remove_peer_impl(peer_id, resource_manager, peers).await
-                    .unwrap_or_else(|cause| error!("Error while removing peer after its stream ended:\n  {cause}"));
+                    .unwrap_or_else(|source| error!("Error while removing peer after its stream ended:\n  {source}"));
             });
         }
 
@@ -211,7 +211,7 @@ impl PeerMessagingBroker {
                 configuration: peer_configuration,
             })
         )).await
-            .map_err(|cause| OpenError::SendApplyPeerConfiguration { peer_id, cause: cause.to_string() })?;
+            .map_err(|source| OpenError::SendApplyPeerConfiguration { peer_id, source: source.to_string() })?;
         Ok(())
     }
 
@@ -297,14 +297,14 @@ async fn handle_stream_message(
         UpstreamMessagePayload::EdgePeerConfigurationState(state) => {
             info!("Received PeerConfigurationState from peer <{peer_id}>:\n  {}", state.to_debug_json());
             let _ignore_result = resource_manager.insert(peer_id, state).await
-                .inspect_err(|cause| {
-                    warn!("Failed to insert PeerConfigurationState for peer <{peer_id}>:\n  {cause}");
+                .inspect_err(|source| {
+                    warn!("Failed to insert PeerConfigurationState for peer <{peer_id}>:\n  {source}");
                 });
         }
         UpstreamMessagePayload::Ping => {
             let _ignore_result =
                 tx_outbound.send(DownstreamMessage { payload: DownstreamMessagePayload::Pong, context }).await
-                    .inspect_err(|cause| warn!("Failed to send ping to peer <{peer_id}>:\n  {cause}"));
+                    .inspect_err(|source| warn!("Failed to send ping to peer <{peer_id}>:\n  {source}"));
         }
     }
 }
@@ -328,11 +328,11 @@ pub enum OpenError {
     #[error("Peer not found. Unknown peer id: <{0}>")]
     PeerNotFound(PeerId),
 
-    #[error("Error while sending peer configuration to peer:\n  {cause}")]
-    SendApplyPeerConfiguration { peer_id: PeerId, cause: String },
+    #[error("Error while sending peer configuration to peer:\n  {message}")]
+    SendApplyPeerConfiguration { peer_id: PeerId, message: String },
 
     #[error("Error while accessing persistence after Peer <{peer_id}> opened stream.")]
-    Persistence { peer_id: PeerId, #[source] source: PersistenceError },
+    Persistence { peer_id: PeerId, source: PersistenceError },
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -340,7 +340,7 @@ pub enum RemovePeerError {
     #[error("PeerNotFound Error while removing peer: {0}")]
     PeerNotFound(PeerId),
     #[error("Error while accessing persistence when removing Peer <{peer_id}>.")]
-    Persistence { peer_id: PeerId, #[source] source: PersistenceError },
+    Persistence { peer_id: PeerId, source: PersistenceError },
 }
 
 #[derive(Clone)]

--- a/opendut-carl/src/manager/viper_manager/delete_viper_source_descriptor.rs
+++ b/opendut-carl/src/manager/viper_manager/delete_viper_source_descriptor.rs
@@ -10,14 +10,14 @@ impl Resources<'_> {
 
         debug!("Fetching list of VIPER tests that might be using VIPER source <{source_id}>.");
         let tests = self.list::<ViperTestRunDescriptor>()
-            .map_err(|cause| DeleteViperSourceDescriptorError::Persistence { source_id, source_name: None, cause })?;
+            .map_err(|source| DeleteViperSourceDescriptorError::Persistence { source_id, source_name: None, source })?;
 
         match tests.values().find(|test| test.source == source_id) {
             None => {
                 debug!("No tests are using VIPER source <{source_id}>. Continuing with deletion of source.");
                 let result = self.remove::<ViperSourceDescriptor>(source_id)
-                    .map_err(|cause: PersistenceError|
-                        DeleteViperSourceDescriptorError::Persistence { source_id, source_name: None, cause }
+                    .map_err(|source: PersistenceError|
+                        DeleteViperSourceDescriptorError::Persistence { source_id, source_name: None, source }
                     )?
                     .ok_or_else(|| DeleteViperSourceDescriptorError::SourceNotFound { source_id })?;
 
@@ -47,7 +47,7 @@ pub enum DeleteViperSourceDescriptorError {
     Persistence {
         source_id: ViperSourceId,
         source_name: Option<ViperTestSuiteIdentifier>,
-        #[source] cause: PersistenceError,
+        source: PersistenceError,
     },
 }
 

--- a/opendut-carl/src/manager/viper_manager/delete_viper_test_descriptor.rs
+++ b/opendut-carl/src/manager/viper_manager/delete_viper_test_descriptor.rs
@@ -10,15 +10,15 @@ impl Resources<'_> {
 
         debug!("Fetching list of VIPER run deployments that might be using VIPER test <{test_id}>.");
         let runs = self.list::<ViperRunDeployment>()
-            .map_err(|cause| DeleteViperTestDescriptorError::Persistence { test_id, cause })?;
+            .map_err(|source| DeleteViperTestDescriptorError::Persistence { test_id, source })?;
 
         match runs.values().find(|run| run.test_id == test_id) {
             None => {
                 debug!("No run deployments are using VIPER test <{test_id}>. Continuing with deletion of test descriptor.");
                 let result = self
                     .remove::<ViperTestRunDescriptor>(test_id)
-                    .map_err(|cause: PersistenceError| {
-                        DeleteViperTestDescriptorError::Persistence { test_id, cause }
+                    .map_err(|source: PersistenceError| {
+                        DeleteViperTestDescriptorError::Persistence { test_id, source }
                     })?
                     .ok_or_else(|| DeleteViperTestDescriptorError::TestNotFound { test_id })?;
 
@@ -51,8 +51,7 @@ pub enum DeleteViperTestDescriptorError {
     #[error("Error when accessing persistence while deleting VIPER test descriptor for test <{test_id}>.")]
     Persistence {
         test_id: ViperTestId,
-        #[source]
-        cause: PersistenceError,
+                source: PersistenceError,
     },
 }
 

--- a/opendut-carl/src/manager/viper_manager/effects.rs
+++ b/opendut-carl/src/manager/viper_manager/effects.rs
@@ -15,7 +15,7 @@ pub(crate) async fn register(resource_manager: ResourceManagerRef) {
         let Source { identifier: test_suite_identifier, location, .. } = source.clone();
 
         let source_code = viper_runtime.fetch_source_code(source).await
-            .map_err(|error| FetchError::Compilation { test_suite_identifier, location, cause: error })?;
+            .map_err(|error| FetchError::Compilation { test_suite_identifier, location, source: error })?;
         Ok(source_code)
     };
 

--- a/opendut-carl/src/manager/viper_manager/fetch_source_code.rs
+++ b/opendut-carl/src/manager/viper_manager/fetch_source_code.rs
@@ -17,7 +17,7 @@ pub async fn fetch_source_code(
     let viper_source = resource_manager.resources(async |resources| {
         resources.get_viper_source_descriptor(test_id)
     }).await
-        .map_err(|error| FetchError::Persistence { test_id, cause: error })??;
+        .map_err(|error| FetchError::Persistence { test_id, source: error })??;
 
     let test_suite_identifier = viper_source.name;
     let url = viper_source.url;
@@ -41,13 +41,13 @@ impl Resources<'_> {
         test_id: ViperTestId,
     ) -> Result<ViperSourceDescriptor, FetchError> {
         let viper_test = self.get::<ViperTestRunDescriptor>(test_id)
-            .map_err(|error| FetchError::Persistence { test_id, cause: error })?
+            .map_err(|error| FetchError::Persistence { test_id, source: error })?
             .ok_or_else(|| FetchError::ViperTestRunDescriptorNotFound { test_id })?;
 
         let viper_source_id = viper_test.source;
 
         let viper_source = self.get::<ViperSourceDescriptor>(viper_source_id)
-            .map_err(|error| FetchError::Persistence { test_id, cause: error })?
+            .map_err(|error| FetchError::Persistence { test_id, source: error })?
             .ok_or_else(|| FetchError::ViperSourceDescriptorNotFound { test_id, source_id: viper_source_id })?;
 
         Ok(viper_source)
@@ -95,13 +95,13 @@ pub enum FetchError {
     #[error("Source code for test <{test_id}> could not be fetched, because of an error when accessing persistence!")]
     Persistence {
         test_id: ViperTestId,
-        #[source] cause: PersistenceError,
+        source: PersistenceError,
     },
 
     #[error("Compilation failed while getting the source code for test suite <{test_suite_identifier}> with the location ({location:?})!")]
     Compilation {
         test_suite_identifier: TestSuiteIdentifier,
         location: SourceLocation,
-        #[source] cause: Box<CompilationError>,
+        source: Box<CompilationError>,
     },
 }

--- a/opendut-carl/src/manager/viper_manager/get_peer_configuration.rs
+++ b/opendut-carl/src/manager/viper_manager/get_peer_configuration.rs
@@ -7,13 +7,13 @@ use crate::resource::manager::error::PersistenceError;
 impl Resources<'_> {
     pub fn get_peer_id_for_test(&self, test_id: ViperTestId) -> Result<PeerId, GetPeerIdForTestError>{
         let test_run_descriptor = self.get::<ViperTestRunDescriptor>(test_id)
-            .map_err(|error| GetPeerIdForTestError::Persistence { test_id, cause: error })?
+            .map_err(|error| GetPeerIdForTestError::Persistence { test_id, source: error })?
             .ok_or_else(|| GetPeerIdForTestError::TestRunDescriptorNotFound { test_id })?;
 
         let cluster_id = test_run_descriptor.cluster;
 
         let cluster_descriptor = self.get::<ClusterDescriptor>(cluster_id)
-            .map_err(|error| GetPeerIdForTestError::Persistence { test_id, cause: error })?
+            .map_err(|error| GetPeerIdForTestError::Persistence { test_id, source: error })?
             .ok_or_else(|| GetPeerIdForTestError::ClusterDescriptorNotFound { cluster_id })?;
 
         let leader_id = cluster_descriptor.leader;
@@ -33,6 +33,6 @@ pub enum GetPeerIdForTestError {
     #[error("Peer id for test <{test_id}> could not be fetches, because of an error when accessing persistence!")]
     Persistence {
         test_id: ViperTestId,
-        #[source] cause: PersistenceError,
+        source: PersistenceError,
     },
 }

--- a/opendut-carl/src/manager/viper_manager/get_viper_test_suite_parameters.rs
+++ b/opendut-carl/src/manager/viper_manager/get_viper_test_suite_parameters.rs
@@ -13,7 +13,7 @@ impl Resources<'_> {
     pub async fn get_viper_test_suite_parameters(&self, source_id: ViperSourceId) -> Result<Option<ViperTestSuiteParameters>, GetViperTestSuiteParametersError> {
 
         let source = self.get::<ViperSourceDescriptor>(source_id)
-            .map_err(|cause| GetViperTestSuiteParametersError::Persistence { source_id, cause })?;
+            .map_err(|source| GetViperTestSuiteParametersError::Persistence { source_id, source })?;
 
         match source {
             Some(source) => discover_suite(source).await,
@@ -49,7 +49,7 @@ async fn discover_suite(source: ViperSourceDescriptor) -> Result<Option<ViperTes
     debug!("VIPER compilation completed.");
 
     let (identifier, parameters) = handle.await
-        .map_err(|cause| GetViperTestSuiteParametersError::TaskJoin { source_id, when: "compiling VIPER source", cause })??;
+        .map_err(|source| GetViperTestSuiteParametersError::TaskJoin { source_id, when: "compiling VIPER source", source })??;
 
     Ok(Some(ViperTestSuiteParameters {
         id: identifier,
@@ -69,7 +69,7 @@ pub enum GetViperTestSuiteParametersError {
     TaskJoin {
         source_id: ViperSourceId,
         when: &'static str,
-        #[source] cause: tokio::task::JoinError,
+        source: tokio::task::JoinError,
     },
     #[error("Error while initializing VIPER runtime for VIPER test source {source_name} with ID <{source_id}>.")]
     ViperRuntime {
@@ -79,6 +79,6 @@ pub enum GetViperTestSuiteParametersError {
     #[error("Error when accessing persistence while getting VIPER test suite descriptor for source <{source_id}>")]
     Persistence {
         source_id: ViperSourceId,
-        #[source] cause: PersistenceError,
+        source: PersistenceError,
     },
 }

--- a/opendut-carl/src/resource/manager/persistence/error.rs
+++ b/opendut-carl/src/resource/manager/persistence/error.rs
@@ -12,26 +12,26 @@ pub enum PersistenceErrorKind {
         resource_name: &'static str,
         operation: PersistenceOperation,
         identifier: Option<String>,
-        #[source] source: Option<Cause>,
+        source: Option<Cause>,
     },
     ProtobufDecode(#[source] prost::DecodeError),
     ProtobufConversion(#[source] opendut_util::proto::ConversionError),
     KeyValueStore(#[source] redb::Error),
 }
 impl PersistenceError {
-    pub fn insert<R>(identifier: impl Debug, cause: impl Into<Cause>) -> Self {
-        Self::new::<R>(Some(identifier), PersistenceOperation::Insert, Some(cause))
+    pub fn insert<R>(identifier: impl Debug, source: impl Into<Cause>) -> Self {
+        Self::new::<R>(Some(identifier), PersistenceOperation::Insert, Some(source))
     }
-    pub fn remove<R>(identifier: impl Debug, cause: impl Into<Cause>) -> Self {
-        Self::new::<R>(Some(identifier), PersistenceOperation::Remove, Some(cause))
+    pub fn remove<R>(identifier: impl Debug, source: impl Into<Cause>) -> Self {
+        Self::new::<R>(Some(identifier), PersistenceOperation::Remove, Some(source))
     }
-    pub fn get<R>(identifier: impl Debug, cause: impl Into<Cause>) -> Self {
-        Self::new::<R>(Some(identifier), PersistenceOperation::Get, Some(cause))
+    pub fn get<R>(identifier: impl Debug, source: impl Into<Cause>) -> Self {
+        Self::new::<R>(Some(identifier), PersistenceOperation::Get, Some(source))
     }
-    pub fn list<R>(cause: impl Into<Cause>) -> Self {
-        Self::new::<R>(Option::<Uuid>::None, PersistenceOperation::List, Some(cause))
+    pub fn list<R>(source: impl Into<Cause>) -> Self {
+        Self::new::<R>(Option::<Uuid>::None, PersistenceOperation::List, Some(source))
     }
-    pub fn new<R>(identifier: Option<impl Debug>, operation: PersistenceOperation, cause: Option<impl Into<Cause>>) -> Self {
+    pub fn new<R>(identifier: Option<impl Debug>, operation: PersistenceOperation, source: Option<impl Into<Cause>>) -> Self {
         let identifier = identifier.map(|identifier| format!("{identifier:?}"));
         Self {
             context_messages: Vec::new(),
@@ -39,7 +39,7 @@ impl PersistenceError {
                 resource_name: std::any::type_name::<R>(),
                 operation,
                 identifier,
-                source: cause.map(Into::into),
+                source: source.map(Into::into),
             })
         }
     }
@@ -115,8 +115,8 @@ pub trait MapErrToInner<T, E> {
 }
 impl<T, E> MapErrToInner<T, E> for PersistenceResult<Result<T, E>> {
     fn map_err_to_inner(self, function: impl FnOnce(PersistenceError) -> E) -> Result<T, E> {
-        self.unwrap_or_else(|cause|
-            Err(function(cause))
+        self.unwrap_or_else(|source|
+            Err(function(source))
         )
     }
 }

--- a/opendut-carl/src/resource/manager/persistence/mod.rs
+++ b/opendut-carl/src/resource/manager/persistence/mod.rs
@@ -26,9 +26,9 @@ impl Db<'_> {
 
         match open_result { //The ReadTransaction does not automatically create the table and rather returns a TableDoesNotExist error
             Ok(table) => Ok(Some(table)),
-            Err(cause) => match cause {
+            Err(source) => match source {
                 TableError::TableDoesNotExist(_) => Ok(None),
-                _ => Err(redb::Error::from(cause))?,
+                _ => Err(redb::Error::from(source))?,
             }
         }
     }

--- a/opendut-carl/src/resource/manager/persistence/storage/mod.rs
+++ b/opendut-carl/src/resource/manager/persistence/storage/mod.rs
@@ -108,8 +108,8 @@ impl ResourceStorage {
                 db_transaction.commit()?;
                 memory_transaction.commit()?;
             }
-            Err(cause) => {
-                debug!("Not committing changes to the database due to error:\n  {cause}");
+            Err(source) => {
+                debug!("Not committing changes to the database due to error:\n  {source}");
             }
         }
 
@@ -215,7 +215,7 @@ impl PersistenceOptions {
             let file = {
                 let field = "persistence.database.file";
                 let value = config.get_string(field)
-                    .map_err(|cause| LoadError::ReadField { field, source: Box::new(cause) })?;
+                    .map_err(|source| LoadError::ReadField { field, source: Box::new(source) })?;
 
                 if value.is_empty() {
                     return Err(LoadError::ParseValue { field, value, source: anyhow!("Path to the database file has to be specified!").into() });

--- a/opendut-carl/src/resource/types/persistable.rs
+++ b/opendut-carl/src/resource/types/persistable.rs
@@ -23,7 +23,7 @@ impl Persistable for ClusterDescriptor {
 impl Persistable for PeerConfiguration {
     type Proto = opendut_model::proto::peer::configuration::api::PeerConfiguration;
     const TABLE: &'static str = "peer_configuration";
-    /// Not persisted at the moment. A restart will cause a reconfiguration of all peers.
+    /// Not persisted at the moment. A restart will source a reconfiguration of all peers.
     /// The `assign_cluster()` method in the `ClusterManager` evaluates the current peer descriptors of the cluster and sends new peer configurations to the peers.
     /// It is called by the `ClusterManager` when a cluster deployment is created or when all peers of a cluster deployment are available.
     /// -> subscription triggers following chain: `schedule_redeploying_clusters_when_all_peers_become_available()` -> `rollout_all_clusters_containing_newly_available_peer()` -> `rollout_cluster_if_all_peers_available()`

--- a/opendut-carl/src/startup/metrics.rs
+++ b/opendut-carl/src/startup/metrics.rs
@@ -20,7 +20,7 @@ pub fn initialize_metrics_collection(
 
                 match result {
                     Ok(deployed_clusters) => observer.observe(deployed_clusters.len() as u64, &[]),
-                    Err(cause) => trace!("Error while loading metrics information from ResourceManager:\n  {cause}")
+                    Err(source) => trace!("Error while loading metrics information from ResourceManager:\n  {source}")
                 }
             })
             .build();
@@ -36,7 +36,7 @@ pub fn initialize_metrics_collection(
 
                 match result {
                     Ok(configured_clusters) => observer.observe(configured_clusters.len() as u64, &[]),
-                    Err(cause) => trace!("Error while loading metrics information from ResourceManager:\n  {cause}")
+                    Err(source) => trace!("Error while loading metrics information from ResourceManager:\n  {source}")
                 }
             })
             .build();
@@ -52,7 +52,7 @@ pub fn initialize_metrics_collection(
 
                 match result {
                     Ok(registered_peers) => observer.observe(registered_peers.len() as u64, &[]),
-                    Err(cause) => trace!("Error while loading metrics information from ResourceManager:\n  {cause}")
+                    Err(source) => trace!("Error while loading metrics information from ResourceManager:\n  {source}")
                 }
             })
             .build();
@@ -74,7 +74,7 @@ pub fn initialize_metrics_collection(
 
                         observer.observe(online_peers.len() as u64, &[]);
                     }
-                    Err(cause) => trace!("Error while loading metrics information from ResourceManager:\n  {cause}")
+                    Err(source) => trace!("Error while loading metrics information from ResourceManager:\n  {source}")
                 }
             })
             .build();

--- a/opendut-cleo/src/commands/apply.rs
+++ b/opendut-cleo/src/commands/apply.rs
@@ -51,17 +51,17 @@ impl ApplyCli {
                         
                         Ok(())
                     }
-                    Err(cause) => {
-                        Err(format!("Failed to parse specification: {cause}"))
+                    Err(source) => {
+                        Err(format!("Failed to parse specification: {source}"))
                     }
                 }
             }
             Source::Inline(InlineSource::Json(json)) => {
                 let json_document = JsonSpecificationDocument::try_from_json_str(json.as_str())
-                    .map_err(|cause| format!("Error while parsing JSON:\n  {cause}"))?;
+                    .map_err(|source| format!("Error while parsing JSON:\n  {source}"))?;
 
                 let document = SpecificationDocument::try_from(json_document)
-                    .map_err(|cause| format!("Error while converting JSON document to specification model:\n  {cause}"))?;
+                    .map_err(|source| format!("Error while converting JSON document to specification model:\n  {source}"))?;
 
                 let model = convert_document_to_model(document)?;
 

--- a/opendut-cleo/src/commands/executor/create.rs
+++ b/opendut-cleo/src/commands/executor/create.rs
@@ -65,7 +65,7 @@ impl CreateContainerExecutorCli {
         for env in self.envs.unwrap_or_default() {
             if let Some((name, value)) = env.split_once('=') {
                 let env = ContainerEnvironmentVariable::new(name, value)
-                    .map_err(|cause| cause.to_string())?;
+                    .map_err(|source| source.to_string())?;
                 environment_variables.push(env)
             }
         };

--- a/opendut-cleo/src/commands/wait/cluster_peers_online.rs
+++ b/opendut-cleo/src/commands/wait/cluster_peers_online.rs
@@ -22,7 +22,7 @@ pub struct WaitPeersInClusterOnline {
 impl WaitPeersInClusterOnline {
     pub async fn execute(self, carl: &mut CarlClient) -> crate::Result<()> {
         let response = carl.cluster.list_cluster_peer_states(self.id).await
-            .map_err(|cause| cause.to_string())?;
+            .map_err(|source| source.to_string())?;
 
         let max_observation_duration = Duration::from_secs(self.timeout);
         match response {

--- a/opendut-cleo/src/commands/wait/mod.rs
+++ b/opendut-cleo/src/commands/wait/mod.rs
@@ -9,7 +9,7 @@ pub mod cluster_peers_online;
 
 async fn await_peers_online(carl: &mut CarlClient, peer_ids: HashSet<PeerId>, max_observation_duration: Duration, peers_may_not_yet_exist: bool) -> crate::Result<()> {
     let mut response_stream = carl.observer.wait_peers_online(peer_ids.clone(), max_observation_duration, peers_may_not_yet_exist).await
-        .map_err(|cause| format!("Failed to get stream: {}", cause.message))?;
+        .map_err(|source| format!("Failed to get stream: {}", source.message))?;
 
     let request_timeout_duration = Duration::from_secs(5);
 

--- a/opendut-cleo/src/parse/cluster.rs
+++ b/opendut-cleo/src/parse/cluster.rs
@@ -9,7 +9,7 @@ impl FromStr for ParseableClusterId {
 
     fn from_str(value: &str) -> Result<Self, Self::Err> {
         let inner = ClusterId::try_from(value)
-            .map_err(|cause| ParseError::new::<Self>(value, cause.to_string()))?;
+            .map_err(|source| ParseError::new::<Self>(value, source.to_string()))?;
         Ok(Self(inner))
     }
 }
@@ -21,7 +21,7 @@ impl FromStr for ParseableClusterName {
 
     fn from_str(value: &str) -> Result<Self, Self::Err> {
         let inner = ClusterName::try_from(value)
-            .map_err(|cause| ParseError::new::<Self>(value, cause.to_string()))?;
+            .map_err(|source| ParseError::new::<Self>(value, source.to_string()))?;
         Ok(Self(inner))
     }
 }

--- a/opendut-edgar/netbird-client-api/src/client.rs
+++ b/opendut-edgar/netbird-client-api/src/client.rs
@@ -33,8 +33,8 @@ impl Client {
                     .without_max_times() //continue retrying indefinitely
                     .with_max_delay(Duration::from_secs(60))
             )
-            .notify(|cause: &tonic::transport::Error, sleep_duration: Duration| {
-                debug!("Trying to connect to NetBird client after waiting {sleep_duration:?}. Had failed to connect due to: {cause}");
+            .notify(|source: &tonic::transport::Error, sleep_duration: Duration| {
+                debug!("Trying to connect to NetBird client after waiting {sleep_duration:?}. Had failed to connect due to: {source}");
             })
             .await;
 
@@ -43,9 +43,9 @@ impl Client {
                 info!("Connected to NetBird Client process via Unix domain socket at '{path}'.");
                 Ok(Self { inner: client })
             }
-            Err(cause) => {
-                error!("Error while connecting to NetBird Client process via Unix domain socket at '{path}': {cause}");
-                Err(Error::transport(cause, format!("Failed to connect to NetBird Unix domain socket at '{path}'")))
+            Err(source) => {
+                error!("Error while connecting to NetBird Client process via Unix domain socket at '{path}': {source}");
+                Err(Error::transport(source, format!("Failed to connect to NetBird Unix domain socket at '{path}'")))
             }
         }
     }

--- a/opendut-edgar/netbird-client-api/src/error.rs
+++ b/opendut-edgar/netbird-client-api/src/error.rs
@@ -1,15 +1,15 @@
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
-    #[error("{message}: {cause}")]
-    Transport { message: String, cause: tonic::transport::Error },
-    #[error("Request error: {cause}")]
-    Request { #[from] cause: tonic::Status }
+    #[error("{message}: {source}")]
+    Transport { message: String, source: tonic::transport::Error },
+    #[error("Request error: {source}")]
+    Request { #[from] source: tonic::Status }
 }
 impl Error {
-    pub fn transport(cause: tonic::transport::Error, message: impl Into<String>) -> Self {
+    pub fn transport(source: tonic::transport::Error, message: impl Into<String>) -> Self {
         Error::Transport {
             message: message.into(),
-            cause,
+            source,
         }
     }
 }

--- a/opendut-edgar/netbird-client-api/src/extension.rs
+++ b/opendut-edgar/netbird-client-api/src/extension.rs
@@ -17,7 +17,7 @@ impl LocalPeerStateExtension for LocalPeerState {
             .ok_or(LocalIpParseError { message: format!("Iterator.split() should always return a first element. Did not do so when stripping CIDR mask off of local IP '{local_ip}'.") })?;
 
         let local_ip = Ipv4Addr::from_str(local_ip)
-            .map_err(|cause| LocalIpParseError { message: format!("Local IP returned by NetBird '{local_ip}' could not be parsed: {cause}") })?;
+            .map_err(|source| LocalIpParseError { message: format!("Local IP returned by NetBird '{local_ip}' could not be parsed: {source}") })?;
 
         Ok(local_ip)
     }

--- a/opendut-edgar/opendut-edgar-kernel-modules/src/lib.rs
+++ b/opendut-edgar/opendut-edgar-kernel-modules/src/lib.rs
@@ -7,16 +7,16 @@ use std::path::{Path, PathBuf};
 
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
-    #[error("Failure while checking for loaded module: {cause}")]
-    CheckModuleLoaded { cause: io::Error },
-    #[error("Failure while checking module <{module}> parameter <{parameter}>: {cause}")]
-    CheckModuleParameters { module: String, parameter: String, cause: io::Error },
-    #[error("Invalid parameters for module <{module}> with parameter <{parameter}>: {cause}")]
-    InvalidModuleParameters { module: String, parameter: String, cause: String },
-    #[error("Failure while loading module: {cause}")]
-    LoadModule { cause: io::Error },
-    #[error("Failure while loading module: {cause}")]
-    LoadModuleExecution { cause: String },
+    #[error("Failure while checking for loaded module: {source}")]
+    CheckModuleLoaded { source: io::Error },
+    #[error("Failure while checking module <{module}> parameter <{parameter}>: {source}")]
+    CheckModuleParameters { module: String, parameter: String, source: io::Error },
+    #[error("Invalid parameters for module <{module}> with parameter <{parameter}>: {message}")]
+    InvalidModuleParameters { module: String, parameter: String, message: String },
+    #[error("Failure while loading module: {source}")]
+    LoadModule { source: io::Error },
+    #[error("Failure while loading module: {message}")]
+    LoadModuleExecution { message: String },
 }
 
 pub struct KernelModule {
@@ -39,7 +39,7 @@ impl KernelParameterFile {
 impl KernelModule {
     pub fn is_loaded(&self, loaded_module_file: &Path, builtin_module_dir: &Path) -> Result<bool, Error> {
         let file = File::open(loaded_module_file)
-            .map_err(|cause| Error::CheckModuleLoaded { cause })?;
+            .map_err(|source| Error::CheckModuleLoaded { source })?;
         let reader = BufReader::new(file);
 
         for mod_line in reader.lines() {
@@ -54,7 +54,7 @@ impl KernelModule {
                         None => continue
                     }
                 }
-                Err(why) => return Err(Error::CheckModuleLoaded { cause: why }),
+                Err(why) => return Err(Error::CheckModuleLoaded { source: why }),
             }
         }
         self.check_module_parameters(builtin_module_dir)?;
@@ -72,12 +72,12 @@ impl KernelModule {
         for (parameter, value) in &self.params {
             let param_file = KernelParameterFile::new(module_dir, &module, parameter);
             let mut file = File::open(param_file.value())
-                .map_err(|cause| Error::CheckModuleParameters { module: module.clone(), parameter: parameter.clone(), cause })?;
+                .map_err(|source| Error::CheckModuleParameters { module: module.clone(), parameter: parameter.clone(), source })?;
             let mut contents = String::new();
             file.read_to_string(&mut contents)
-                .map_err(|cause| Error::CheckModuleParameters { module: module.clone(), parameter: parameter.clone(), cause })?;
+                .map_err(|source| Error::CheckModuleParameters { module: module.clone(), parameter: parameter.clone(), source })?;
             if contents.trim() != value.as_str() {
-                return Err(Error::InvalidModuleParameters { module, parameter: parameter.clone(), cause: contents.trim().to_string() });
+                return Err(Error::InvalidModuleParameters { module, parameter: parameter.clone(), message: contents.trim().to_string() });
             }
         }
         Ok(())
@@ -100,10 +100,10 @@ impl KernelModule {
             cmd.arg(format!("{key}={value}"));
         }
 
-        let output = cmd.output().map_err(|cause| Error::LoadModule { cause })?;
+        let output = cmd.output().map_err(|source| Error::LoadModule { source })?;
 
         if ! output.status.success() {
-            return Err(Error::LoadModuleExecution { cause: format!("{:?}", String::from_utf8_lossy(&output.stderr).trim()) });
+            return Err(Error::LoadModuleExecution { message: format!("{:?}", String::from_utf8_lossy(&output.stderr).trim()) });
         }
         Ok(())
     }

--- a/opendut-edgar/src/common/carl.rs
+++ b/opendut-edgar/src/common/carl.rs
@@ -25,7 +25,7 @@ pub async fn open_stream(
         context: None,
         payload: broker::UpstreamMessagePayload::Ping,
     }).await
-        .map_err(|cause| broker::error::OpenStream { message: format!("Error while sending initial ping: {cause}") })?;
+        .map_err(|source| broker::error::OpenStream { message: format!("Error while sending initial ping: {source}") })?;
 
     info!("Peer messaging stream opened.");
     Ok((rx_inbound, tx_outbound))

--- a/opendut-edgar/src/service/network_interface/manager/addresses.rs
+++ b/opendut-edgar/src/service/network_interface/manager/addresses.rs
@@ -12,7 +12,7 @@ impl NetworkInterfaceManager {
         self.handle.address().add(interface.index, address, prefix_len)
             .execute()
             .await
-            .map_err(|error| Error::ModificationFailure { name: interface.name.clone(), cause: format!("Failed to add ip address. {}", error) })?;
+            .map_err(|error| Error::ModificationFailure { name: interface.name.clone(), source: format!("Failed to add ip address. {}", error) })?;
         Ok(interface)
     }
 
@@ -33,7 +33,7 @@ impl NetworkInterfaceManager {
 
         self.handle.address().del(address_message.clone()).execute()
             .await
-            .map_err(|error| Error::ModificationFailure { name: interface.name.clone(), cause: format!("Failed to delete ip address. {}", error) })?;
+            .map_err(|error| Error::ModificationFailure { name: interface.name.clone(), source: format!("Failed to delete ip address. {}", error) })?;
         let interface = self.try_find_interface(&interface.name).await?;
 
         Ok(interface)
@@ -44,7 +44,7 @@ impl NetworkInterfaceManager {
         let link = self.handle
             .link().get().match_name(name.name()).execute()
             .try_next().await
-            .map_err(|cause| Error::ListInterfaces { cause: cause.into() })?
+            .map_err(|source| Error::ListInterfaces { source: source.into() })?
             .ok_or(Error::InterfaceNotFound { name: name.clone() })?;
 
         let addresses = self.handle
@@ -53,10 +53,10 @@ impl NetworkInterfaceManager {
             .set_link_index_filter(link.header.index)
             .execute()
             .try_collect::<Vec<AddressMessage>>().await
-            .map_err(|cause| Error::ListAddresses { cause: cause.into() } )?;
+            .map_err(|source| Error::ListAddresses { source: source.into() } )?;
         for address in addresses {
             self.handle.address().del(address).execute().await
-                .map_err(|cause| Error::DeleteAddress { name: name.clone(), cause: cause.into() })?;
+                .map_err(|source| Error::DeleteAddress { name: name.clone(), source: source.into() })?;
         }
 
         Ok(())
@@ -69,7 +69,7 @@ impl NetworkInterfaceManager {
             .execute()
             .try_collect::<Vec<_>>()
             .await
-            .map_err(|cause| Error::ListInterfaces { cause: cause.into() })?;
+            .map_err(|source| Error::ListInterfaces { source: source.into() })?;
 
         for link in links {
             let mut address_messages = self.handle
@@ -79,7 +79,7 @@ impl NetworkInterfaceManager {
                 .execute()
                 .try_collect::<Vec<_>>()
                 .await
-                .map_err(|cause| Error::ListInterfaces { cause: cause.into() })?;
+                .map_err(|source| Error::ListInterfaces { source: source.into() })?;
             for address_message in address_messages.iter_mut() {
                 let ips = address_message.attributes.iter().filter_map(|attribute| {
                     if let AddressAttribute::Address(ip) = attribute {
@@ -125,7 +125,7 @@ mod tests {
         let interface = manager.create_dummy_ipv4_interface(&dummy).await?;
         let interface = manager.add_address(&interface, address, 24).await?;
         let interface = manager.delete_address(&interface, address, 24)
-            .await.inspect_err(|cause| println!("Failed to delete address: {cause}"))?;
+            .await.inspect_err(|source| println!("Failed to delete address: {source}"))?;
 
         manager.delete_interface(&interface).await?;
 

--- a/opendut-edgar/src/service/network_interface/manager/altname.rs
+++ b/opendut-edgar/src/service/network_interface/manager/altname.rs
@@ -12,7 +12,7 @@ impl NetworkInterfaceManager {
             .property_add(interface.index)
             .alt_ifname(&alt_names).execute()
             .await
-            .map_err(|cause| Error::BridgeCreation { name: interface.name.clone(), cause: cause.into() })?;
+            .map_err(|source| Error::BridgeCreation { name: interface.name.clone(), source: source.into() })?;
         let interface = self.try_find_interface(&interface.name).await?;
         Ok(interface)
     }

--- a/opendut-edgar/src/service/network_interface/manager/bridge.rs
+++ b/opendut-edgar/src/service/network_interface/manager/bridge.rs
@@ -19,12 +19,12 @@ impl NetworkInterfaceManager {
                     .filter_interfaces_joined_to(interface.index)
                     .execute()
                     .try_collect::<Vec<_>>().await
-                    .map_err(|cause| Error::ListInterfaces { cause: cause.into() })?
+                    .map_err(|source| Error::ListInterfaces { source: source.into() })?
                     .into_iter()
                     .filter_map(|link_message| {
                         let index = link_message.header.index;
                         Interface::try_from(link_message)
-                            .inspect_err(|cause| warn!("Could not determine attributes of interface with index '{index}': {cause}"))
+                            .inspect_err(|source| warn!("Could not determine attributes of interface with index '{index}': {source}"))
                             .ok()
                     })
                     .collect::<Vec<_>>();
@@ -43,10 +43,10 @@ impl NetworkInterfaceManager {
                     .build()
             )
             .execute().await
-            .map_err(|cause| Error::JoinInterfaceToBridge {
+            .map_err(|source| Error::JoinInterfaceToBridge {
                 interface: Box::new(interface.clone()),
                 bridge: Box::new(bridge.clone()),
-                cause: cause.into()
+                source: source.into()
             })?;
         Ok(())
     }
@@ -61,7 +61,7 @@ impl NetworkInterfaceManager {
                     .build()
             )
             .execute().await
-            .map_err(|cause| Error::ModificationFailure { name: interface.name.clone(), cause: format!("Failed to remove controller from interface. {cause}") })?;
+            .map_err(|source| Error::ModificationFailure { name: interface.name.clone(), source: format!("Failed to remove controller from interface. {source}") })?;
         Ok(())
     }
 }

--- a/opendut-edgar/src/service/network_interface/manager/mod.rs
+++ b/opendut-edgar/src/service/network_interface/manager/mod.rs
@@ -30,7 +30,7 @@ pub struct NetworkInterfaceManager {
 impl NetworkInterfaceManager {
     pub fn create() -> Result<NetworkInterfaceManagerRef, Error> {
         let (connection, handle, _) = rtnetlink::new_connection()
-            .map_err(|cause| Error::Connecting { cause })?;
+            .map_err(|source| Error::Connecting { source })?;
         tokio::spawn(connection);
 
         Ok(Arc::new(Self { handle }))
@@ -42,12 +42,12 @@ impl NetworkInterfaceManager {
             .get()
             .execute()
             .try_collect::<Vec<_>>().await
-            .map_err(|cause| Error::ListInterfaces { cause: cause.into() })?
+            .map_err(|source| Error::ListInterfaces { source: source.into() })?
             .into_iter()
             .filter_map(|link_message| {
                 let index = link_message.header.index;
                 Interface::try_from(link_message)
-                    .inspect_err(|cause| warn!("Could not determine attributes of interface with index '{index}': {cause}"))
+                    .inspect_err(|source| warn!("Could not determine attributes of interface with index '{index}': {source}"))
                     .ok()
             })
             .collect::<Vec<_>>();
@@ -72,7 +72,7 @@ impl NetworkInterfaceManager {
                     .build()
             )
             .execute().await
-            .map_err(|cause| Error::BridgeCreation { name: name.clone(), cause: cause.into() })?;
+            .map_err(|source| Error::BridgeCreation { name: name.clone(), source: source.into() })?;
 
         let interface = self.try_find_interface(name).await?;
         Ok(interface)
@@ -89,7 +89,7 @@ impl NetworkInterfaceManager {
                     .build()
             )
             .execute().await
-            .map_err(|cause| Error::GretapCreation { name: name.clone(), cause: cause.into() })?;
+            .map_err(|source| Error::GretapCreation { name: name.clone(), source: source.into() })?;
         let interface = self.try_find_interface(name).await?;
         Ok(interface)
     }
@@ -104,7 +104,7 @@ impl NetworkInterfaceManager {
                     .build()
             )
             .execute().await
-            .map_err(|cause| Error::SetInterfaceUp { interface: Box::new(interface.clone()), cause: cause.into() })?;
+            .map_err(|source| Error::SetInterfaceUp { interface: Box::new(interface.clone()), source: source.into() })?;
         Ok(())
     }
 
@@ -118,7 +118,7 @@ impl NetworkInterfaceManager {
                     .build()
             )
             .execute().await
-            .map_err(|cause| Error::SetInterfaceDown { interface: Box::new(interface.clone()), cause: cause.into() })?;
+            .map_err(|source| Error::SetInterfaceDown { interface: Box::new(interface.clone()), source: source.into() })?;
         Ok(())
     }
 
@@ -158,10 +158,10 @@ impl NetworkInterfaceManager {
         let output = ip_link_command
             .output()
             .await
-            .map_err(|cause| Error::CommandLineProgramExecution { command: format!("{ip_link_command:?}"), cause })?;
+            .map_err(|source| Error::CommandLineProgramExecution { command: format!("{ip_link_command:?}"), source })?;
 
         if !output.status.success() {
-            return Err(Error::CanInterfaceUpdate { name: interface_name.clone(), cause: format!("{:?}", String::from_utf8_lossy(&output.stderr).trim()) });
+            return Err(Error::CanInterfaceUpdate { name: interface_name.clone(), source: format!("{:?}", String::from_utf8_lossy(&output.stderr).trim()) });
         }
 
         Ok(())
@@ -172,7 +172,7 @@ impl NetworkInterfaceManager {
             .link()
             .del(interface.index)
             .execute().await
-            .map_err(|cause| Error::DeleteInterface { interface: Box::new(interface.clone()), cause: cause.into() })?;
+            .map_err(|source| Error::DeleteInterface { interface: Box::new(interface.clone()), source: source.into() })?;
         Ok(())
     }
 
@@ -186,7 +186,7 @@ impl NetworkInterfaceManager {
             )
             .execute()
             .await
-            .map_err(|error| Error::VcanInterfaceCreation { name: name.clone(), cause: error.to_string() })?;
+            .map_err(|error| Error::VcanInterfaceCreation { name: name.clone(), source: error.to_string() })?;
         let interface = self.try_find_interface(name).await?;
         Ok(interface)
     }
@@ -201,7 +201,7 @@ impl NetworkInterfaceManager {
             )
             .execute()
             .await
-            .map_err(|error| Error::ModificationFailure { name: name.clone(), cause: error.to_string() })?;
+            .map_err(|error| Error::ModificationFailure { name: name.clone(), source: error.to_string() })?;
 
         let interface = self.try_find_interface(name).await?;
         Ok(interface)
@@ -210,32 +210,32 @@ impl NetworkInterfaceManager {
 
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
-    #[error("Failure while creating bridge '{name}': {cause}")]
-    BridgeCreation { name: NetworkInterfaceName, cause: Box<rtnetlink::Error> },
-    #[error("Failed to establish connection to netlink: {cause}")]
-    Connecting { cause: io::Error },
-    #[error("Failure while deleting interface {interface}: {cause}")]
-    DeleteInterface { interface: Box<Interface>, cause: Box<rtnetlink::Error> },
-    #[error("Failure while creating gretap interface '{name}': {cause}")]
-    GretapCreation { name: NetworkInterfaceName, cause: Box<rtnetlink::Error> },
+    #[error("Failure while creating bridge '{name}': {source}")]
+    BridgeCreation { name: NetworkInterfaceName, source: Box<rtnetlink::Error> },
+    #[error("Failed to establish connection to netlink: {source}")]
+    Connecting { source: io::Error },
+    #[error("Failure while deleting interface {interface}: {source}")]
+    DeleteInterface { interface: Box<Interface>, source: Box<rtnetlink::Error> },
+    #[error("Failure while creating gretap interface '{name}': {source}")]
+    GretapCreation { name: NetworkInterfaceName, source: Box<rtnetlink::Error> },
     #[error("Interface with name '{name}' not found.")]
     InterfaceNotFound { name: NetworkInterfaceName },
-    #[error("Failure while listing interfaces: {cause}")]
-    ListInterfaces { cause: Box<rtnetlink::Error> },
-    #[error("Failure while setting interface {interface} to state 'up': {cause}")]
-    SetInterfaceUp { interface: Box<Interface>, cause: Box<rtnetlink::Error> },
-    #[error("Failure while setting interface {interface} to state 'down': {cause}")]
-    SetInterfaceDown { interface: Box<Interface>, cause: Box<rtnetlink::Error> },
-    #[error("Failure while joining interface {interface} to bridge {bridge}: {cause}")]
-    JoinInterfaceToBridge { interface: Box<Interface>, bridge: Box<Interface>, cause: Box<rtnetlink::Error> },
-    #[error("Failure while creating virtual CAN interface '{name}': {cause}")]
-    VcanInterfaceCreation { name: NetworkInterfaceName, cause: String },
-    #[error("Failed to modify interface '{name}': {cause}")]
-    ModificationFailure { name: NetworkInterfaceName, cause: String},
-    #[error("Failure during updating CAN interface '{name}': {cause}")]
-    CanInterfaceUpdate { name: NetworkInterfaceName, cause: String},
-    #[error("Failure while invoking command line program '{command}': {cause}")]
-    CommandLineProgramExecution { command: String, cause: std::io::Error },
+    #[error("Failure while listing interfaces: {source}")]
+    ListInterfaces { source: Box<rtnetlink::Error> },
+    #[error("Failure while setting interface {interface} to state 'up': {source}")]
+    SetInterfaceUp { interface: Box<Interface>, source: Box<rtnetlink::Error> },
+    #[error("Failure while setting interface {interface} to state 'down': {source}")]
+    SetInterfaceDown { interface: Box<Interface>, source: Box<rtnetlink::Error> },
+    #[error("Failure while joining interface {interface} to bridge {bridge}: {source}")]
+    JoinInterfaceToBridge { interface: Box<Interface>, bridge: Box<Interface>, source: Box<rtnetlink::Error> },
+    #[error("Failure while creating virtual CAN interface '{name}': {message}")]
+    VcanInterfaceCreation { name: NetworkInterfaceName, message: String },
+    #[error("Failed to modify interface '{name}': {message}")]
+    ModificationFailure { name: NetworkInterfaceName, message: String},
+    #[error("Failure during updating CAN interface '{name}': {message}")]
+    CanInterfaceUpdate { name: NetworkInterfaceName, message: String},
+    #[error("Failure while invoking command line program '{command}': {source}")]
+    CommandLineProgramExecution { command: String, source: std::io::Error },
 }
 
 

--- a/opendut-edgar/src/service/network_metrics/manager.rs
+++ b/opendut-edgar/src/service/network_metrics/manager.rs
@@ -71,7 +71,7 @@ impl NetworkMetricsManager {
 
                 if project::is_running_in_development().not() {
                     let _ = super::rperf::server::exponential_backoff_launch_rperf_server(spawner.clone(), rperf_backoff_max_elapsed_time).await //ignore errors during startup of rperf server, as we do not want to crash EDGAR for this
-                        .inspect_err(|cause| error!("Failed to start rperf server:\n  {cause}"));
+                        .inspect_err(|source| error!("Failed to start rperf server:\n  {source}"));
 
                     super::rperf::client::launch_rperf_clients(remote_peers, spawner.clone(), target_bandwidth_kbit_per_second, rperf_backoff_max_elapsed_time).await;
                 }

--- a/opendut-edgar/src/service/network_metrics/ping.rs
+++ b/opendut-edgar/src/service/network_metrics/ping.rs
@@ -38,8 +38,8 @@ pub async fn spawn_cluster_ping(peers: HashMap<PeerId, IpAddr>, ping_interval_ms
                         last_ping_was_successful = true;
                     }
                 },
-                Err(cause) => {
-                    error!("Error while pinging peer {peer_id} with IP {peer_ip}: {cause:?}", peer_ip=remote_address);
+                Err(source) => {
+                    error!("Error while pinging peer {peer_id} with IP {peer_ip}: {source:?}", peer_ip=remote_address);
                     last_ping_was_successful = false;
                 }
             }

--- a/opendut-edgar/src/service/network_metrics/rperf/client.rs
+++ b/opendut-edgar/src/service/network_metrics/rperf/client.rs
@@ -43,7 +43,7 @@ pub async fn launch_rperf_clients(
                     megabits_second_send_mutex,
                     megabits_second_receive_mutex
                 ).await
-                    .inspect_err(|cause| error!("Failed to start rperf client for peer {peer_id}: {cause}"));
+                    .inspect_err(|source| error!("Failed to start rperf client for peer {peer_id}: {source}"));
             });
     }
 }
@@ -66,7 +66,7 @@ async fn exponential_backoff_launch_rperf_client(
         .await;
 
     backoff_result
-        .map_err(|cause| RperfClientError { message: "Could not run rperf client".to_string(), cause })
+        .map_err(|source| RperfClientError { message: "Could not run rperf client".to_string(), source })
 }
 
 async fn launch_rperf_client(
@@ -109,9 +109,9 @@ async fn launch_rperf_client(
                                                 .record(value, &[KeyValue::new("peer_ip_address", vpn_address.to_string())]);
                                             debug!("Sending to {} in megabits/second: {}", vpn_address.to_string(), value);
                                         },
-                                        Err(cause) => {
-                                            error!("Failed to parse rperf bandwidth: {}", cause);
-                                            return Err(RperfError::BandwidthParse { message: "Failed to parse rperf bandwidth".to_string(), cause });
+                                        Err(source) => {
+                                            error!("Failed to parse rperf bandwidth: {}", source);
+                                            return Err(RperfError::BandwidthParse { message: "Failed to parse rperf bandwidth".to_string(), source });
                                         }
                                     },
                                     RperfOperation::Receive => match number_str.parse::<f64>() {
@@ -120,9 +120,9 @@ async fn launch_rperf_client(
                                                 .record(value, &[KeyValue::new("peer_ip_address", vpn_address.to_string())]);
                                             debug!("Receiving from {} in megabits/second: {}", vpn_address.to_string(), value);
                                         },
-                                        Err(cause) => {
-                                            error!("Failed to parse rperf bandwidth: {}", cause);
-                                            return Err(RperfError::BandwidthParse { message: "Failed to parse rperf bandwidth".to_string(), cause });
+                                        Err(source) => {
+                                            error!("Failed to parse rperf bandwidth: {}", source);
+                                            return Err(RperfError::BandwidthParse { message: "Failed to parse rperf bandwidth".to_string(), source });
                                         }
                                     },
                                     RperfOperation::Default => {} //do nothing
@@ -167,7 +167,7 @@ async fn launch_rperf_client(
         }
         Err(error) => {
             error!("The rperf client could not be started: {}", error);
-            Err(RperfError::Start { message: "The rperf client could not be started".to_string(), cause: error })
+            Err(RperfError::Start { message: "The rperf client could not be started".to_string(), source: error })
         }
     }
 }

--- a/opendut-edgar/src/service/network_metrics/rperf/mod.rs
+++ b/opendut-edgar/src/service/network_metrics/rperf/mod.rs
@@ -6,21 +6,21 @@ pub mod server;
 
 #[derive(thiserror::Error, Debug)]
 pub enum RperfError {
-    #[error("'{message}'. Cause: '{cause}'")]
-    Start { message: String, cause: Error },
+    #[error("'{message}'. Cause: '{source}'")]
+    Start { message: String, source: Error },
     #[error("{message}\n")]
     StdoutAccess { message: String},
     #[error("{message}\n")]
     StderrAccess { message: String},
-    #[error("{message}\n  {cause}")]
-    BandwidthParse { message: String, cause: ParseFloatError },
+    #[error("{message}\n  {source}")]
+    BandwidthParse { message: String, source: ParseFloatError },
     #[error("Client error: '{message}'.")]
     Other { message: String },
 }
 #[derive(thiserror::Error, Debug)]
 pub enum RperfRunError {
-    #[error("RperfClientError: '{message}'. Cause: '{cause}'")]
-    RperfClientError { message: String, cause: RperfError },
-    #[error("RperfServerError: '{message}'. Cause: '{cause}'")]
-    RperfServerError { message: String, cause: RperfError },
+    #[error("RperfClientError: '{message}'. Cause: '{source}'")]
+    RperfClientError { message: String, source: RperfError },
+    #[error("RperfServerError: '{message}'. Cause: '{source}'")]
+    RperfServerError { message: String, source: RperfError },
 }

--- a/opendut-edgar/src/service/network_metrics/rperf/server.rs
+++ b/opendut-edgar/src/service/network_metrics/rperf/server.rs
@@ -23,7 +23,7 @@ pub async fn exponential_backoff_launch_rperf_server(
         .await;
 
     backoff_result
-        .map_err(|cause| RperfServerError { message: "Could not run rperf server".to_string(), cause })
+        .map_err(|source| RperfServerError { message: "Could not run rperf server".to_string(), source })
 }
 
 pub async fn launch_rperf_server(spawner: Spawner) -> Result<(), RperfError> {
@@ -64,7 +64,7 @@ pub async fn launch_rperf_server(spawner: Spawner) -> Result<(), RperfError> {
         }
         Err(error) => {
             error!("The rperf server could not be started: {}", error);
-            Err(RperfError::Start { message: "The rperf server could not be started".to_string(), cause: error })
+            Err(RperfError::Start { message: "The rperf server could not be started".to_string(), source: error })
         }
     }
 }

--- a/opendut-edgar/src/service/peer_configuration.rs
+++ b/opendut-edgar/src/service/peer_configuration.rs
@@ -92,7 +92,7 @@ async fn spawn_peer_configuration_handler_loop(
             error!("Some unknown parameters were reported in the state: {}", unknown.to_debug_json());
         }
         let _ = tx_peer_configuration_state.send(state).await
-            .inspect_err(|cause| error!("Failed to send peer configuration state to CARL: {cause}"));
+            .inspect_err(|source| error!("Failed to send peer configuration state to CARL: {source}"));
     }
 }
 

--- a/opendut-edgar/src/service/peer_messaging_client.rs
+++ b/opendut-edgar/src/service/peer_messaging_client.rs
@@ -230,7 +230,7 @@ impl PeerMessagingClient {
                         };
                         let _ignore_error =
                             tx_outbound.send(message).await
-                                .inspect_err(|cause| debug!("Failed to send ping to CARL: {cause:?}"));
+                                .inspect_err(|source| debug!("Failed to send ping to CARL: {source:?}"));
                     }
                     _ = connect_cancel.cancelled() => {
                         debug!("Responding with Pong message cancelled.");

--- a/opendut-edgar/src/service/start.rs
+++ b/opendut-edgar/src/service/start.rs
@@ -154,7 +154,7 @@ pub async fn connect_and_start(config: &ConnectAndStart<'_>, settings: &LoadedCo
                     return Ok(());
                 }
             }
-            Err(cause) => {
+            Err(source) => {
                 if connect_cancel.is_cancelled() {
                     info!("Connection to CARL was explicitly cancelled. Terminating EDGAR.");
                     break;
@@ -163,14 +163,14 @@ pub async fn connect_and_start(config: &ConnectAndStart<'_>, settings: &LoadedCo
                     let mut backoff = backoff.lock().await;
 
                     if let Some(delay) = backoff.next() {
-                        error!("Error in connection to CARL. Reconnecting in {delay:?}. Error was: {cause:?}");
+                        error!("Error in connection to CARL. Reconnecting in {delay:?}. Error was: {source:?}");
 
                         tokio::select! {
                             _ = tokio::time::sleep(delay) => {}
                             _ = connect_cancel.cancelled() => return Ok(()),
                         }
                     } else {
-                        error!("Error in connection to CARL. No retries left. Terminating EDGAR. Error was: {cause:?}");
+                        error!("Error in connection to CARL. No retries left. Terminating EDGAR. Error was: {source:?}");
                         break;
                     }
                 }

--- a/opendut-edgar/src/service/tasks/can_local_route.rs
+++ b/opendut-edgar/src/service/tasks/can_local_route.rs
@@ -34,10 +34,10 @@ impl Display for CanRouteOperation {
 
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
-    #[error("Failure while invoking command line program '{command}': {cause}")]
-    CommandLineProgramExecution { command: String, cause: std::io::Error },
-    #[error("Failed to {operation} CAN route '{src}' -> '{dst}': {cause}")]
-    CanRouteCreation { src: NetworkInterfaceName, dst: NetworkInterfaceName, operation: CanRouteOperation, cause: String },
+    #[error("Failure while invoking command line program '{command}': {source}")]
+    CommandLineProgramExecution { command: String, source: std::io::Error },
+    #[error("Failed to {operation} CAN route '{src}' -> '{dst}': {message}")]
+    CanRouteCreation { src: NetworkInterfaceName, dst: NetworkInterfaceName, operation: CanRouteOperation, message: String },
 }
 
 
@@ -127,7 +127,7 @@ async fn check_can_route_exists(src: &NetworkInterfaceName, dst: &NetworkInterfa
         .arg("-L")
         .output()
         .await
-        .map_err(|cause| Error::CommandLineProgramExecution { command: "cangw".to_string(), cause })?;
+        .map_err(|source| Error::CommandLineProgramExecution { command: "cangw".to_string(), source })?;
 
     // cangw -L returns non-zero exit code despite succeeding, so we don't check it here
 
@@ -173,7 +173,7 @@ async fn modify_can_route(src: &NetworkInterfaceName, dst: &NetworkInterfaceName
 
     trace!("{operation:?} CAN route, executing command: {cmd:?}");
     let output = cmd.output().await
-        .map_err(|cause| Error::CommandLineProgramExecution { command: "cangw".to_string(), cause })?;
+        .map_err(|source| Error::CommandLineProgramExecution { command: "cangw".to_string(), source })?;
 
     if output.status.success() {
         Ok(())
@@ -182,7 +182,7 @@ async fn modify_can_route(src: &NetworkInterfaceName, dst: &NetworkInterfaceName
             src: src.clone(),
             dst: dst.clone(),
             operation,
-            cause: format!("{:?}", String::from_utf8_lossy(&output.stderr).trim())
+            source: format!("{:?}", String::from_utf8_lossy(&output.stderr).trim())
         }))
     }
 }

--- a/opendut-edgar/src/service/tasks/runner/service_runner.rs
+++ b/opendut-edgar/src/service/tasks/runner/service_runner.rs
@@ -40,11 +40,11 @@ impl From<CollectedResult> for EdgePeerConfigurationState {
             }
         }).collect::<HashSet<_>>();
 
-        fn make_error(kind: ParameterDetectedStateErrorKind, cause: impl ToString) -> ParameterEdgeDetectedStateKind {
+        fn make_error(kind: ParameterDetectedStateErrorKind, source: impl ToString) -> ParameterEdgeDetectedStateKind {
             ParameterEdgeDetectedStateKind::Error(
                 ParameterDetectedStateError {
                     kind,
-                    cause: ParameterDetectedStateErrorCause::Unclassified(cause.to_string()),
+                    source: ParameterDetectedStateErrorCause::Unclassified(source.to_string()),
                 }
             )
         }
@@ -106,7 +106,7 @@ impl From<CollectedResult> for EdgePeerConfigurationState {
             let state = ParameterEdgeDetectedStateKind::Error(
                 ParameterDetectedStateError {
                     kind: ParameterDetectedStateErrorKind::WaitingForDependenciesFailed,
-                    cause: ParameterDetectedStateErrorCause::MissingDependencies(missing_dependencies)
+                    source: ParameterDetectedStateErrorCause::MissingDependencies(missing_dependencies)
                 }
             );
 

--- a/opendut-edgar/src/service/test_execution/container_manager.rs
+++ b/opendut-edgar/src/service/test_execution/container_manager.rs
@@ -60,7 +60,7 @@ impl ContainerManager {
     pub async fn start(&mut self) {
         match self.run().await {
             Ok(_) => (),
-            Err(cause) => error!("{}", cause.to_string()),
+            Err(source) => error!("{}", source.to_string()),
         }
     }
 
@@ -116,7 +116,7 @@ impl ContainerManager {
             .args(["inspect", "-f", "'{{.State.Status}}'", container_name])
             .output()
             .await
-            .map_err(|cause| Error::CommandLineProgramExecution { command: format!("{} inspect", self.config.engine.command_name()), cause })?;
+            .map_err(|source| Error::CommandLineProgramExecution { command: format!("{} inspect", self.config.engine.command_name()), source })?;
         
         match String::from_utf8_lossy(&output.stdout).into_owned().replace('\'', "").trim() {
             "created" => Ok(ContainerState::Created),
@@ -173,7 +173,7 @@ impl ContainerManager {
         }
         let output = cmd.output()
             .await
-            .map_err(|cause| Error::CommandLineProgramExecution { command: format!("{} run", self.config.engine.command_name()), cause })?;
+            .map_err(|source| Error::CommandLineProgramExecution { command: format!("{} run", self.config.engine.command_name()), source })?;
 
         if output.status.success() {
             info!("Started container {}", self.config.name);
@@ -189,7 +189,7 @@ impl ContainerManager {
             .args(["container", "inspect", name])
             .output()
             .await
-            .map_err(|cause| Error::CommandLineProgramExecution { command: format!("{} inspect", self.config.engine.command_name()), cause })?;
+            .map_err(|source| Error::CommandLineProgramExecution { command: format!("{} inspect", self.config.engine.command_name()), source })?;
 
         Ok(output.status.success())
     }
@@ -199,7 +199,7 @@ impl ContainerManager {
             .args(["stop", container_name])
             .output()
             .await
-            .map_err(|cause| Error::CommandLineProgramExecution { command: format!("{} stop", self.config.engine.command_name()), cause })?;
+            .map_err(|source| Error::CommandLineProgramExecution { command: format!("{} stop", self.config.engine.command_name()), source })?;
 
         match output.status.success() {
             true => Ok(()),
@@ -233,19 +233,19 @@ impl ContainerManager {
         let mut zipped_data = Vec::new();
         // https://github.com/zip-rs/zip2/issues/195 large_file(true) produces invalid zip file with crate version 2.1.3
         let zip_options = SimpleFileOptions::default().compression_method(CompressionMethod::BZIP2).large_file(false);
-        create_zip_from_directory(&mut zipped_data, &self.results_dir, zip_options).await.map_err(|cause| Error::ResultZipping { path: self.results_dir.clone(), cause })?;
+        create_zip_from_directory(&mut zipped_data, &self.results_dir, zip_options).await.map_err(|source| Error::ResultZipping { path: self.results_dir.clone(), source })?;
 
         self.webdav_client.create_collection_path(results_url.clone())
             .await
-            .map_err(|cause| Error::ResultUploadingInternal { url: results_url.clone(), cause })?;
+            .map_err(|source| Error::ResultUploadingInternal { url: results_url.clone(), source })?;
 
         let results_file_url = results_url.join(
             format!("{}_{}.zip", chrono::offset::Local::now().format("%Y-%m-%d_%H-%M-%S"), self.config.name).as_str()
-        ).map_err(|cause| Error::Other { message: format!("Failed to construct URL for results directory: {cause}") })?;
+        ).map_err(|source| Error::Other { message: format!("Failed to construct URL for results directory: {source}") })?;
 
         let response = self.webdav_client.put(zipped_data, results_file_url.clone())
             .await
-            .map_err(|cause| Error::ResultUploadingInternal { url: results_file_url.clone(), cause })?;
+            .map_err(|source| Error::ResultUploadingInternal { url: results_file_url.clone(), source })?;
 
         match response.status().is_success() {
             true => {
@@ -260,14 +260,14 @@ impl ContainerManager {
     async fn create_results_dir(&mut self) -> Result<(), Error>{
         fs::create_dir_all(&self.results_dir)
             .await
-            .map_err(|cause| Error::Other { message: format!("Failed to create results directory '{}': {}", self.results_dir.to_string_lossy(), cause) })?;
+            .map_err(|source| Error::Other { message: format!("Failed to create results directory '{}': {}", self.results_dir.to_string_lossy(), source) })?;
         Ok(())
     }
 
     async fn cleanup_results_dir(&self) -> Result<(), Error> {
         fs::remove_dir_all(&self.results_dir)
             .await
-            .map_err(|cause| Error::Other { message: format!("Failed to remove results directory '{}': {}", self.results_dir.to_string_lossy(), cause) })?;
+            .map_err(|source| Error::Other { message: format!("Failed to remove results directory '{}': {}", self.results_dir.to_string_lossy(), source) })?;
         Ok(())
     }
 
@@ -309,12 +309,12 @@ async fn create_zip_from_directory<T>(data: &mut Vec<u8>, directory: &PathBuf, f
 
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
-    #[error("Failure while invoking command line program '{command}': {cause}")]
-    CommandLineProgramExecution { command: String, cause: std::io::Error },
-    #[error("Failure while creating a ZIP archive of the test results at '{path}' : {cause}")]
-    ResultZipping { path: PathBuf, cause: anyhow::Error },
-    #[error("Failure while uploading test results to '{url}': {cause}")]
-    ResultUploadingInternal { url: Url, cause: webdav_client::Error },
+    #[error("Failure while invoking command line program '{command}': {source}")]
+    CommandLineProgramExecution { command: String, source: std::io::Error },
+    #[error("Failure while creating a ZIP archive of the test results at '{path}' : {source}")]
+    ResultZipping { path: PathBuf, source: anyhow::Error },
+    #[error("Failure while uploading test results to '{url}': {source}")]
+    ResultUploadingInternal { url: Url, source: webdav_client::Error },
     #[error("Failure while uploading test results for '{container_name}' to '{url}' (HTTP status {status})")]
     ResultUploadingServer { container_name: ContainerName, url: Url, status: reqwest::StatusCode },
     #[error("{message}")]
@@ -336,7 +336,7 @@ impl ContainerLogReader {
         cmd.kill_on_drop(true);
 
         let mut child = cmd.spawn()
-            .map_err(|cause| Error::CommandLineProgramExecution { command: format!("{engine} logs"), cause })?;
+            .map_err(|source| Error::CommandLineProgramExecution { command: format!("{engine} logs"), source })?;
 
         let stdout = child.stdout.take().ok_or(Error::Other { message: format!("Failed to get stdout of '{engine} logs' process")})?;
 

--- a/opendut-edgar/src/service/test_execution/executor_manager.rs
+++ b/opendut-edgar/src/service/test_execution/executor_manager.rs
@@ -76,8 +76,8 @@ impl ExecutorManager {
     pub fn terminate_executors(&mut self) {
         debug!("Terminating executors.");
         for tx_termination_channel in &self.tx_termination_channels {
-            if let Err(cause) = tx_termination_channel.send(true) {
-                warn!("Failed to send termination signal to executor, perhaps it already terminated? Cause: {cause}");
+            if let Err(source) = tx_termination_channel.send(true) {
+                warn!("Failed to send termination signal to executor, perhaps it already terminated? Cause: {source}");
             }
         }
         self.tx_termination_channels.clear();

--- a/opendut-edgar/src/service/test_execution/webdav_client.rs
+++ b/opendut-edgar/src/service/test_execution/webdav_client.rs
@@ -39,14 +39,14 @@ impl WebdavClient {
             .body(body)
             .send()
             .await
-            .map_err(|cause| Error::Request { method: String::from("PUT"), cause } )
+            .map_err(|source| Error::Request { method: String::from("PUT"), source } )
     }
 
     pub async fn mkcol(&self, path: Url) -> Result<Response, Error> {
         self.start_request(Method::from_bytes(b"MKCOL").unwrap(), path)
             .send()
             .await
-            .map_err(|cause| Error::Request { method: String::from("MKCOL"), cause } )
+            .map_err(|source| Error::Request { method: String::from("MKCOL"), source } )
     }
 
     pub async fn create_collection_path(&self, path: Url) -> Result<(), Error>{
@@ -61,7 +61,7 @@ impl WebdavClient {
             
             // The '/' in the beginning of the accumulated path causes the existing path in the URL to be dropped
             let partial_url = path.join(&accumulated_path)
-                .map_err(|cause| Error::Other { message: format!("Failed to join partial path '{accumulated_path}' to base URL: {cause}") } )?;
+                .map_err(|source| Error::Other { message: format!("Failed to join partial path '{accumulated_path}' to base URL: {source}") } )?;
 
             let response = self.mkcol(partial_url.clone())
                 .await?;
@@ -79,8 +79,8 @@ impl WebdavClient {
 
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
-    #[error("Failure while sending WebDAV '{method}' request: {cause}")]
-    Request { method: String, cause: reqwest::Error },
+    #[error("Failure while sending WebDAV '{method}' request: {source}")]
+    Request { method: String, source: reqwest::Error },
     #[error("{message}")]
     Other { message: String },
 }

--- a/opendut-edgar/src/setup/tasks/claim_file_ownership.rs
+++ b/opendut-edgar/src/setup/tasks/claim_file_ownership.rs
@@ -27,7 +27,7 @@ impl Task for ClaimFileOwnership {
             for path_result in walkdir::WalkDir::new(dir) {
                 match path_result {
                     Ok(path) => chown(&self.service_user, path.path())?,
-                    Err(cause) => bail!("Error while setting ownership for a sub-path in directory '{dir}': {cause}"),
+                    Err(source) => bail!("Error while setting ownership for a sub-path in directory '{dir}': {source}"),
                 }
             }
         }

--- a/opendut-edgar/src/setup/write_configuration.rs
+++ b/opendut-edgar/src/setup/write_configuration.rs
@@ -106,7 +106,7 @@ fn load_current_settings_from_file_and_env(path: &Path) -> Option<toml_edit::Doc
         Config::builder()
     )
     .build()
-    .inspect_err(|cause| error!("Failed to read existing configuration file at {path:?}. Continuing as if no configuration existed.\n  {cause}"))
+    .inspect_err(|source| error!("Failed to read existing configuration file at {path:?}. Continuing as if no configuration existed.\n  {source}"))
     .ok()?;
 
     let current_settings = config.try_deserialize::<toml::Table>()
@@ -114,8 +114,8 @@ fn load_current_settings_from_file_and_env(path: &Path) -> Option<toml_edit::Doc
 
     match toml_edit::DocumentMut::from_str(&current_settings.to_string()) {
         Ok(current_settings) => Some(current_settings),
-        Err(cause) => {
-            error!("Failed to parse existing configuration as TOML.\n  {cause}");
+        Err(source) => {
+            error!("Failed to parse existing configuration as TOML.\n  {source}");
             None
         }
     }
@@ -130,8 +130,8 @@ fn needs_writing_to_config_file(new_settings: &str, config_file: &Path) -> anyho
 
     let current_settings = match fs::read_to_string(config_file) { //read anew from config file, because we do not want ENVs to be included here
         Ok(content) => content,
-        Err(cause) => {
-            error!("Failed to read existing configuration file at {config_file:?}. Will assume, it needs to be written.\n  {cause}");
+        Err(source) => {
+            error!("Failed to read existing configuration file at {config_file:?}. Will assume, it needs to be written.\n  {source}");
             return Ok(true);
         }
     };

--- a/opendut-lea/src/api/mod.rs
+++ b/opendut-lea/src/api/mod.rs
@@ -52,15 +52,15 @@ mod licenses {
             let licenses_index = http::Request::get("/api/licenses")
                 .send()
                 .await
-                .map_err(|cause| ApiError::HttpError {
+                .map_err(|source| ApiError::HttpError {
                     message: format!(
-                        "Failed to request the licenses index file due to: {cause}"
+                        "Failed to request the licenses index file due to: {source}"
                     ),
                 })?
                 .json::<LicensesIndexJson>()
                 .await
-                .map_err(|cause| ApiError::JsonParseError {
-                    message: format!("Failed to parse the licenses index file due to: {cause}"),
+                .map_err(|source| ApiError::JsonParseError {
+                    message: format!("Failed to parse the licenses index file due to: {source}"),
                 })?;
 
             [
@@ -76,13 +76,13 @@ mod licenses {
             let licenses = http::Request::get(&path)
                 .send()
                 .await
-                .map_err(|cause| ApiError::HttpError {
-                    message: format!("Failed to request the licenses file due to: {cause}"),
+                .map_err(|source| ApiError::HttpError {
+                    message: format!("Failed to request the licenses file due to: {source}"),
                 })?
                 .json::<BTreeMap<String, LicenseJsonEntry>>()
                 .await
-                .map_err(|cause| ApiError::HttpError {
-                    message: format!("Failed to parse the licenses file due to: {cause}"),
+                .map_err(|source| ApiError::HttpError {
+                    message: format!("Failed to parse the licenses file due to: {source}"),
                 })?;
 
             let dependencies = licenses

--- a/opendut-lea/src/app.rs
+++ b/opendut-lea/src/app.rs
@@ -58,9 +58,9 @@ pub fn LoadingApp() -> impl IntoView {
             let config = {
                 let LeaConfig { carl_url, idp_config, footer_available } = http::Request::get("/api/lea/config")
                     .send().await
-                    .map_err(|cause| AppGlobalsError { message: format!("Could not fetch configuration:\n  {cause}")})?
+                    .map_err(|source| AppGlobalsError { message: format!("Could not fetch configuration:\n  {source}")})?
                     .json::<LeaConfig>().await
-                    .map_err(|cause| AppGlobalsError { message: format!("Could not parse configuration:\n  {cause}")})?;
+                    .map_err(|source| AppGlobalsError { message: format!("Could not parse configuration:\n  {source}")})?;
 
 
                 let footer = if footer_available {
@@ -70,11 +70,11 @@ pub fn LoadingApp() -> impl IntoView {
                     match footer {
                         Ok(footer) => {
                             footer.text().await
-                                .inspect_err(|cause| warn!("Failed to parse footer as text: {cause}"))
+                                .inspect_err(|source| warn!("Failed to parse footer as text: {source}"))
                                 .ok()
                         }
-                        Err(cause) => {
-                            warn!("Failed to fetch footer: {cause}");
+                        Err(source) => {
+                            warn!("Failed to fetch footer: {source}");
                             None
                         }
                     }

--- a/opendut-lea/src/clusters/components/deploy_toggle.rs
+++ b/opendut-lea/src/clusters/components/deploy_toggle.rs
@@ -45,9 +45,9 @@ where
                                 .success()
                         );
                     }
-                    Err(cause) => {
-                        error!("Failed to store cluster deployment <{}>, due to error: {:?}", cluster_id, cause);
-                        match cause {
+                    Err(source) => {
+                        error!("Failed to store cluster deployment <{}>, due to error: {:?}", cluster_id, source);
+                        match source {
                             ClientError::UsageError(StoreClusterDeploymentError::IllegalPeerState { invalid_peers, .. }) => {
                                 toaster.toast(
                                     Toast::builder()

--- a/opendut-lea/src/clusters/configurator/components/cluster_name_input.rs
+++ b/opendut-lea/src/clusters/configurator/components/cluster_name_input.rs
@@ -22,8 +22,8 @@ pub fn ClusterNameInput(cluster_descriptor: RwSignal<UserClusterDescriptor>) -> 
             Ok(_) => {
                 UserInputValue::Right(input)
             }
-            Err(cause) => {
-                match cause {
+            Err(source) => {
+                match source {
                     IllegalClusterName::TooShort { expected, actual, value } => {
                         if actual > 0 {
                             UserInputValue::Both(format!("A cluster name must be at least {expected} characters long."), value)

--- a/opendut-lea/src/clusters/configurator/components/controls.rs
+++ b/opendut-lea/src/clusters/configurator/components/controls.rs
@@ -123,8 +123,8 @@ fn SaveClusterButton(
                             );
                             set_is_new.set(false);
                         }
-                        Err(cause) => {
-                            error!("Failed to store cluster <{}>, due to error: {:?}", "id", cause);
+                        Err(source) => {
+                            error!("Failed to store cluster <{}>, due to error: {:?}", "id", source);
                             toaster.toast(Toast::builder()
                                 .simple("Failed to store cluster descriptor!")
                                 .error()

--- a/opendut-lea/src/components/util.rs
+++ b/opendut-lea/src/components/util.rs
@@ -11,7 +11,7 @@ pub fn use_active_tab<
     Signal::derive(move || params.with(|params| {
         let tab = params.get("tab")
             .ok_or(String::from("No tab identifier given in URL!"))
-            .and_then(|value| T::try_from(value.as_str()).map_err(|cause| cause.to_string()));
+            .and_then(|value| T::try_from(value.as_str()).map_err(|source| source.to_string()));
         match tab {
             Err(details) => {
                 let use_navigate = use_navigate();

--- a/opendut-lea/src/peers/components/delete_peer_button.rs
+++ b/opendut-lea/src/peers/components/delete_peer_button.rs
@@ -51,8 +51,8 @@ where F: Fn() + Clone + Send + 'static {
                             .success()
                     );
                 }
-                Err(cause) => {
-                    error!("Failed to delete peer <{:?}>, due to error: {cause:?}", peer_id);
+                Err(source) => {
+                    error!("Failed to delete peer <{:?}>, due to error: {source:?}", peer_id);
                     toaster.toast(
                         Toast::builder()
                             .simple("Failed to delete peer!")

--- a/opendut-lea/src/peers/configurator/components/controls.rs
+++ b/opendut-lea/src/peers/configurator/components/controls.rs
@@ -114,8 +114,8 @@ fn SavePeerButton(
                             );
                             setter.set(false);
                         }
-                        Err(cause) => {
-                            error!("Failed to create peer <{peer_id}>, due to error: {cause:?}");
+                        Err(source) => {
+                            error!("Failed to create peer <{peer_id}>, due to error: {source:?}");
                             toaster.toast(Toast::builder().simple("Failed to store peer!").error());
                         }
                     }

--- a/opendut-lea/src/peers/configurator/components/peer_location_input.rs
+++ b/opendut-lea/src/peers/configurator/components/peer_location_input.rs
@@ -18,8 +18,8 @@ pub fn PeerLocationInput(peer_configuration: RwSignal<UserPeerConfiguration>) ->
             Ok(_) => {
                 UserInputValue::Right(input)
             }
-            Err(cause) => {
-                match cause {
+            Err(source) => {
+                match source {
                     IllegalLocation::TooLong { expected, value, .. } => {
                         UserInputValue::Both(format!("A peer location must be at most {expected} characters long."), value)
                     },

--- a/opendut-lea/src/peers/configurator/components/peer_name_input.rs
+++ b/opendut-lea/src/peers/configurator/components/peer_name_input.rs
@@ -22,8 +22,8 @@ pub fn PeerNameInput(peer_configuration: RwSignal<UserPeerConfiguration>) -> imp
             Ok(_) => {
                 UserInputValue::Right(input)
             }
-            Err(cause) => {
-                match cause {
+            Err(source) => {
+                match source {
                     IllegalPeerName::TooShort { expected, actual, value } => {
                         if actual > 0 {
                             UserInputValue::Both(format!("A peer name must be at least {expected} characters long."), value)

--- a/opendut-lea/src/peers/configurator/tabs/devices/name_input.rs
+++ b/opendut-lea/src/peers/configurator/tabs/devices/name_input.rs
@@ -23,8 +23,8 @@ pub fn DeviceNameInput(
             Ok(_) => {
                 UserInputValue::Right(input)
             }
-            Err(cause) => {
-                match cause {
+            Err(source) => {
+                match source {
                     IllegalDeviceName::TooShort { expected, actual, value } => {
                         if actual > 0 {
                             UserInputValue::Both(format!("A device name must be at least {expected} characters long."), value)

--- a/opendut-lea/src/peers/configurator/tabs/devices/tag_input.rs
+++ b/opendut-lea/src/peers/configurator/tabs/devices/tag_input.rs
@@ -33,8 +33,8 @@ pub fn DeviceTagInput(
             Ok(_) => {
                 UserInputValue::Right(input)
             }
-            Err(cause) => {
-                match cause {
+            Err(source) => {
+                match source {
                     IllegalDeviceTag::TooLong { expected, value, .. } => {
                         UserInputValue::Both(format!("A tag must be at most {expected} characters long."), value)
                     }

--- a/opendut-lea/src/peers/configurator/tabs/executor/executor_panel.rs
+++ b/opendut-lea/src/peers/configurator/tabs/executor/executor_panel.rs
@@ -202,8 +202,8 @@ fn ExecutorContainerNameInput(
             Ok(_) => {
                 UserInputValue::Right(input)
             }
-            Err(cause) => {
-                UserInputValue::Both(cause.to_string(), input)
+            Err(source) => {
+                UserInputValue::Both(source.to_string(), input)
             }
         }
     };
@@ -242,8 +242,8 @@ fn ExecutorContainerImageInput(
             Ok(_) => {
                 UserInputValue::Right(input)
             }
-            Err(cause) => {
-                match cause {
+            Err(source) => {
+                match source {
                     IllegalContainerImage::TooShort { value, .. } => {
                         UserInputValue::Both(String::from(EMPTY_CONTAINER_IMAGE_ERROR_MESSAGE), value)
                     }
@@ -286,8 +286,8 @@ fn ExecutorContainerVolumesInput(
             Ok(_) => {
                 UserInputValue::Right(input)
             }
-            Err(cause) => {
-                UserInputValue::Both(cause.to_string(), input)
+            Err(source) => {
+                UserInputValue::Both(source.to_string(), input)
             }
         }
     };
@@ -341,8 +341,8 @@ fn ExecutorContainerDevicesInput(
             Ok(_) => {
                 UserInputValue::Right(input)
             }
-            Err(cause) => {
-                UserInputValue::Both(cause.to_string(), input)
+            Err(source) => {
+                UserInputValue::Both(source.to_string(), input)
             }
         }
     };
@@ -396,8 +396,8 @@ fn ExecutorContainerPortsInput(
             Ok(_) => {
                 UserInputValue::Right(input)
             }
-            Err(cause) => {
-                UserInputValue::Both(cause.to_string(), input)
+            Err(source) => {
+                UserInputValue::Both(source.to_string(), input)
             }
         }
     };
@@ -451,8 +451,8 @@ fn ExecutorContainerCommandInput(
             Ok(_) => {
                 UserInputValue::Right(input)
             }
-            Err(cause) => {
-                UserInputValue::Both(cause.to_string(), input)
+            Err(source) => {
+                UserInputValue::Both(source.to_string(), input)
             }
         }
     };
@@ -491,8 +491,8 @@ fn ExecutorContainerArgsInput(
             Ok(_) => {
                 UserInputValue::Right(input)
             }
-            Err(cause) => {
-                UserInputValue::Both(cause.to_string(), input)
+            Err(source) => {
+                UserInputValue::Both(source.to_string(), input)
             }
         }
     };
@@ -735,8 +735,8 @@ fn ExecutorContainerResultsUrlInput(
             Ok(_) => {
                 UserInputValue::Right(input)
             }
-            Err(cause) => {
-                UserInputValue::Both(cause.to_string(), input)
+            Err(source) => {
+                UserInputValue::Both(source.to_string(), input)
             }
         }
     };

--- a/opendut-lea/src/peers/configurator/tabs/network/bridge_name_input.rs
+++ b/opendut-lea/src/peers/configurator/tabs/network/bridge_name_input.rs
@@ -18,8 +18,8 @@ pub fn BridgeNameInput(peer_configuration: RwSignal<UserPeerConfiguration>) -> i
             Ok(_) => {
                 UserInputValue::Right(input)
             }
-            Err(cause) => {
-                match cause {
+            Err(source) => {
+                match source {
                     NetworkInterfaceNameError::Empty => {
                         UserInputValue::Right(String::new())
                     }

--- a/opendut-lea/src/peers/configurator/tabs/network/network_interface_input.rs
+++ b/opendut-lea/src/peers/configurator/tabs/network/network_interface_input.rs
@@ -44,8 +44,8 @@ where A: Fn(NetworkInterfaceName, UserNetworkInterfaceConfiguration) + 'static {
                     UserInputValue::Right(input)
                 }
             }
-            Err(cause) => {
-                match cause {
+            Err(source) => {
+                match source {
                     NetworkInterfaceNameError::TooLong { value, max } => {
                         UserInputValue::Both(format!("A network interface name must be at most {max} characters long."), value)
                     },
@@ -272,7 +272,7 @@ fn bitrate_validator(input: String) -> UserInputValue {
         Ok(_bitrate) => {
             UserInputValue::Right(input)
         }
-        Err(_cause) => {
+        Err(_source) => {
             UserInputValue::Both("Could not parse String into u32.".to_string(), input)
         }
     }
@@ -287,7 +287,7 @@ fn sample_points_validator(input: String) -> UserInputValue {
                     Ok(_can_sample_point) => {
                         UserInputValue::Right(input)
                     }
-                    Err(_cause) => {
+                    Err(_source) => {
                         UserInputValue::Both("Not a valid sample point.".to_string(), input)
                     }
                 }
@@ -295,7 +295,7 @@ fn sample_points_validator(input: String) -> UserInputValue {
                 UserInputValue::Both("Range must be between 0.000 and 0.999.".to_string(), input)
             }
         }
-        Err(_cause) => {
+        Err(_source) => {
             UserInputValue::Both("Range must be between 0.000 and 0.999.".to_string(), input)
         }
     }

--- a/opendut-lea/src/viper_sources/components/delete_viper_source_button.rs
+++ b/opendut-lea/src/viper_sources/components/delete_viper_source_button.rs
@@ -46,11 +46,11 @@ where F: Fn() + Clone + Send + 'static {
                             .success()
                     );
                 }
-                Err(cause) => {
-                    error!("Failed to delete viper source <{}>, due to error: {cause}", viper_source_id.get_untracked());
+                Err(source) => {
+                    error!("Failed to delete viper source <{}>, due to error: {source}", viper_source_id.get_untracked());
                     toaster.toast(
                         Toast::builder()
-                            .simple(cause.to_string())
+                            .simple(source.to_string())
                             .error()
                     );
                 }

--- a/opendut-lea/src/viper_sources/configurator/components/controls.rs
+++ b/opendut-lea/src/viper_sources/configurator/components/controls.rs
@@ -90,8 +90,8 @@ fn SaveViperSourceButton(
                             );
                             setter.set(false);
                         }
-                        Err(cause) => {
-                            error!("Failed to create viper source <{viper_source_id}>, due to error: {cause:?}");
+                        Err(source) => {
+                            error!("Failed to create viper source <{viper_source_id}>, due to error: {source:?}");
                             toaster.toast(Toast::builder().simple("Failed to store viper source!").error());
                         }
                     }

--- a/opendut-lea/src/viper_sources/configurator/tabs/general/name_input.rs
+++ b/opendut-lea/src/viper_sources/configurator/tabs/general/name_input.rs
@@ -20,16 +20,16 @@ pub fn ViperSourceNameInput(viper_source_configuration: RwSignal<UserViperSource
             Ok(_) => {
                 UserInputValue::Right(input)
             }
-            Err(cause) => {
-                match cause.kind {
+            Err(source) => {
+                match source.kind {
                     InvalidViperTestSuiteIdentifierErrorKind::Empty => {
-                        UserInputValue::Both("Enter a VIPER source name.".to_string(), cause.value)
+                        UserInputValue::Both("Enter a VIPER source name.".to_string(), source.value)
                     }
                     InvalidViperTestSuiteIdentifierErrorKind::IllegalTestSuiteIdentifierCharacter { character } => {
-                        UserInputValue::Both(format!("The VIPER source name contains an invalid character: '{character}'"), cause.value)
+                        UserInputValue::Both(format!("The VIPER source name contains an invalid character: '{character}'"), source.value)
                     }
                     _ => {
-                        UserInputValue::Both("The VIPER source name is invalid.".to_string(), cause.value)
+                        UserInputValue::Both("The VIPER source name is invalid.".to_string(), source.value)
                     }
                 }
             }

--- a/opendut-lea/src/viper_tests/components/delete_viper_test_button.rs
+++ b/opendut-lea/src/viper_tests/components/delete_viper_test_button.rs
@@ -46,8 +46,8 @@ where F: Fn() + Clone + Send + 'static {
                             .success()
                     );
                 }
-                Err(cause) => {
-                    error!("Failed to delete VIPER test <{:?}>, due to error: {cause:?}", viper_test_id);
+                Err(source) => {
+                    error!("Failed to delete VIPER test <{:?}>, due to error: {source:?}", viper_test_id);
                     toaster.toast(
                         Toast::builder()
                             .simple("Failed to delete VIPER test!")

--- a/opendut-lea/src/viper_tests/components/deploy_viper_test_button.rs
+++ b/opendut-lea/src/viper_tests/components/deploy_viper_test_button.rs
@@ -32,8 +32,8 @@ pub fn DeployViperTestButton(
                             .success()
                     );
                 }
-                Err(cause) => {
-                    error!("Failed to deploy VIPER test run for test <{:?}>, due to error: {cause:?}", test_id);
+                Err(source) => {
+                    error!("Failed to deploy VIPER test run for test <{:?}>, due to error: {source:?}", test_id);
                     toaster.toast(
                         Toast::builder()
                             .simple("Failed to deploy VIPER test run!")

--- a/opendut-lea/src/viper_tests/components/duplicate_viper_test_button.rs
+++ b/opendut-lea/src/viper_tests/components/duplicate_viper_test_button.rs
@@ -55,8 +55,8 @@ pub fn DuplicateViperTestButton(
                             .success(),
                     );
                 }
-                Err(cause) => {
-                    error!("Failed to create viper test <{viper_test_id}>, due to error: {cause:?}");
+                Err(source) => {
+                    error!("Failed to create viper test <{viper_test_id}>, due to error: {source:?}");
                     toaster.toast(Toast::builder().simple("Failed to store viper test!").error());
                 }
             }

--- a/opendut-lea/src/viper_tests/configurator/components/controls.rs
+++ b/opendut-lea/src/viper_tests/configurator/components/controls.rs
@@ -90,8 +90,8 @@ fn SaveViperTestButton(
                             );
                             setter.set(false);
                         }
-                        Err(cause) => {
-                            error!("Failed to create viper test <{viper_test_id}>, due to error: {cause:?}");
+                        Err(source) => {
+                            error!("Failed to create viper test <{viper_test_id}>, due to error: {source:?}");
                             toaster.toast(Toast::builder().simple("Failed to store viper test!").error());
                         }
                     }

--- a/opendut-lea/src/viper_tests/configurator/tabs/general/name_input.rs
+++ b/opendut-lea/src/viper_tests/configurator/tabs/general/name_input.rs
@@ -22,8 +22,8 @@ pub fn ViperTestNameInput(viper_test_run_descriptor: RwSignal<UserViperTestRunDe
             Ok(_) => {
                 UserInputValue::Right(input)
             }
-            Err(cause) => {
-                match cause {
+            Err(source) => {
+                match source {
                     IllegalViperTestName::TooShort { expected, actual, value } => {
                         if actual > 0 {
                             UserInputValue::Both(format!("A VIPER test name must be at least {expected} characters long."), value)

--- a/opendut-lea/src/viper_tests/configurator/tabs/parameters/mod.rs
+++ b/opendut-lea/src/viper_tests/configurator/tabs/parameters/mod.rs
@@ -136,14 +136,14 @@ pub fn ParametersTab(
                                 </p>
                             }.into_any()
                         },
-                        GetViperTestSuiteParametersError::Internal { source_id, cause } => {
+                        GetViperTestSuiteParametersError::Internal { source_id, source } => {
                             let source_href = create_source_href(&source_id);
                             view! {
                                 <p class="help has-text-danger">
                                     "An internal error occurred while fetching the VIPER test suite descriptor for the "
                                     <a href=source_href> selected source </a>:
                                     <br />
-                                    {cause}
+                                    {source}
                                 </p>
                             }.into_any()
                         },

--- a/opendut-model/src/cleo/mod.rs
+++ b/opendut-model/src/cleo/mod.rs
@@ -19,15 +19,15 @@ pub struct CleoSetup {
 
 impl CleoSetup {
     pub fn encode(&self) -> Result<String, CleoSetupEncodeError> {
-        let json = serde_json::to_string(self).map_err(|cause| CleoSetupEncodeError {
-            details: format!("Serialization failed due to: {cause}"),
+        let json = serde_json::to_string(self).map_err(|source| CleoSetupEncodeError {
+            details: format!("Serialization failed due to: {source}"),
         })?;
 
         let compressed = {
             let mut buffer = Vec::new();
             crate::util::brotli::compress(&mut buffer, json.as_bytes())
-                .map_err(|cause| CleoSetupEncodeError {
-                    details: format!("Compression failed due to: {cause}"),
+                .map_err(|source| CleoSetupEncodeError {
+                    details: format!("Compression failed due to: {source}"),
                 })?;
             buffer
         };
@@ -40,21 +40,21 @@ impl CleoSetup {
     pub fn decode(encoded: &str) -> Result<Self, CleoSetupDecodeError> {
         let compressed = BASE64_URL_SAFE
             .decode(encoded.as_bytes())
-            .map_err(|cause| CleoSetupDecodeError {
-                details: format!("Base64 decoding failed due to: {cause}"),
+            .map_err(|source| CleoSetupDecodeError {
+                details: format!("Base64 decoding failed due to: {source}"),
             })?;
 
         let json = {
             let mut buffer = Vec::new();
             crate::util::brotli::decompress(&mut buffer, compressed.as_slice())
-                .map_err(|cause| CleoSetupDecodeError {
-                    details: format!("Decompression failed due to: {cause}"),
+                .map_err(|source| CleoSetupDecodeError {
+                    details: format!("Decompression failed due to: {source}"),
                 })?;
             buffer
         };
 
-        let decoded = serde_json::from_slice(&json).map_err(|cause| CleoSetupDecodeError {
-            details: format!("Deserialization failed due to: {cause}"),
+        let decoded = serde_json::from_slice(&json).map_err(|source| CleoSetupDecodeError {
+            details: format!("Deserialization failed due to: {source}"),
         })?;
 
         Ok(decoded)

--- a/opendut-model/src/peer/configuration/api/mod.rs
+++ b/opendut-model/src/peer/configuration/api/mod.rs
@@ -106,7 +106,7 @@ impl ParameterEdgeDetectedStateKind {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ParameterDetectedStateError {
     pub kind: ParameterDetectedStateErrorKind,
-    pub cause: ParameterDetectedStateErrorCause,
+    pub source: ParameterDetectedStateErrorCause,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/opendut-model/src/peer/executor/mod.rs
+++ b/opendut-model/src/peer/executor/mod.rs
@@ -63,8 +63,8 @@ impl ResultsUrl {
 
 #[derive(thiserror::Error, Clone, Debug)]
 pub enum IllegalResultsUrl{
-    #[error("Failed to parse results URL: {cause}")]
-    ParseFailure {cause: url::ParseError},
+    #[error("Failed to parse results URL: {source}")]
+    ParseFailure {source: url::ParseError},
 }
 
 impl TryFrom<&str> for ResultsUrl {
@@ -73,7 +73,7 @@ impl TryFrom<&str> for ResultsUrl {
     fn try_from(value: &str) -> Result<Self, Self::Error> {
         match Url::parse(value) {
             Ok(url) => Ok(Self(url)),
-            Err(cause) => Err(IllegalResultsUrl::ParseFailure { cause}),
+            Err(source) => Err(IllegalResultsUrl::ParseFailure { source}),
         }
     }
 }

--- a/opendut-model/src/peer/mod.rs
+++ b/opendut-model/src/peer/mod.rs
@@ -238,15 +238,15 @@ pub struct PeerSetup {
 
 impl PeerSetup {
     pub fn encode(&self) -> Result<String, PeerSetupEncodeError> {
-        let json = serde_json::to_string(self).map_err(|cause| PeerSetupEncodeError {
-            details: format!("Serialization failed due to: {cause}"),
+        let json = serde_json::to_string(self).map_err(|source| PeerSetupEncodeError {
+            details: format!("Serialization failed due to: {source}"),
         })?;
 
         let compressed = {
             let mut buffer = Vec::new();
             crate::util::brotli::compress(&mut buffer, json.as_bytes())
-                .map_err(|cause| PeerSetupEncodeError {
-                    details: format!("Compression failed due to: {cause}"),
+                .map_err(|source| PeerSetupEncodeError {
+                    details: format!("Compression failed due to: {source}"),
                 })?;
             buffer
         };
@@ -259,21 +259,21 @@ impl PeerSetup {
     pub fn decode(encoded: &str) -> Result<Self, PeerSetupDecodeError> {
         let compressed = BASE64_URL_SAFE
             .decode(encoded.as_bytes())
-            .map_err(|cause| PeerSetupDecodeError {
-                details: format!("Base64 decoding failed due to: {cause}"),
+            .map_err(|source| PeerSetupDecodeError {
+                details: format!("Base64 decoding failed due to: {source}"),
             })?;
 
         let json = {
             let mut buffer = Vec::new();
             crate::util::brotli::decompress(&mut buffer, compressed.as_slice())
-                .map_err(|cause| PeerSetupDecodeError {
-                    details: format!("Decompression failed due to: {cause}"),
+                .map_err(|source| PeerSetupDecodeError {
+                    details: format!("Decompression failed due to: {source}"),
                 })?;
             buffer
         };
 
-        let decoded = serde_json::from_slice(&json).map_err(|cause| PeerSetupDecodeError {
-            details: format!("Deserialization failed due to: {cause}"),
+        let decoded = serde_json::from_slice(&json).map_err(|source| PeerSetupDecodeError {
+            details: format!("Deserialization failed due to: {source}"),
         })?;
 
         Ok(decoded)

--- a/opendut-model/src/proto/peer/configuration/api.rs
+++ b/opendut-model/src/proto/peer/configuration/api.rs
@@ -323,7 +323,7 @@ conversion! {
                 peer_configuration_parameter_state_kind_error::Kind::WaitingForDependencies(PeerConfigurationParameterStateKindErrorWaitingForDependencies {})
             }
         };
-        let error_cause = match value.cause {
+        let error_source = match value.source {
             crate::peer::configuration::api::ParameterDetectedStateErrorCause::Unclassified(message) => {
                 peer_configuration_parameter_state_kind_error::Cause::Unclassified(UnclassifiedError { message })
             }
@@ -333,7 +333,7 @@ conversion! {
                 )
             }
         };
-        PeerConfigurationParameterStateKindError { kind: Some(error_kind), cause: Some(error_cause)}
+        PeerConfigurationParameterStateKindError { kind: Some(error_kind), cause: Some(error_source)}
     }
 
     fn try_from(value: Proto) -> ConversionResult<Model> {
@@ -344,7 +344,7 @@ conversion! {
             peer_configuration_parameter_state_kind_error::Kind::CheckAbsentFailed(_) => crate::peer::configuration::api::ParameterDetectedStateErrorKind::CheckAbsentFailed,
             peer_configuration_parameter_state_kind_error::Kind::WaitingForDependencies(_) => crate::peer::configuration::api::ParameterDetectedStateErrorKind::CheckAbsentFailed,
         };
-        let error_cause = match extract!(value.cause)? {
+        let error_source = match extract!(value.cause)? {
             peer_configuration_parameter_state_kind_error::Cause::Unclassified(details) => {
                 crate::peer::configuration::api::ParameterDetectedStateErrorCause::Unclassified(details.message)
             }
@@ -357,7 +357,7 @@ conversion! {
         };
         Ok(crate::peer::configuration::api::ParameterDetectedStateError {
             kind: error_kind,
-            cause: error_cause,
+            source: error_source,
         })
     }
 }

--- a/opendut-model/src/specs/parse/json.rs
+++ b/opendut-model/src/specs/parse/json.rs
@@ -43,7 +43,7 @@ impl JsonSpecificationDocument {
     /// ```
     pub fn try_from_json_str(input: &str) -> Result<Self, ParseSpecificationError> {
         serde_json::from_str::<Self>(input)
-            .map_err(|cause| ParseSpecificationError::IllegalJsonSpecification { cause })
+            .map_err(|source| ParseSpecificationError::IllegalJsonSpecification { source })
     }
 }
 
@@ -76,7 +76,7 @@ fn parse_spec(kind: ResourceKind, version: SpecificationVersion, spec: Value) ->
     match (kind, version) {
         (ResourceKind::ClusterDescriptor, SpecificationVersion::V1) => {
             let spec = serde_json::from_value::<specs::cluster::ClusterDescriptorSpecificationV1>(spec)
-                .map_err(|cause| ParseSpecificationError::IllegalJsonSpecification { cause } )?;
+                .map_err(|source| ParseSpecificationError::IllegalJsonSpecification { source } )?;
             Ok(Specification::ClusterDescriptorSpecification(specs::cluster::ClusterDescriptorSpecification::V1(spec)))
         }
         (ResourceKind::ClusterDescriptor, _) => {
@@ -84,7 +84,7 @@ fn parse_spec(kind: ResourceKind, version: SpecificationVersion, spec: Value) ->
         }
         (ResourceKind::PeerDescriptor, SpecificationVersion::V1) => {
             let spec = serde_json::from_value::<specs::peer::PeerDescriptorSpecificationV1>(spec)
-                .map_err(|cause| ParseSpecificationError::IllegalJsonSpecification { cause } )?;
+                .map_err(|source| ParseSpecificationError::IllegalJsonSpecification { source } )?;
             Ok(Specification::PeerDescriptorSpecification(specs::peer::PeerDescriptorSpecification::V1(spec)))
         }
         (ResourceKind::PeerDescriptor, _) => {

--- a/opendut-model/src/specs/parse/mod.rs
+++ b/opendut-model/src/specs/parse/mod.rs
@@ -16,11 +16,11 @@ pub enum ParseSpecificationError {
     #[error("Failed to parse specification. Unknown version '{version}' for resource specification '{kind}'")]
     UnknownVersion { kind: ResourceKind, version: SpecificationVersion },
     #[cfg(feature = "yaml-specs")]
-    #[error("Failed to parse yaml specification, due to: {cause}")]
-    IllegalYamlSpecification { cause: serde_yaml::Error },
+    #[error("Failed to parse yaml specification, due to: {source}")]
+    IllegalYamlSpecification { source: serde_yaml::Error },
     #[cfg(feature = "json-specs")]
-    #[error("Failed to parse json specification, due to: {cause}")]
-    IllegalJsonSpecification { cause: serde_json::Error },
+    #[error("Failed to parse json specification, due to: {source}")]
+    IllegalJsonSpecification { source: serde_json::Error },
 }
 
 #[derive(Clone, Copy, Debug, Deserialize, Display)]

--- a/opendut-model/src/specs/parse/yaml/document.rs
+++ b/opendut-model/src/specs/parse/yaml/document.rs
@@ -45,7 +45,7 @@ impl YamlSpecificationDocument {
     /// ```
     pub fn try_from_yaml_str(s: &str) -> Result<Self, ParseSpecificationError> {
         serde_yaml::from_str::<YamlSpecificationDocument>(s)
-            .map_err(|cause| ParseSpecificationError::IllegalYamlSpecification { cause })
+            .map_err(|source| ParseSpecificationError::IllegalYamlSpecification { source })
     }
 }
 
@@ -86,7 +86,7 @@ fn parse_spec(kind: ResourceKind, version: SpecificationVersion, spec: Value) ->
     match (kind, version) {
         (ResourceKind::ClusterDescriptor, SpecificationVersion::V1) => {
             let spec = serde_yaml::from_value::<cluster::ClusterDescriptorSpecificationV1>(spec)
-                .map_err(|cause| ParseSpecificationError::IllegalYamlSpecification { cause } )?;
+                .map_err(|source| ParseSpecificationError::IllegalYamlSpecification { source } )?;
             Ok(Specification::ClusterDescriptorSpecification(cluster::ClusterDescriptorSpecification::V1(spec)))
         }
         (ResourceKind::ClusterDescriptor, _) => {
@@ -94,7 +94,7 @@ fn parse_spec(kind: ResourceKind, version: SpecificationVersion, spec: Value) ->
         }
         (ResourceKind::PeerDescriptor, SpecificationVersion::V1) => {
             let spec = serde_yaml::from_value::<peer::PeerDescriptorSpecificationV1>(spec)
-                .map_err(|cause| ParseSpecificationError::IllegalYamlSpecification { cause } )?;
+                .map_err(|source| ParseSpecificationError::IllegalYamlSpecification { source } )?;
             Ok(Specification::PeerDescriptorSpecification(peer::PeerDescriptorSpecification::V1(spec)))
         }
         (ResourceKind::PeerDescriptor, _) => {

--- a/opendut-model/src/specs/parse/yaml/file.rs
+++ b/opendut-model/src/specs/parse/yaml/file.rs
@@ -53,7 +53,7 @@ impl YamlSpecificationFile {
                     .and_then(serde_yaml::from_value::<YamlSpecificationDocument>)
             })
             .collect::<Result<Vec<_>, _>>()
-            .map_err(|cause| ParseSpecificationError::IllegalYamlSpecification { cause })?;
+            .map_err(|source| ParseSpecificationError::IllegalYamlSpecification { source })?;
         Ok(Self { documents })
     }
 }

--- a/opendut-telemetry/src/lib.rs
+++ b/opendut-telemetry/src/lib.rs
@@ -45,12 +45,12 @@ pub enum Error {
     EndpointConfigurationMissing,
     #[error("Failed to get token from AuthenticationManager")]
     FailedToGetTokenFromAuthenticationManager { #[from] source: AuthError },
-    #[error("Failed to create LoggingConfig: {cause}")]
-    LoggingConfigError { #[from] cause: LoggingConfigError },
-    #[error("Failed to create OpenTelemetryConfig: {cause}")]
-    OpenTelemetryConfigError { #[from] cause: OpentelemetryConfigError },
-    #[error("Failed to create ConfidentialClient: {cause}")]
-    ConfidentialClientError { #[from] cause: ConfidentialClientError },
+    #[error("Failed to create LoggingConfig: {source}")]
+    LoggingConfigError { #[from] source: LoggingConfigError },
+    #[error("Failed to create OpenTelemetryConfig: {source}")]
+    OpenTelemetryConfigError { #[from] source: OpentelemetryConfigError },
+    #[error("Failed to create ConfidentialClient: {source}")]
+    ConfidentialClientError { #[from] source: ConfidentialClientError },
 }
 
 #[tracing::instrument(name="opentelemetry_initialize", skip_all)]
@@ -103,7 +103,7 @@ pub async fn initialize_with_config(
                     .append(true)
                     .create(true)
                     .open(&log_file)
-                    .unwrap_or_else(|cause| panic!("Failed to open log file at '{}': {cause}", log_file.display()));
+                    .unwrap_or_else(|source| panic!("Failed to open log file at '{}': {source}", log_file.display()));
 
                 tracing_subscriber::fmt::layer()
                     .with_writer(log_file)

--- a/opendut-telemetry/src/logging.rs
+++ b/opendut-telemetry/src/logging.rs
@@ -34,7 +34,7 @@ impl LoggingConfig {
         let pipe_logging_enabled = {
             let field = String::from("logging.pipe.enabled");
             config.get_bool(&field)
-                .map_err(|_cause| LoggingConfigError::ValueParseError {
+                .map_err(|_source| LoggingConfigError::ValueParseError {
                     field,
                 })?
         };
@@ -44,7 +44,7 @@ impl LoggingConfig {
                 let stream = {
                     let field = String::from("logging.pipe.stream");
                     config.get::<PipeLoggingStream>(&field)
-                        .map_err(|_cause| LoggingConfigError::ValueParseError {
+                        .map_err(|_source| LoggingConfigError::ValueParseError {
                             field,
                         })?
                 };

--- a/opendut-telemetry/src/opentelemetry_types.rs
+++ b/opendut-telemetry/src/opentelemetry_types.rs
@@ -58,9 +58,9 @@ impl Opentelemetry {
     pub async fn load(config: &config::Config, service_metadata: ServiceMetadata) -> Result<Self, OpentelemetryConfigError> {
         let field = String::from("opentelemetry.enabled");
         let opentelemetry_enabled = config.get_bool("opentelemetry.enabled")
-            .map_err(|cause| OpentelemetryConfigError::ValueParseError {
+            .map_err(|source| OpentelemetryConfigError::ValueParseError {
                 field: field.clone(),
-                cause: format!("{cause:?}")
+                message: format!("{source:?}")
             })?;
 
         startup_message!("Loading configuration. OpenTelemetry enabled: {opentelemetry_enabled}.");
@@ -68,14 +68,14 @@ impl Opentelemetry {
             let collector_endpoint = {
                 let field = String::from("opentelemetry.collector.endpoint");
                 let url = config.get_string(&field)
-                    .map_err(|cause| OpentelemetryConfigError::ValueParseError {
+                    .map_err(|source| OpentelemetryConfigError::ValueParseError {
                         field: field.clone(),
-                        cause: format!("{cause:?}")
+                        message: format!("{source:?}")
                     })?;
                 let url = Url::parse_without_quotes(&url)
-                    .map_err(|cause| OpentelemetryConfigError::InvalidValueError {
+                    .map_err(|source| OpentelemetryConfigError::InvalidValueError {
                         field,
-                        message: format!("Failed to parse url from given string: '{url}'. Error: {cause:?}")
+                        message: format!("Failed to parse url from given string: '{url}'. Error: {source:?}")
                     })?;
                 Endpoint { url }
             };
@@ -83,9 +83,9 @@ impl Opentelemetry {
             let service_name = {
                 let field = String::from("opentelemetry.service.name");
                 config.get_string(&field)
-                    .map_err(|cause| OpentelemetryConfigError::ValueParseError {
+                    .map_err(|source| OpentelemetryConfigError::ValueParseError {
                         field: field.clone(),
-                        cause: format!("{cause:?}")
+                        message: format!("{source:?}")
                     })?
             };
 
@@ -93,15 +93,15 @@ impl Opentelemetry {
                 let field = String::from("opentelemetry.metrics.interval.ms");
 
                 let interval_i64 = config.get_int(&field)
-                    .map_err(|cause| OpentelemetryConfigError::ValueParseError {
+                    .map_err(|source| OpentelemetryConfigError::ValueParseError {
                         field: field.clone(),
-                        cause: format!("{cause:?}")
+                        message: format!("{source:?}")
                     })?;
 
                 let interval_u64 = u64::try_from(interval_i64)
-                    .map_err(|cause| OpentelemetryConfigError::ValueParseError {
+                    .map_err(|source| OpentelemetryConfigError::ValueParseError {
                         field: field.clone(),
-                        cause: format!("{cause:?}")
+                        message: format!("{source:?}")
                     })?;
 
                 Duration::from_millis(interval_u64)
@@ -111,15 +111,15 @@ impl Opentelemetry {
                 let field = String::from("opentelemetry.metrics.cpu.collection.interval.ms");
 
                 let interval_i64 = config.get_int(&field)
-                    .map_err(|cause| OpentelemetryConfigError::ValueParseError {
+                    .map_err(|source| OpentelemetryConfigError::ValueParseError {
                         field: field.clone(),
-                        cause: format!("{cause:?}")
+                        message: format!("{source:?}")
                     })?;
 
                 let interval_u64 = u64::try_from(interval_i64)
-                    .map_err(|cause| OpentelemetryConfigError::ValueParseError {
+                    .map_err(|source| OpentelemetryConfigError::ValueParseError {
                         field: field.clone(),
-                        cause: format!("{cause:?}")
+                        message: format!("{source:?}")
                     })?;
                 let interval = Duration::from_millis(interval_u64);
 
@@ -136,9 +136,9 @@ impl Opentelemetry {
             };
 
             let confidential_client = ConfidentialClient::from_settings(config).await
-                .map_err(|cause| OpentelemetryConfigError::ConfidentialClientError {
+                .map_err(|source| OpentelemetryConfigError::ConfidentialClientError {
                     message: String::from("Could not create AuthenticationManager"),
-                    cause
+                    source
                 })?;
 
 
@@ -149,9 +149,9 @@ impl Opentelemetry {
 
                 let load_pem = |config_key, fallback_config_key| {
                     Pem::read_from_configured_path_or_content(config_key, Some(fallback_config_key), config)
-                        .map_err(|cause| OpentelemetryConfigError::ValueParseError {
+                        .map_err(|source| OpentelemetryConfigError::ValueParseError {
                             field: [config_key, fallback_config_key].join(" | "), //somewhat hacky way to display both config fields
-                            cause: format!("{cause:?}")
+                            message: format!("{source:?}")
                         })
                 };
 
@@ -165,9 +165,9 @@ impl Opentelemetry {
                 }
 
                 let client_auth = ClientAuth::load_from_config(pem::config_keys::OPENTELEMETRY_TLS_CLIENT_AUTH, Some(pem::config_keys::DEFAULT_NETWORK_TLS_CLIENT_AUTH), config)
-                    .map_err(|cause| OpentelemetryConfigError::ValueParseError {
+                    .map_err(|source| OpentelemetryConfigError::ValueParseError {
                         field: [pem::config_keys::OPENTELEMETRY_TLS_CLIENT_AUTH.prefix, pem::config_keys::DEFAULT_NETWORK_TLS_CLIENT_AUTH.prefix].join(" | "),
-                        cause: format!("Failed to read mTLS client auth configuration: {cause}"),
+                        message: format!("Failed to read mTLS client auth configuration: {source}"),
                     })?;
 
                 match client_auth {
@@ -219,25 +219,25 @@ impl UrlWithoutQuotes for Url {
 
 #[derive(Debug, thiserror::Error)]
 pub enum OpentelemetryConfigError {
-    #[error("Failed to parse configuration from field: '{field}'. Cause: {cause}")]
+    #[error("Failed to parse configuration from field: '{field}'. Cause: {message}")]
     ValueParseError {
         field: String,
-        cause: String
+        message: String
     },
     #[error("'{message}': '{field}'")]
     InvalidValueError {
         field: String,
         message: String,
     },
-    #[error("'{message}': '{cause}'")]
+    #[error("'{message}': '{source}'")]
     ConfidentialClientError {
         message: String,
-        cause: ConfidentialClientError,
+        source: ConfidentialClientError,
     },
-    #[error("{message}, cause: '{cause}")]
+    #[error("{message}, caused by: '{details}")]
     ClientAuthentication {
         message: String,
-        cause: String,
+        details: String,
     }
 }
 

--- a/opendut-util/src/error.rs
+++ b/opendut-util/src/error.rs
@@ -1,9 +1,9 @@
 pub fn render_error_message<T: std::error::Error>(fail: &T, msg: &'static str) -> String {
     let mut err_msg = format!("{}\nError sources: ", msg);
     let mut cur_fail: Option<&dyn std::error::Error> = Some(fail);
-    while let Some(cause) = cur_fail {
-        err_msg += &format!("\n    Caused by: {}", cause);
-        cur_fail = cause.source();
+    while let Some(source) = cur_fail {
+        err_msg += &format!("\n    Caused by: {}", source);
+        cur_fail = source.source();
     }
     err_msg
 }

--- a/opendut-util/src/pem/mod.rs
+++ b/opendut-util/src/pem/mod.rs
@@ -93,9 +93,9 @@ fn read_pem_from_config_key(config_key: &str, config: &Config) -> anyhow::Result
     fn try_load_pem_from_file_path(config_value: &str, config_key: &str) -> anyhow::Result<Vec<Pem>> {
         let path = project::make_path_absolute(config_value)?;
         read_pem_from_file_path(&path)
-            .inspect_err(|cause| {
-                let mut error_message = cause.to_string();
-                for error in cause.chain() {
+            .inspect_err(|source| {
+                let mut error_message = source.to_string();
+                for error in source.chain() {
                     error_message.push_str("\n    Caused by: ");
                     error_message.push_str(&error.to_string())
                 }
@@ -112,9 +112,9 @@ fn read_pem_from_config_key(config_key: &str, config: &Config) -> anyhow::Result
                     debug!("Using PEM loaded from text value of configuration key: {config_key}, number of PEM object(s): {}", pems.len());
                     Ok(pems)
                 }
-                Err(cause) => {
+                Err(source) => {
                     if config_value.starts_with("-----BEGIN") { //very likely that user wanted to specify PEM, so return error directly
-                        Err(cause)
+                        Err(source)
                             .context("Failed to load text value as PEM, which was configured in configuration key.")
                     }
                     else if let Ok(pem) = try_load_pem_from_file_path(&config_value, config_key) {

--- a/opendut-viper/viper-cli/src/main.rs
+++ b/opendut-viper/viper-cli/src/main.rs
@@ -183,7 +183,7 @@ async fn build_and_run(params_from_file: Option<String>, test_identifier_filter:
                 Err(err) => {
                     return Err(IncompleteBindingsError {
                         suite: suite.name().to_string(),
-                        cause: err
+                        source: err
                     }.into());
                 }
             };

--- a/opendut-viper/viper-cli/src/param_config/error.rs
+++ b/opendut-viper/viper-cli/src/param_config/error.rs
@@ -4,27 +4,27 @@ use opendut_viper_rt::run::{BindParameterError, IncompleteParameterBindingsError
 #[derive(Debug)]
 pub struct ParameterTomlError {
     pub suite: String,
-    pub cause: BindParameterError,
+    pub source: BindParameterError,
 }
 
 impl std::error::Error for ParameterTomlError {}
 
 impl Display for ParameterTomlError {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(f, "Failed to load parameters for suite '{}': {}", self.suite, self.cause)
+        write!(f, "Failed to load parameters for suite '{}': {}", self.suite, self.source)
     }
 }
 
 #[derive(Debug)]
 pub struct IncompleteBindingsError {
     pub suite: String,
-    pub cause: IncompleteParameterBindingsError
+    pub source: IncompleteParameterBindingsError
 }
 
 impl std::error::Error for IncompleteBindingsError {}
 
 impl Display for IncompleteBindingsError {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{} ({})",self.cause, self.suite)
+        write!(f, "{} ({})",self.source, self.suite)
     }
 }

--- a/opendut-viper/viper-cli/src/param_config/mod.rs
+++ b/opendut-viper/viper-cli/src/param_config/mod.rs
@@ -69,7 +69,7 @@ impl ParameterToml {
 
         }).map_err(|err| ParameterTomlError {
             suite: suite_name.to_owned(),
-            cause: err,
+            source: err,
         })
     }
 

--- a/opendut-viper/viper-rt/src/proto/test_suite.rs
+++ b/opendut-viper/viper-rt/src/proto/test_suite.rs
@@ -17,7 +17,7 @@ conversion! {
 
     fn try_from(value: Proto) -> ConversionResult<Model> {
         let result = Model::try_from(value.value)
-            .map_err(|cause| ErrorBuilder::message(format!("Error while parsing TestSuiteIdentifier from Protobuf message: {cause}")))?;
+            .map_err(|source| ErrorBuilder::message(format!("Error while parsing TestSuiteIdentifier from Protobuf message: {source}")))?;
 
         Ok(result)
     }
@@ -64,7 +64,7 @@ conversion! {
             Kind::Boolean(ViperParameterDescriptorBoolean { name, info, default }) =>
                 Model::BooleanParameter {
                     name: name.try_into()
-                        .map_err(|cause| ErrorBuilder::message(format!("Error while converting ParameterName from Protobuf: {cause}")))?,
+                        .map_err(|source| ErrorBuilder::message(format!("Error while converting ParameterName from Protobuf: {source}")))?,
                     info: extract!(info)?
                         .try_into()?,
                     default,
@@ -72,7 +72,7 @@ conversion! {
             Kind::Number(ViperParameterDescriptorNumber { name, info, default, min, max }) =>
                 Model::NumberParameter {
                     name: name.try_into()
-                        .map_err(|cause| ErrorBuilder::message(format!("Error while converting ParameterName from ProtoBuf: {cause}")))?,
+                        .map_err(|source| ErrorBuilder::message(format!("Error while converting ParameterName from ProtoBuf: {source}")))?,
                     info: extract!(info)?
                         .try_into()?,
                     default,
@@ -82,7 +82,7 @@ conversion! {
             Kind::Text(ViperParameterDescriptorText { name, info, default, max_length }) =>
                 Model::TextParameter {
                     name: name.try_into()
-                        .map_err(|cause| ErrorBuilder::message(format!("Error while converting ParameterName from ProtoBuf: {cause}")))?,
+                        .map_err(|source| ErrorBuilder::message(format!("Error while converting ParameterName from ProtoBuf: {source}")))?,
                     info: extract!(info)?
                         .try_into()?,
                     default,

--- a/opendut-viper/viper-rt/src/runtime/emitter.rs
+++ b/opendut-viper/viper-rt/src/runtime/emitter.rs
@@ -32,7 +32,7 @@ where
 #[derive(Debug)]
 #[non_exhaustive]
 pub struct EventEmissionError {
-    pub cause: String,
+    pub source: String,
 }
 
 struct SinkEventEmitter<S, E>
@@ -64,7 +64,7 @@ where
 {
     async fn emit(&mut self, event: I) -> Result<(), EventEmissionError> {
         self.sink.send(event).await
-            .map_err(|e| EventEmissionError { cause: format!("{e:?}") } )
+            .map_err(|e| EventEmissionError { source: format!("{e:?}") } )
     }
 }
 
@@ -110,6 +110,6 @@ where
     E: Send + Sync,
 {
     async fn emit(&mut self, _event: E) -> Result<(), EventEmissionError> {
-        Err(EventEmissionError { cause: String::from("failed") })
+        Err(EventEmissionError { source: String::from("failed") })
     }
 }

--- a/opendut-viper/viper-rt/src/runtime/error.rs
+++ b/opendut-viper/viper-rt/src/runtime/error.rs
@@ -42,18 +42,18 @@ impl Display for CompilationError {
             CompilationErrorKind::FailedEventEmission { message } => {
                 write!(f, "Compilation failed, due to an event emission error: {message}")
             }
-            CompilationErrorKind::FailedLoading { source_location, cause } => {
+            CompilationErrorKind::FailedLoading { source_location, source } => {
                 match source_location {
                     SourceLocation::Embedded(_) => {
                         panic!("This should never happen because embedded sources must not be loaded.")
                     }
                     SourceLocation::Url(url) => {
-                        write!(f, "Compilation failed because source '{source_name}' could not be loaded from '{url}': '{cause}'")
+                        write!(f, "Compilation failed because source '{source_name}' could not be loaded from '{url}': '{source}'")
                     }
                 }
             }
-            CompilationErrorKind::InvalidSource { cause } => {
-                write!(f, "Compilation failed, due to an invalid source '{source_name}': {cause}")
+            CompilationErrorKind::InvalidSource { source } => {
+                write!(f, "Compilation failed, due to an invalid source '{source_name}': {source}")
             }
             CompilationErrorKind::NoSuitableSourceLoader { source_location } => {
                 match source_location {
@@ -65,17 +65,17 @@ impl Display for CompilationError {
                     }
                 }
             }
-            CompilationErrorKind::FailedInspection { cause } => {
-                write!(f, "Compilation failed during inspection of source '{source_name}': {cause}")
+            CompilationErrorKind::FailedInspection { source } => {
+                write!(f, "Compilation failed during inspection of source '{source_name}': {source}")
             }
             CompilationErrorKind::PythonCompilationError { details } => {
                 write!(f, "Compilation failed, due to a Python compilation error in source '{source_name}': {details}")
             }
-            CompilationErrorKind::PythonReflectionError { cause } => {
-                write!(f, "Compilation failed, due to a Python reflection error in source '{source_name}': {cause}")
+            CompilationErrorKind::PythonReflectionError { source } => {
+                write!(f, "Compilation failed, due to a Python reflection error in source '{source_name}': {source}")
             }
-            CompilationErrorKind::PythonRuntimeError { cause } => {
-                write!(f, "Compilation failed, due to a Python runtime error in source '{source_name}': {cause}")
+            CompilationErrorKind::PythonRuntimeError { source } => {
+                write!(f, "Compilation failed, due to a Python runtime error in source '{source_name}': {source}")
             }
         }
     }
@@ -130,9 +130,9 @@ impl Display for InvalidNumberParameterValueError {
 impl Display for InspectionError {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
-            InspectionError::Metadata(cause) => write!(f, "{cause}"),
-            InspectionError::Parameter(cause) => write!(f, "{cause}"),
-            InspectionError::Filter(cause) => write!(f, "{cause}"),
+            InspectionError::Metadata(source) => write!(f, "{source}"),
+            InspectionError::Parameter(source) => write!(f, "{source}"),
+            InspectionError::Filter(source) => write!(f, "{source}"),
         }
     }
 }
@@ -214,14 +214,14 @@ impl Display for FilterError {
 impl Display for ParameterError {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
-            ParameterError::IllegalParameterName(cause) => {
-                write!(f, "{cause}")
+            ParameterError::IllegalParameterName(source) => {
+                write!(f, "{source}")
             }
-            ParameterError::IllegalTextParameterValue(cause) => {
-                write!(f, "{cause}")
+            ParameterError::IllegalTextParameterValue(source) => {
+                write!(f, "{source}")
             }
-            ParameterError::IllegalNumberParameterValue(cause) => {
-                write!(f, "{cause}")
+            ParameterError::IllegalNumberParameterValue(source) => {
+                write!(f, "{source}")
             }
         }
     }
@@ -250,8 +250,8 @@ impl Display for RunError {
             RunErrorKind::FailedEventEmission { message } => {
                 write!(f, "Run failed for '{identifier}', due to an event-emitting error: {message}")
             }
-            RunErrorKind::PythonReflectionError { cause } => {
-                write!(f, "Run failed for '{identifier}', due to a Python reflection error: {cause}")
+            RunErrorKind::PythonReflectionError { source } => {
+                write!(f, "Run failed for '{identifier}', due to a Python reflection error: {source}")
             }
         }
     }

--- a/opendut-viper/viper-rt/src/runtime/run/emit.rs
+++ b/opendut-viper/viper-rt/src/runtime/run/emit.rs
@@ -10,7 +10,7 @@ pub async fn initialized(
 ) -> RunResult<()> {
     let suite = Clone::clone(&state.identifier);
     emitter.emit(RunEvent::Initialized(state))
-        .map_err(|error| Box::new(RunError::new_failed_event_emission_error(suite, format!("Failed to emit `Initialized` event: {}", error.cause))))
+        .map_err(|error| Box::new(RunError::new_failed_event_emission_error(suite, format!("Failed to emit `Initialized` event: {}", error.source))))
         .await
 }
 

--- a/opendut-viper/viper-rt/src/runtime/run/instantiate.rs
+++ b/opendut-viper/viper-rt/src/runtime/run/instantiate.rs
@@ -30,7 +30,7 @@ pub fn instantiate(
 
         let name = key.downcast_ref::<PyStr>()
             .ok_or_else(|| PythonReflectionError::new_downcast_error(&key, "PyStr"))
-            .map_err(|cause| RunError::new_python_reflection_error(Clone::clone(suite), cause))?;
+            .map_err(|source| RunError::new_python_reflection_error(Clone::clone(suite), source))?;
 
         let Some(case) = test_cases.iter()
             .find(|case| case.identifier.name() == name.as_str())
@@ -42,13 +42,13 @@ pub fn instantiate(
 
         let ty = value.downcast_ref::<PyType>()
             .ok_or_else(|| PythonReflectionError::new_downcast_error(&value, "PyType"))
-            .map_err(|cause| RunError::new_python_reflection_error(Clone::clone(identifier), cause))?
+            .map_err(|source| RunError::new_python_reflection_error(Clone::clone(identifier), source))?
             .to_owned();
 
         let bindings = Rc::clone(&bindings);
 
         let instance = make_test_case_instance(&ty, context, bindings, vm)
-            .map_err(|cause| RunError::new_python_reflection_error(Clone::clone(identifier), cause))?;
+            .map_err(|source| RunError::new_python_reflection_error(Clone::clone(identifier), source))?;
 
         let tests = tests.iter()
             .map(|test| {

--- a/opendut-viper/viper-rt/src/runtime/run/mod.rs
+++ b/opendut-viper/viper-rt/src/runtime/run/mod.rs
@@ -152,7 +152,7 @@ async fn run_test(
                 let owner = instance.str(vm).expect("Invoke `__str__` on object");
                 PythonReflectionError::new_attribute_not_writable_error(owner.to_string(), "report")
             })
-            .map_err(|cause| RunError::new_python_reflection_error(Clone::clone(&identifier), cause))?;
+            .map_err(|source| RunError::new_python_reflection_error(Clone::clone(&identifier), source))?;
 
         if let Some(setup_fn) = setup_fn
         && let Err(err) = setup_fn.call((Clone::clone(&instance), ), vm) { // TODO: Decide, what should happen when a setup function fails.
@@ -161,13 +161,13 @@ async fn run_test(
 
         vm.sys_module.set_attr("stdout", stdout, vm)
             .map_err(|_| PythonReflectionError::new_attribute_not_writable_error("sys", "stdout"))
-            .map_err(|cause| RunError::new_python_reflection_error(Clone::clone(&identifier), cause))?;
+            .map_err(|source| RunError::new_python_reflection_error(Clone::clone(&identifier), source))?;
         vm.sys_module.set_attr("stderr", stderr, vm)
             .map_err(|_| PythonReflectionError::new_attribute_not_writable_error("sys", "stderr"))
-            .map_err(|cause| RunError::new_python_reflection_error(Clone::clone(&identifier), cause))?;
+            .map_err(|source| RunError::new_python_reflection_error(Clone::clone(&identifier), source))?;
         vm.builtins.set_attr("open", vm.new_function("open", open_fn), vm)
             .map_err(|_| PythonReflectionError::new_attribute_not_writable_error("builtins", "open"))
-            .map_err(|cause| RunError::new_python_reflection_error(Clone::clone(&identifier), cause))?;
+            .map_err(|source| RunError::new_python_reflection_error(Clone::clone(&identifier), source))?;
 
         let py_result = test_fn.call((Clone::clone(&instance), ), vm);
 

--- a/opendut-viper/viper-rt/src/runtime/types/compile/error.rs
+++ b/opendut-viper/viper-rt/src/runtime/types/compile/error.rs
@@ -40,22 +40,22 @@ pub enum CompilationErrorKind {
     },
     FailedLoading {
         source_location: SourceLocation,
-        cause: SourceLoaderError,
+        source: SourceLoaderError,
     },
     InvalidSource {
-        cause: InvalidSourceError,
+        source: InvalidSourceError,
     },
     FailedInspection {
-        cause: InspectionError,
+        source: InspectionError,
     },
     PythonCompilationError {
         details: String,
     },
     PythonReflectionError {
-        cause: PythonReflectionError,
+        source: PythonReflectionError,
     },
     PythonRuntimeError {
-        cause: PythonRuntimeError,
+        source: PythonRuntimeError,
     }
 }
 
@@ -80,37 +80,37 @@ impl CompilationError {
 
     pub(crate) fn new_source_loading_failure_error(
         source: &Source,
-        cause: SourceLoaderError,
+        error: SourceLoaderError,
     ) -> Self {
         Self::new(
             Clone::clone(&source.identifier),
             CompilationErrorKind::FailedLoading {
                 source_location: Clone::clone(&source.location),
-                cause
+                source: error
             }
         )
     }
 
     pub(crate) fn new_invalid_source_error(
         source: &Source,
-        cause: InvalidSourceError
+        error: InvalidSourceError
     ) -> Self {
         Self::new(
             Clone::clone(&source.identifier),
             CompilationErrorKind::InvalidSource {
-                cause
+                source: error
             }
         )
     }
 
     pub(crate) fn new_inspection_failure_error(
         source: &Source,
-        cause: InspectionError
+        error: InspectionError
     ) -> Self {
         Self::new(
             Clone::clone(&source.identifier),
             CompilationErrorKind::FailedInspection {
-                cause
+                source: error
             }
         )
     }
@@ -140,24 +140,24 @@ impl CompilationError {
 
     pub(crate) fn new_python_runtime_error(
         identifier: TestSuiteIdentifier,
-        cause: PythonRuntimeError
+        source: PythonRuntimeError
     ) -> Self {
         Self::new(
             identifier,
             CompilationErrorKind::PythonRuntimeError {
-                cause,
+                source,
             }
         )
     }
 
     pub(crate) fn new_python_reflection_error(
         identifier: TestSuiteIdentifier,
-        cause: PythonReflectionError
+        source: PythonReflectionError
     ) -> Self {
         Self::new(
             identifier,
             CompilationErrorKind::PythonReflectionError {
-                cause,
+                source,
             }
         )
     }

--- a/opendut-viper/viper-rt/src/runtime/types/compile/inspect.rs
+++ b/opendut-viper/viper-rt/src/runtime/types/compile/inspect.rs
@@ -13,18 +13,18 @@ pub enum InspectionError {
 impl InspectionError {
 
     pub(crate) fn new_invalid_metadata_error(
-        cause: MetadataError
+        source: MetadataError
     ) -> Self {
-        Self::Metadata(cause)
+        Self::Metadata(source)
     }
 
     pub(crate) fn new_invalid_parameter_error(
-        cause: ParameterError
+        source: ParameterError
     ) -> Self {
-        Self::Parameter(cause)
+        Self::Parameter(source)
     }
 
     pub(crate) fn new_invalid_filter_error(
-        cause: FilterError
-    ) -> Self { Self::Filter(cause) }
+        source: FilterError
+    ) -> Self { Self::Filter(source) }
 }

--- a/opendut-viper/viper-rt/src/runtime/types/run/error.rs
+++ b/opendut-viper/viper-rt/src/runtime/types/run/error.rs
@@ -32,7 +32,7 @@ pub enum RunErrorKind {
         message: String,
     },
     PythonReflectionError {
-        cause: PythonReflectionError,
+        source: PythonReflectionError,
     },
 }
 
@@ -63,12 +63,12 @@ impl RunError {
 
     pub(crate) fn new_python_reflection_error(
         identifier: impl Identifier + 'static,
-        cause: PythonReflectionError
+        source: PythonReflectionError
     ) -> Self {
         Self::new(
             identifier,
             RunErrorKind::PythonReflectionError {
-                cause,
+                source,
             }
         )
     }

--- a/opendut-vpn/opendut-vpn-netbird/src/client/auth.rs
+++ b/opendut-vpn/opendut-vpn-netbird/src/client/auth.rs
@@ -52,23 +52,23 @@ async fn get_netbird_user_id(client: ClientWithMiddleware, username: &str, netbi
         .get(url)
         .send()
         .await
-        .map_err(|cause| CreateClientError::InstantiationFailure { cause: format!("Failed to request NetBird users: {}", cause) })?;
+        .map_err(|source| CreateClientError::InstantiationFailure { message: format!("Failed to request NetBird users: {}", source) })?;
 
     if response.status() != StatusCode::OK {
-        return Err(CreateClientError::InstantiationFailure { cause: String::from("Unauthorized to access NetBird users. Check your token.") })
+        return Err(CreateClientError::InstantiationFailure { message: String::from("Unauthorized to access NetBird users. Check your token.") })
     }
     
     let users = response
         .json::<Vec<NetbirdUser>>()
         .await
-        .map_err(|cause| CreateClientError::InstantiationFailure { cause: format!("Failed to parse NetBird users response: {cause}")})?
+        .map_err(|source| CreateClientError::InstantiationFailure { message: format!("Failed to parse NetBird users response: {source}")})?
         .into_iter()
         .filter(|user| user.name.eq(username))
         .collect::<Vec<_>>();
 
     match users.first() {
         Some(user) => Ok(user.id.clone()),
-        None => Err(CreateClientError::InstantiationFailure { cause: String::from("No NetBird users found.") }),
+        None => Err(CreateClientError::InstantiationFailure { message: String::from("No NetBird users found.") }),
     }
 }
 
@@ -89,20 +89,20 @@ async fn create_netbird_api_token_for_user_id(client: ClientWithMiddleware, netb
     };
 
     let request = post_json_request(url, body)
-        .map_err(|cause| CreateClientError::InstantiationFailure { cause: format!("Failed to create NetBird create API token request: {}", cause) })?;
+        .map_err(|source| CreateClientError::InstantiationFailure { message: format!("Failed to create NetBird create API token request: {}", source) })?;
 
     let response = client
         .execute(request)
         .await
-        .map_err(|cause| CreateClientError::InstantiationFailure { cause: format!("Failed to request NetBird create API token: {}", cause) })?;
+        .map_err(|source| CreateClientError::InstantiationFailure { message: format!("Failed to request NetBird create API token: {}", source) })?;
 
     if response.status() != StatusCode::OK {
-        return Err(CreateClientError::InstantiationFailure { cause: format!("Failed to create NetBird API token. Status: {}", response.status()) })
+        return Err(CreateClientError::InstantiationFailure { message: format!("Failed to create NetBird API token. Status: {}", response.status()) })
     }
     let token_response = response
         .json::<CreateApiTokenResponse>()
         .await
-        .map_err(|cause| CreateClientError::InstantiationFailure { cause: format!("Failed to parse NetBird create API token response: {}", cause) })?;
+        .map_err(|source| CreateClientError::InstantiationFailure { message: format!("Failed to parse NetBird create API token response: {}", source) })?;
 
     Ok(token_response)
 }

--- a/opendut-vpn/opendut-vpn-netbird/src/client/integration_tests.rs
+++ b/opendut-vpn/opendut-vpn-netbird/src/client/integration_tests.rs
@@ -53,10 +53,10 @@ async fn test_netbird_vpn_client() -> anyhow::Result<()> {
     let Fixture { management_url, authentication_method, ca, timeout, retries, setup_key_expiration } = Fixture::default();
     let management_ca = {
         let mut file = File::open(ca)
-            .map_err(|cause| CreateClientError::InstantiationFailure { cause: format!("Failed to open ca certificate:\n  {cause}") })?;
+            .map_err(|source| CreateClientError::InstantiationFailure { message: format!("Failed to open ca certificate:\n  {source}") })?;
         let mut buffer = Vec::new();
         file.read_to_end(&mut buffer)
-            .map_err(|cause| CreateClientError::InstantiationFailure { cause: format!("Failed to read ca certificate:\n  {cause}") })?;
+            .map_err(|source| CreateClientError::InstantiationFailure { message: format!("Failed to read ca certificate:\n  {source}") })?;
         buffer
     };
 
@@ -101,10 +101,10 @@ async fn test_netbird_vpn_client_list_keys() -> anyhow::Result<()> {
     let Fixture { management_url, authentication_method, ca, timeout, retries, setup_key_expiration } = Fixture::default();
     let management_ca = {
         let mut file = File::open(ca.clone())
-            .map_err(|cause| CreateClientError::InstantiationFailure { cause: format!("Failed to open ca certificate:\n  {cause}") })?;
+            .map_err(|source| CreateClientError::InstantiationFailure { message: format!("Failed to open ca certificate:\n  {source}") })?;
         let mut buffer = Vec::new();
         file.read_to_end(&mut buffer)
-            .map_err(|cause| CreateClientError::InstantiationFailure { cause: format!("Failed to read ca certificate:\n  {cause}") })?;
+            .map_err(|source| CreateClientError::InstantiationFailure { message: format!("Failed to read ca certificate:\n  {source}") })?;
         buffer
     };
     let netbird_management_client = NetbirdManagementClient::create_client_and_delete_default_policy(

--- a/opendut-vpn/opendut-vpn-netbird/src/client/mod.rs
+++ b/opendut-vpn/opendut-vpn-netbird/src/client/mod.rs
@@ -68,7 +68,7 @@ impl DefaultClient {
 
             if let Some(ca) = ca {
                 let certificate = Certificate::from_pem(ca)
-                    .map_err(|cause| CreateClientError::InstantiationFailure { cause: format!("Failed to parse ca certificate:\n  {cause}") })?;
+                    .map_err(|source| CreateClientError::InstantiationFailure { message: format!("Failed to parse ca certificate:\n  {source}") })?;
                 client = client.add_root_certificate(certificate);
             }
 
@@ -82,7 +82,7 @@ impl DefaultClient {
                 let netbird_username = oidc_config.username.clone();
                 let config = OidcClientConfig::ResourceOwner(oidc_config);
                 let confidential_client = ConfidentialClient::from_client_config(config, client.clone())
-                    .map_err(|cause| CreateClientError::InstantiationFailure { cause: format!("Failed to create confidential client:\n  {cause}") })?;
+                    .map_err(|source| CreateClientError::InstantiationFailure { message: format!("Failed to create confidential client:\n  {source}") })?;
                 let auth_client = ConfidentialClient::build_client_with_middleware(confidential_client.clone());
                 create_api_token(auth_client.clone(), netbird_username.as_str(), &netbird_url).await?
             }
@@ -90,7 +90,7 @@ impl DefaultClient {
                 token
             }
             NetbirdAuthenticationMethod::Disabled => {
-                return Err(CreateClientError::InstantiationFailure { cause: String::from("No authentication method specified.") });
+                return Err(CreateClientError::InstantiationFailure { message: String::from("No authentication method specified.") });
             }
         };
 
@@ -148,10 +148,10 @@ impl Client for DefaultClient {
         let request = Request::new(Method::GET, url);
 
         let response = self.requester.handle(request).await
-            .map_err(|cause| GetGroupError::RequestFailure { group_name: group_name.to_owned(), cause })?;
+            .map_err(|source| GetGroupError::RequestFailure { group_name: group_name.to_owned(), source })?;
 
         let result = response.json::<Vec<netbird::Group>>().await
-            .map_err(|cause| GetGroupError::RequestFailure { group_name: group_name.to_owned(), cause: RequestError::JsonDeserialization(cause) })?;
+            .map_err(|source| GetGroupError::RequestFailure { group_name: group_name.to_owned(), source: RequestError::JsonDeserialization(source) })?;
 
         let groups = result.into_iter()
             .filter(|group| group.name == *group_name)
@@ -300,9 +300,9 @@ impl Client for DefaultClient {
         let url = routes::policies(self.netbird_url.clone());
         let request = Request::new(Method::GET, url);
         let response = self.requester.handle(request).await
-            .map_err(|cause| GetPoliciesError::RequestFailure { policy_name: policy_name.to_owned(), cause })?;
+            .map_err(|source| GetPoliciesError::RequestFailure { policy_name: policy_name.to_owned(), source })?;
         let result = response.json::<Vec<netbird::Policy>>().await
-            .map_err(|cause| GetPoliciesError::RequestFailure { policy_name: policy_name.to_owned(), cause: RequestError::JsonDeserialization(cause) })?;
+            .map_err(|source| GetPoliciesError::RequestFailure { policy_name: policy_name.to_owned(), source: RequestError::JsonDeserialization(source) })?;
 
         let policies = result.into_iter()
             .filter(|policy| policy.name == *policy_name)
@@ -330,7 +330,7 @@ impl Client for DefaultClient {
     async fn generate_netbird_setup_key(&self, peer_id: PeerId) -> Result<netbird::SetupKey, CreateSetupKeyError> {
         let peer_group_name = netbird::GroupName::from(peer_id);
         let peer_group = self.get_netbird_group(&peer_group_name).await
-            .map_err(|cause| CreateSetupKeyError::PeerGroupNotFound { peer_id, cause })?;
+            .map_err(|source| CreateSetupKeyError::PeerGroupNotFound { peer_id, source })?;
 
         let url = routes::setup_keys(self.netbird_url.clone());
 
@@ -356,14 +356,14 @@ impl Client for DefaultClient {
         };
 
         let request = post_json_request(url, body)
-            .map_err(|cause| CreateSetupKeyError::RequestFailure { peer_id, cause })?;
+            .map_err(|source| CreateSetupKeyError::RequestFailure { peer_id, source })?;
 
         let response = self.requester.handle(request).await
-            .map_err(|cause| CreateSetupKeyError::RequestFailure { peer_id, cause })?
-            .error_for_status().map_err(|cause| CreateSetupKeyError::RequestFailure { peer_id, cause: RequestError::IllegalStatus(cause) })?;
+            .map_err(|source| CreateSetupKeyError::RequestFailure { peer_id, source })?
+            .error_for_status().map_err(|source| CreateSetupKeyError::RequestFailure { peer_id, source: RequestError::IllegalStatus(source) })?;
 
         let result = response.json().await
-            .map_err(|cause| CreateSetupKeyError::RequestFailure { peer_id, cause: RequestError::JsonDeserialization(cause) })?;
+            .map_err(|source| CreateSetupKeyError::RequestFailure { peer_id, source: RequestError::JsonDeserialization(source) })?;
 
         Ok(result)
     }

--- a/opendut-vpn/opendut-vpn-netbird/src/lib.rs
+++ b/opendut-vpn/opendut-vpn-netbird/src/lib.rs
@@ -53,13 +53,13 @@ impl NetbirdManagementClient {
     async fn create(configuration: NetbirdManagementClientConfiguration) -> Result<Self, CreateClientError> {
         let management_url = configuration.management_url;
         let management_ca_path = configuration.ca
-            .ok_or_else(|| CreateClientError::InstantiationFailure { cause: String::from("No ca certificate provided.") })?;
+            .ok_or_else(|| CreateClientError::InstantiationFailure { message: String::from("No ca certificate provided.") })?;
         let management_ca = {
             let mut file = File::open(management_ca_path)
-                .map_err(|cause| CreateClientError::InstantiationFailure { cause: format!("Failed to open ca certificate:\n  {cause}") })?;
+                .map_err(|source| CreateClientError::InstantiationFailure { message: format!("Failed to open ca certificate:\n  {source}") })?;
             let mut buffer = Vec::new();
             file.read_to_end(&mut buffer)
-                .map_err(|cause| CreateClientError::InstantiationFailure { cause: format!("Failed to read ca certificate:\n  {cause}") })?;
+                .map_err(|source| CreateClientError::InstantiationFailure { message: format!("Failed to read ca certificate:\n  {source}") })?;
             buffer
         };
         let inner = Box::new(DefaultClient::create(
@@ -102,7 +102,7 @@ impl VpnManagementClient for NetbirdManagementClient {
 
         match self.delete_cluster(cluster_id).await {
             Ok(_) => debug!("Deleted a previous cluster with ID <{cluster_id}> before creating the new cluster."),
-            Err(cause) => match cause {
+            Err(source) => match source {
                 DeleteClusterError::NotFound { cluster_id, message } => trace!("Did not need to delete a previous cluster with ID <{cluster_id}> before creating the new cluster. ({message})"),
                 DeleteClusterError::DeletionFailure { cluster_id, error } => {
                     return Err(CreateClusterError::CreationFailure { cluster_id, error: anyhow!("Failure while deleting a previous cluster with ID <{cluster_id}> before creating the new cluster: {error}").into() });
@@ -138,7 +138,7 @@ impl VpnManagementClient for NetbirdManagementClient {
             Ok(policy) => {
                 match self.inner.delete_netbird_policy(&policy.id).await {
                     Ok(_) => debug!("Deleted NetBird policy with name '{}' and NetBird Policy ID '{}'.", policy.name, policy.id.0),
-                    Err(cause) => return match cause {
+                    Err(source) => return match source {
                         RequestError::IllegalStatus(error) => {
                             if let Some(http::StatusCode::NOT_FOUND) = error.status() {
                                 Err(DeleteClusterError::NotFound { cluster_id, message: format!("Received '404 Not Found' when deleting policy for cluster <{cluster_id}> with NetBird policy ID <{netbird_policy}>.", netbird_policy = policy.id.0) })
@@ -159,8 +159,8 @@ impl VpnManagementClient for NetbirdManagementClient {
             Err(GetPoliciesError::PolicyNotFound { .. }) => {
                 // No policy found, so no need to delete it.
             }
-            Err(cause) => {
-                return Err(DeleteClusterError::DeletionFailure { cluster_id, error: anyhow!("Failed to get cluster policy '{policy_name}' to be deleted.\n {cause}").into() });
+            Err(source) => {
+                return Err(DeleteClusterError::DeletionFailure { cluster_id, error: anyhow!("Failed to get cluster policy '{policy_name}' to be deleted.\n {source}").into() });
             }
         };
 
@@ -172,7 +172,7 @@ impl VpnManagementClient for NetbirdManagementClient {
                         debug!("Deleted NetBird group with name '{}' and NetBird Group ID '{}'.", group.name, group.id.0) ;
                         Ok(())
                     },
-                    Err(cause) => match cause {
+                    Err(source) => match source {
                         RequestError::IllegalStatus(error) => {
                             if let Some(http::StatusCode::NOT_FOUND) = error.status() {
                                 Err(DeleteClusterError::NotFound { cluster_id, message: format!("Received '404 Not Found' when deleting group for cluster <{cluster_id}> with NetBird group ID <{netbird_group}>.", netbird_group = group.id.0) })
@@ -188,8 +188,8 @@ impl VpnManagementClient for NetbirdManagementClient {
                 // No group found, so no need to delete it.
                 Ok(())
             }
-            Err(cause) => {
-                Err(DeleteClusterError::DeletionFailure { cluster_id, error: anyhow!("Failed to get cluster group '{group_name}' to be deleted.\n {cause}").into() })
+            Err(source) => {
+                Err(DeleteClusterError::DeletionFailure { cluster_id, error: anyhow!("Failed to get cluster group '{group_name}' to be deleted.\n {source}").into() })
             }
         }
     }
@@ -249,7 +249,7 @@ impl VpnManagementClient for NetbirdManagementClient {
         if let Some(group) = group {
             for netbird_peer in &group.peers {
                 self.inner.delete_netbird_peer(&netbird_peer.id).await //Delete NetBird peer to log it out. This means that during EDGAR Setup, it will be logged back in, which allows adjusting the MTU.
-                    .map_err(|cause| CreateVpnPeerConfigurationError::CreationFailure { peer_id, error: Box::new(cause) })?;
+                    .map_err(|source| CreateVpnPeerConfigurationError::CreationFailure { peer_id, error: Box::new(source) })?;
                 debug!("Deleted Peer <{peer_id}> from NetBird with NetBird-Peer-Id <{}>.", netbird_peer.id.0);
             }
         }
@@ -267,7 +267,7 @@ impl VpnManagementClient for NetbirdManagementClient {
 
         let setup_key = self.inner.generate_netbird_setup_key(peer_id).await
             .map_err(|error| match error {
-                CreateSetupKeyError::PeerGroupNotFound { cause: error, .. } => {
+                CreateSetupKeyError::PeerGroupNotFound { source: error, .. } => {
                     error!("Failed to generate vpn configuration for peer <{peer_id}>, because the peer's self group could not be found!");
                     CreateVpnPeerConfigurationError::CreationFailure { peer_id, error: error.into() }
                 }

--- a/opendut-vpn/opendut-vpn-netbird/src/netbird/error.rs
+++ b/opendut-vpn/opendut-vpn-netbird/src/netbird/error.rs
@@ -14,10 +14,10 @@ pub enum GetGroupError {
     GroupNotFound { group_name: GroupName },
     #[error("Multiple groups with name '{group_name}' exist!")]
     MultipleGroupsFound { group_name: GroupName },
-    #[error("Could not request group '{group_name}':\n  {cause}")]
+    #[error("Could not request group '{group_name}':\n  {source}")]
     RequestFailure {
         group_name: GroupName,
-        cause: RequestError
+        source: RequestError
     }
 }
 
@@ -27,21 +27,21 @@ pub enum GetPoliciesError {
     PolicyNotFound { policy_name: PolicyName },
     #[error("Multiple policies with name '{policy_name}' exist!")]
     MultiplePoliciesFound { policy_name: PolicyName },
-    #[error("Could not request policy '{policy_name}:\n  {cause}")]
+    #[error("Could not request policy '{policy_name}:\n  {source}")]
     RequestFailure {
         policy_name: PolicyName,
-        cause: RequestError
+        source: RequestError
     }
 }
 
 #[derive(thiserror::Error, Debug)]
 pub enum CreateSetupKeyError {
-    #[error("Auto-assign group for peer <{peer_id}> not found for setup-key creation:\n  {cause}!")]
-    PeerGroupNotFound { peer_id: PeerId, cause: GetGroupError },
-    #[error("Could not request setup-key creation for peer <{peer_id}>:\n  {cause}")]
+    #[error("Auto-assign group for peer <{peer_id}> not found for setup-key creation:\n  {source}!")]
+    PeerGroupNotFound { peer_id: PeerId, source: GetGroupError },
+    #[error("Could not request setup-key creation for peer <{peer_id}>:\n  {source}")]
     RequestFailure {
         peer_id: PeerId,
-        cause: RequestError
+        source: RequestError
     }
 }
 
@@ -63,9 +63,9 @@ pub enum RequestError {
 pub enum CreateClientError {
     #[error("Invalid header: {0}")]
     InvalidHeader(InvalidHeaderValue),
-    #[error("Failed to instantiated client, due to an error: {cause}")]
+    #[error("Failed to instantiated client, due to an error: {message}")]
     InstantiationFailure {
-        cause: String
+        message: String
     },
     #[error("Failed to delete default policy.")]
     DeleteDefaultPolicy(#[source] RequestError),

--- a/opendut-vpn/opendut-vpn-netbird/src/netbird/group/group_name.rs
+++ b/opendut-vpn/opendut-vpn-netbird/src/netbird/group/group_name.rs
@@ -7,10 +7,10 @@ use opendut_model::cluster::ClusterId;
 use opendut_model::peer::PeerId;
 
 #[derive(thiserror::Error, Debug)]
-#[error("Cannot create GroupName from '{value}':\n  {cause}")]
+#[error("Cannot create GroupName from '{value}':\n  {source}")]
 pub struct InvalidGroupNameError {
     value: String,
-    cause: Box<dyn Error>,
+    source: Box<dyn Error>,
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
@@ -46,12 +46,12 @@ impl TryFrom<&str> for GroupName {
         if let Some(uuid) = value.strip_prefix(GroupName::PEER_GROUP_PREFIX) {
             PeerId::try_from(uuid)
                 .map(Self::Peer)
-                .map_err(|cause| InvalidGroupNameError { value: value.to_owned(), cause: cause.into() })
+                .map_err(|source| InvalidGroupNameError { value: value.to_owned(), source: source.into() })
         }
         else if let Some(uuid) = value.strip_prefix(GroupName::CLUSTER_GROUP_PREFIX) {
             ClusterId::try_from(uuid)
                 .map(Self::Cluster)
-                .map_err(|cause| InvalidGroupNameError { value: value.to_owned(), cause: cause.into() })
+                .map_err(|source| InvalidGroupNameError { value: value.to_owned(), source: source.into() })
         }
         else {
             Ok(Self::Other(value.to_owned()))

--- a/opendut-vpn/opendut-vpn-netbird/src/netbird/policies/mod.rs
+++ b/opendut-vpn/opendut-vpn-netbird/src/netbird/policies/mod.rs
@@ -8,10 +8,10 @@ use opendut_model::cluster::ClusterId;
 use crate::netbird::group::GroupId;
 
 #[derive(thiserror::Error, Debug)]
-#[error("Cannot create PolicyName from '{value}':\n  {cause}")]
+#[error("Cannot create PolicyName from '{value}':\n  {source}")]
 pub struct InvalidPolicyNameError {
     value: String,
-    cause: Box<dyn Error>,
+    source: Box<dyn Error>,
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
@@ -45,7 +45,7 @@ impl TryFrom<&str> for PolicyName {
         if let Some(uuid) = value.strip_prefix(PolicyName::CLUSTER_POLICY_PREFIX) {
             ClusterId::try_from(uuid)
                 .map(Self::Cluster)
-                .map_err(|cause| InvalidPolicyNameError { value: value.to_owned(), cause: cause.into() })
+                .map_err(|source| InvalidPolicyNameError { value: value.to_owned(), source: source.into() })
         }
         else {
             Ok(Self::Other(value.to_owned()))


### PR DESCRIPTION
Closes #552

`thiserror` automatically treats a field named `source` as the source error, so the explicit `#[source]` annotation is no longer needed. This renames the fields across the codebase to establish that convention.

## What changed

- Error type fields named `cause` renamed to `source`, and the now-redundant `#[source]` annotations removed.
- The corresponding `.map_err()` bindings, closure parameters and local variables renamed to match.

## Two cases that could not simply become `source`

A plain find & replace does not work everywhere:

1. **`String`-typed causes.** A `cause` field holding a `String` is not an error, so `thiserror` rejects it as a source. Those fields are renamed to `message` instead. Where a `message` field already existed on the same variant (`OpentelemetryConfigError::ClientAuthentication`), the new field is called `details`.
2. **Name collisions.** Where an unrelated `source` was already in scope - notably the VIPER `source: &Source` constructor parameters, where `source` means a source *file* - the error value is named `error` to avoid the collision.



