### PR TITLE
Fix LEA warnings

### DIFF
--- a/opendut-lea/opendut-lea-components/src/health.rs
+++ b/opendut-lea/opendut-lea-components/src/health.rs
@@ -1,3 +1,4 @@
+use std::sync::Arc;
 use leptos::prelude::*;
 use crate::tooltip::{Tooltip, TooltipDirection};
 
@@ -33,7 +34,7 @@ pub fn Health(
         Clone::clone(&state.text)
     }));
     
-    let tooltip_content = Box::new(move || {
+    let tooltip_content = Arc::new(move || {
         view! {
             <p> { tooltip_text } </p>
 

--- a/opendut-lea/opendut-lea-components/src/tooltip.rs
+++ b/opendut-lea/opendut-lea-components/src/tooltip.rs
@@ -1,3 +1,4 @@
+use std::sync::Arc;
 use leptos::prelude::*;
 
 #[derive(Default, Clone, Copy)]
@@ -20,7 +21,7 @@ impl TooltipDirection {
     }
 }
 
-pub type TooltipContent = Box<dyn FnOnce() -> AnyView + Send>;
+pub type TooltipContent = Arc<dyn Fn() -> AnyView + Send + Sync>;
 
 #[component]
 pub fn Tooltip(
@@ -38,7 +39,7 @@ pub fn Tooltip(
             <div class="tooltip-container" class=("is-hidden", move || is_hidden.get())>
                 <div class="tooltip-content p-0">
                     <div class="tooltip-item p-3">
-                        { text() }
+                        { move || text() }
                     </div>
                 </div>
             </div>

--- a/opendut-lea/src/clusters/components/delete_cluster_button.rs
+++ b/opendut-lea/src/clusters/components/delete_cluster_button.rs
@@ -1,3 +1,4 @@
+use std::sync::Arc;
 use leptos::prelude::*;
 use tracing::{error, info};
 use opendut_lea_components::{use_toaster, ButtonColor, ButtonSize, ButtonState, ConfirmationButton, FontAwesomeIcon, Toast};
@@ -69,7 +70,7 @@ where F: Fn() + Clone + Send + 'static {
         !matches!(button_state.get(), ButtonState::Disabled)
     });
 
-    let tooltip_content = Box::new(move || {
+    let tooltip_content = Arc::new(move || {
         view! {
             Cluster can not be deleted while it is deployed.
         }.into_any()

--- a/opendut-lea/src/clusters/components/deploy_toggle.rs
+++ b/opendut-lea/src/clusters/components/deploy_toggle.rs
@@ -165,9 +165,9 @@ where
                 }
             });
 
-            let tooltip_content = Box::new(move || {
+            let tooltip_content = Arc::new(move || {
                 view! {
-                    <DeploymentTooltipContent is_new_cluster is_deployed blocked_deployment />
+                    <DeploymentTooltipContent is_new_cluster is_deployed blocked_deployment=Clone::clone(&blocked_deployment) />
                 }.into_any()
             });
 

--- a/opendut-lea/src/clusters/configurator/components/controls.rs
+++ b/opendut-lea/src/clusters/configurator/components/controls.rs
@@ -18,7 +18,7 @@ use crate::util;
 #[component]
 pub fn Controls<OnDeploymentChanged>(
     user_cluster_descriptor: RwSignal<UserClusterDescriptor>,
-    deployed_signal: Signal<IsDeployed>,
+    deployed_signal: Memo<IsDeployed>,
     cluster_state: Signal<ClusterState>,
     on_deployment_changed: OnDeploymentChanged,
 ) -> impl IntoView
@@ -76,7 +76,7 @@ where
 #[component]
 fn SaveClusterButton(
     user_cluster_descriptor: RwSignal<UserClusterDescriptor>,
-    deployed_signal: Signal<IsDeployed>
+    deployed_signal: Memo<IsDeployed>
 ) -> impl IntoView {
 
     let globals = use_app_globals();
@@ -148,7 +148,7 @@ fn SaveClusterButton(
         all_tabs_valid.get() && !deployed_signal.get().0
     });
 
-    let tooltip_content = Box::new(move || {
+    let tooltip_content = Arc::new(move || {
         if !all_tabs_valid.get() {
             util::view::tooltip_content_for_configurator_errors("Cluster")
         } else if deployed_signal.get().0 {

--- a/opendut-lea/src/clusters/configurator/components/controls.rs
+++ b/opendut-lea/src/clusters/configurator/components/controls.rs
@@ -13,6 +13,7 @@ use crate::clusters::configurator::types::UserClusterDescriptor;
 use crate::clusters::IsDeployed;
 use crate::components::{ButtonColor, ButtonSize, ButtonState, FontAwesomeIcon, IconButton, Toast, use_toaster};
 use crate::routing::{navigate_to, WellKnownRoutes};
+use crate::util;
 
 #[component]
 pub fn Controls<OnDeploymentChanged>(
@@ -149,13 +150,7 @@ fn SaveClusterButton(
 
     let tooltip_content = Box::new(move || {
         if !all_tabs_valid.get() {
-            view! {
-                "Cluster cannot be saved while configuration errors "
-                <span class="icon has-text-danger">
-                    <i class=FontAwesomeIcon::CircleExclamation.as_class() />
-                </span>
-                " remain."
-            }.into_any()
+            util::view::tooltip_content_for_configurator_errors("Cluster")
         } else if deployed_signal.get().0 {
             view! {
                 Cluster can not be updated while it is deployed.

--- a/opendut-lea/src/clusters/configurator/mod.rs
+++ b/opendut-lea/src/clusters/configurator/mod.rs
@@ -88,8 +88,11 @@ fn LoadedClusterConfigurator(
     let globals = use_app_globals();
     let cluster_state = RwSignal::new(ClusterState::default());
     let active_tab = use_active_tab::<TabIdentifier>();
-    
-    let cluster_id = Signal::derive(move || user_cluster_descriptor.get().id);
+
+    let cluster_id = create_read_slice(
+        user_cluster_descriptor,
+        |descriptor| Clone::clone(&descriptor.id),
+    );
 
     let breadcrumbs = Signal::derive(move || {
         let cluster_id = cluster_id.get().uuid.to_string();
@@ -115,18 +118,18 @@ fn LoadedClusterConfigurator(
         })
     };
 
-    let deployed_clusters = Signal::derive(move || {
-        match cluster_deployments.get() {
-            Some(deployed_clusters) => {
-                deployed_clusters.iter().map(|cluster_deployment| cluster_deployment.id).collect::<Vec<_>>()
-            }
-            None => Vec::new()
-        }
-    });
+    let deployed_signal = Memo::new(move |_| {
+        let cluster_id = cluster_id.get();
 
-    let deployed_signal = Signal::derive(move || IsDeployed(
-        deployed_clusters.get().contains(&cluster_id.get())
-    ));
+        let is_deployed = cluster_deployments.get()
+            .is_some_and(|deployments| {
+                deployments
+                    .iter()
+                    .any(|deployment| deployment.id == cluster_id)
+            });
+
+        IsDeployed(is_deployed)
+    });
 
     let subtitle = Signal::derive(move || {
         if let UserInputValue::Right(name) = user_cluster_descriptor.get().name {

--- a/opendut-lea/src/peers/components/delete_peer_button.rs
+++ b/opendut-lea/src/peers/components/delete_peer_button.rs
@@ -1,3 +1,4 @@
+use std::sync::Arc;
 use leptos::{component, view, IntoView};
 use leptos::prelude::*;
 use tracing::{error, info};
@@ -69,7 +70,7 @@ where F: Fn() + Clone + Send + 'static {
         !matches!(button_state.get(), ButtonState::Disabled)
     });
 
-    let tooltip_content = Box::new(move || {
+    let tooltip_content = Arc::new(move || {
         view! {
             Peer can not be deleted while it is configured in a cluster.
         }.into_any()

--- a/opendut-lea/src/peers/configurator/components/controls.rs
+++ b/opendut-lea/src/peers/configurator/components/controls.rs
@@ -16,6 +16,7 @@ use crate::peers::components::DeletePeerButton;
 use crate::peers::configurator::types::UserPeerDescriptor;
 use crate::routing::{navigate_to, WellKnownRoutes};
 use crate::peers::components::PeerHealth;
+use crate::util;
 
 #[component]
 pub fn Controls(
@@ -135,13 +136,7 @@ fn SavePeerButton(
 
     let tooltip_content = Box::new(move || {
         if !all_tabs_valid.get() {
-            view! {
-                "Peer cannot be saved while configuration errors "
-                <span class="icon has-text-danger">
-                    <i class=FontAwesomeIcon::CircleExclamation.as_class() />
-                </span>
-                " remain."
-            }.into_any()
+            util::view::tooltip_content_for_configurator_errors("Peer")
         } else { ().into_any() }
     });
 

--- a/opendut-lea/src/peers/configurator/components/controls.rs
+++ b/opendut-lea/src/peers/configurator/components/controls.rs
@@ -134,7 +134,7 @@ fn SavePeerButton(
         all_tabs_valid.get()
     });
 
-    let tooltip_content = Box::new(move || {
+    let tooltip_content = Arc::new(move || {
         if !all_tabs_valid.get() {
             util::view::tooltip_content_for_configurator_errors("Peer")
         } else { ().into_any() }

--- a/opendut-lea/src/util.rs
+++ b/opendut-lea/src/util.rs
@@ -4,6 +4,7 @@ use opendut_model::topology::DeviceId;
 
 pub mod view {
     use leptos::prelude::*;
+    use opendut_lea_components::FontAwesomeIcon;
 
     pub fn join_with_comma_spans<T: RenderHtml + 'static>(elements: Vec<View<T>>) -> Vec<AnyView> {
         let elements_length = elements.len();
@@ -20,6 +21,16 @@ pub mod view {
             }
         }
         elements_with_separator
+    }
+
+    pub fn tooltip_content_for_configurator_errors(configurator: &str) -> AnyView {
+        view! {
+            { configurator } " cannot be saved while configuration errors "
+            <span class="icon has-text-danger">
+                <i class=FontAwesomeIcon::CircleExclamation.as_class() />
+            </span>
+            " remain."
+        }.into_any()
     }
 }
 

--- a/opendut-lea/src/viper_sources/configurator/components/controls.rs
+++ b/opendut-lea/src/viper_sources/configurator/components/controls.rs
@@ -110,7 +110,7 @@ fn SaveViperSourceButton(
         all_tabs_valid.get()
     });
 
-    let tooltip_content = Box::new(move || {
+    let tooltip_content = Arc::new(move || {
         if !all_tabs_valid.get() {
             util::view::tooltip_content_for_configurator_errors("VIPER Source")
         } else { ().into_any() }

--- a/opendut-lea/src/viper_sources/configurator/components/controls.rs
+++ b/opendut-lea/src/viper_sources/configurator/components/controls.rs
@@ -7,6 +7,7 @@ use opendut_lea_components::tooltip::{Tooltip, TooltipDirection};
 use opendut_model::viper::ViperSourceDescriptor;
 use crate::app::use_app_globals;
 use crate::routing::{navigate_to, WellKnownRoutes};
+use crate::util;
 use crate::viper_sources::components::DeleteViperSourceButton;
 use crate::viper_sources::configurator::types::UserViperSourceConfiguration;
 
@@ -111,13 +112,7 @@ fn SaveViperSourceButton(
 
     let tooltip_content = Box::new(move || {
         if !all_tabs_valid.get() {
-            view! {
-                "VIPER Source cannot be saved while configuration errors "
-                <span class="icon has-text-danger">
-                    <i class=FontAwesomeIcon::CircleExclamation.as_class() />
-                </span>
-                " remain."
-            }.into_any()
+            util::view::tooltip_content_for_configurator_errors("VIPER Source")
         } else { ().into_any() }
     });
 

--- a/opendut-lea/src/viper_tests/components/duplicate_viper_test_button.rs
+++ b/opendut-lea/src/viper_tests/components/duplicate_viper_test_button.rs
@@ -63,7 +63,7 @@ pub fn DuplicateViperTestButton(
         })
     };
 
-    let tooltip_content = Box::new(move || {
+    let tooltip_content = Arc::new(move || {
         view! {
             Duplicate Test Run.
         }.into_any()

--- a/opendut-lea/src/viper_tests/configurator/components/controls.rs
+++ b/opendut-lea/src/viper_tests/configurator/components/controls.rs
@@ -7,6 +7,7 @@ use opendut_lea_components::tooltip::{Tooltip, TooltipDirection};
 use opendut_model::viper::ViperTestRunDescriptor;
 use crate::app::use_app_globals;
 use crate::routing::{navigate_to, WellKnownRoutes};
+use crate::util;
 use crate::viper_tests::components::DeleteViperTestButton;
 use crate::viper_tests::configurator::types::UserViperTestRunDescriptor;
 
@@ -111,13 +112,7 @@ fn SaveViperTestButton(
 
     let tooltip_content = Box::new(move || {
         if !all_tabs_valid.get() {
-            view! {
-                "VIPER Test cannot be saved while configuration errors "
-                <span class="icon has-text-danger">
-                    <i class=FontAwesomeIcon::CircleExclamation.as_class() />
-                </span>
-                " remain."
-            }.into_any()
+            util::view::tooltip_content_for_configurator_errors("VIPER Test")
         } else { ().into_any() }
     });
 

--- a/opendut-lea/src/viper_tests/configurator/components/controls.rs
+++ b/opendut-lea/src/viper_tests/configurator/components/controls.rs
@@ -110,7 +110,7 @@ fn SaveViperTestButton(
         all_tabs_valid.get()
     });
 
-    let tooltip_content = Box::new(move || {
+    let tooltip_content = Arc::new(move || {
         if !all_tabs_valid.get() {
             util::view::tooltip_content_for_configurator_errors("VIPER Test")
         } else { ().into_any() }


### PR DESCRIPTION
## Changes

- Fixed LEA warnings in all configurators (`ClusterConfigurator`, `PeerConfigurator`, `ViperSourceConfigurator`, `ViperTestConfigurator`) caused by using reactive signals outside a reactive context.  <img width="1923" height="202" alt="image" src="https://github.com/user-attachments/assets/d5aa087f-0984-4030-b1a9-bd4cb1b3d3e1" />

- Extracted the tooltip error message when trying to save a faulty configuration into its own util function to reduce code duplication


## Checklist
<!--
Mark all that apply. Not all checkboxes need to be checked.
-->

- [ ] I have added or updated automated tests.
- [x] I have tested my changes manually.
- [ ] I have added or updated documentation.
